### PR TITLE
style: adopt SwiftLint at zero findings and gate it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,11 +18,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Shell only: the release/e2e/smoke scripts are load-bearing infrastructure.
-  # No SwiftLint (766 style-opinion findings on default rules against a
-  # deliberately styled codebase — noise, not bugs; revisit if outside PRs
-  # pick up) and no Python lint (one icon script plus heredocs inside shell
-  # scripts that no linter can reach).
+  # The release/e2e/smoke scripts are load-bearing infrastructure. No Python
+  # lint (one icon script plus heredocs inside shell scripts that no linter
+  # can reach).
   lint:
     name: ShellCheck
     runs-on: ubuntu-latest
@@ -30,6 +28,19 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: shellcheck scripts/*.sh design/icon/build.sh
+
+  # Rules and thresholds live in .swiftlint.yml. The container image is pinned
+  # to the same SwiftLint version used locally so findings never differ by
+  # environment (learned the hard way with ShellCheck's SC2317/SC2329 skew).
+  # --strict: the repo is at zero findings, so any new warning is a failure.
+  swiftlint:
+    name: SwiftLint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    container: ghcr.io/realm/swiftlint:0.65.0
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - run: swiftlint lint --strict --reporter github-actions-logging
 
   test:
     name: ${{ matrix.name }}

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,52 @@
+# SwiftLint configuration — tuned for a SwiftUI app, not the defaults.
+# Thresholds were set from the codebase's real shape when lint was adopted
+# (2026-07-17): rules that catch bugs stay strict; size metrics are a
+# ratchet — set just above the current largest offender so existing code is
+# green but meaningful growth trips the gate. LiveContainerService (the one
+# deliberate monolith) carries its own file-level disable instead of
+# stretching these numbers to cover it.
+
+excluded:
+  - design # one-off icon rasterizer script, not shipped code
+
+identifier_name:
+  # Short names (i, n, fh, kb) are idiomatic Swift in tight closure/loop
+  # scopes; the default 3-char minimum flags ~140 of them. Casing and the
+  # max-length check still apply.
+  min_length: 1
+
+line_length:
+  warning: 160
+  error: 300
+  ignores_comments: true
+  ignores_urls: true
+  ignores_interpolated_strings: true
+
+file_length:
+  # Journey-style test suites (BerthlyTests, BerthlyUITests, BerthlyE2ETests)
+  # are deliberately few-and-long per the testing strategy in CLAUDE.md.
+  warning: 1400
+  error: 2000
+
+type_body_length:
+  warning: 650
+  error: 1000
+
+function_body_length:
+  warning: 120
+  error: 200
+
+cyclomatic_complexity:
+  # A flat switch dispatcher (e.g. MainWindowView's palette-action dispatch)
+  # is table lookup, not complexity.
+  ignores_case_statements: true
+  warning: 15
+  error: 30
+
+function_parameter_count:
+  warning: 8
+  error: 12
+
+large_tuple:
+  warning: 3
+  error: 5

--- a/Berthly/AppCommands.swift
+++ b/Berthly/AppCommands.swift
@@ -63,12 +63,12 @@ struct ContainerCommands: Commands {
             // routes through the same `navigate` intent the window reads on `.onChange`/`.onAppear`.
             // Enabled while disconnected: the sections still render their empty/connect states.
             Group {
-                paneItem("Compute",    .compute,    "1")
-                paneItem("Volumes",    .volumes,    "2")
-                paneItem("Networks",   .networks,   "3")
-                paneItem("Images",     .images,     "4")
+                paneItem("Compute", .compute, "1")
+                paneItem("Volumes", .volumes, "2")
+                paneItem("Networks", .networks, "3")
+                paneItem("Images", .images, "4")
                 paneItem("Registries", .registries, "5")
-                paneItem("System",     .system,     "6")
+                paneItem("System", .system, "6")
             }
 
             Divider()
@@ -132,7 +132,7 @@ struct ContainerCommands: Commands {
         var body: some View {
             Group {
                 tabItem("Show Overview", .overview, "1")
-                tabItem("Show Logs",     .logs,     "2")
+                tabItem("Show Logs", .logs, "2")
                 tabItem("Show Terminal", .terminal, "3")
             }
             .disabled(!bridge.isComputeDetailOpen)

--- a/Berthly/Core/ANSIEscape.swift
+++ b/Berthly/Core/ANSIEscape.swift
@@ -30,6 +30,7 @@ enum ANSIEscape {
     // Constant pattern with a unit test guarding it, so `try!` can never fire at runtime.
     // `nonisolated` so the `nonisolated` `strip` can read it: `NSRegularExpression` is `Sendable`
     // and its matching methods are thread-safe, so it's safe from any isolation domain.
+    // swiftlint:disable:next force_try
     private nonisolated static let regex = try! NSRegularExpression(pattern: pattern)
 
     /// Returns `line` with escape sequences and stray C0/DEL control bytes removed. Tabs are

--- a/Berthly/Core/BuildJobManager.swift
+++ b/Berthly/Core/BuildJobManager.swift
@@ -27,7 +27,7 @@ final class BuildJob: Identifiable {
     let id = UUID()
     let reference: String
     let startedAt = Date()
-    private(set) var finishedAt: Date? = nil
+    private(set) var finishedAt: Date?
     private(set) var logLines: [LogLine] = []
     private(set) var status: Status = .building
 
@@ -36,7 +36,7 @@ final class BuildJob: Identifiable {
     var seen = false
 
     /// The running build task. Held so `cancel` works; cleared when the build ends.
-    fileprivate var task: Task<Void, Never>? = nil
+    fileprivate var task: Task<Void, Never>?
 
     init(reference: String) {
         self.reference = reference

--- a/Berthly/Core/CommandPalette.swift
+++ b/Berthly/Core/CommandPalette.swift
@@ -154,7 +154,7 @@ func buildPaletteCommands(isConnected: Bool, containers: [Container], machines: 
         PaletteCommand(id: "nav.registries", title: "Go to Registries", systemImage: "building.columns",
                        action: .navigate(.registries)),
         PaletteCommand(id: "nav.system", title: "Go to System", systemImage: "gearshape",
-                       action: .navigate(.system)),
+                       action: .navigate(.system))
     ]
 
     guard isConnected else { return commands }
@@ -177,7 +177,7 @@ func buildPaletteCommands(isConnected: Bool, containers: [Container], machines: 
         PaletteCommand(id: "action.addRegistry", title: "Add Registry…", systemImage: "plus.circle",
                        keywords: ["login", "sign in"], action: .addRegistry),
         PaletteCommand(id: "action.refresh", title: "Refresh", systemImage: "arrow.clockwise",
-                       keywords: ["reload"], action: .refresh),
+                       keywords: ["reload"], action: .refresh)
     ]
 
     for container in containers {

--- a/Berthly/Core/ContainerServiceBase.swift
+++ b/Berthly/Core/ContainerServiceBase.swift
@@ -29,24 +29,24 @@ class ContainerServiceBase {
     /// regardless (it's the correct state for most purposes), so without this the failure is
     /// otherwise invisible until an unrelated later operation fails for a confusing reason.
     /// `nil` means no warning; cleared at the start of every `startDaemon()` call.
-    var lastStartupWarning: String? = nil
+    var lastStartupWarning: String?
 
     /// The running daemon's version, from the health-check ping. `nil` before the first
     /// successful connect. Compared against `ContainerCompatibility.requiredVersion` to decide
     /// `.connected` vs `.versionMismatch`.
-    var installedContainerVersion: String? = nil
+    var installedContainerVersion: String?
 
     /// System-page data, fetched on demand when that page appears rather than on every
     /// `refresh()` poll — it's low-frequency, look-it-up-when-needed information.
-    var diskUsage: DiskUsageSummary? = nil
-    var kernelInfo: KernelInfo? = nil
-    var systemConfigInfo: SystemConfigInfo? = nil
+    var diskUsage: DiskUsageSummary?
+    var kernelInfo: KernelInfo?
+    var systemConfigInfo: SystemConfigInfo?
     /// Local DNS domains registered for containers (like `container system dns list`).
     /// `nil` until the first `fetchDNSDomains()`, so the UI can show a loading state.
-    var dnsDomains: [String]? = nil
+    var dnsDomains: [String]?
     /// Resolved system properties (like `container system property list`), defaults included.
     /// Read-only in Berthly — editing stays a `config.toml` / CLI affair.
-    var systemProperties: [SystemProperty]? = nil
+    var systemProperties: [SystemProperty]?
 
     func buildContext(for reference: String) -> BuildContext? { buildContexts[reference] }
     func saveBuildContext(_ ctx: BuildContext, for reference: String) { buildContexts[reference] = ctx }
@@ -121,7 +121,8 @@ class ContainerServiceBase {
     /// wedged/bloated builder" action, not a permanent removal. Callers gate on stopped status
     /// (the CLI requires `--force` to delete a running builder; the GUI just doesn't offer it).
     func deleteBuilder(_ id: String) async throws {}
-    func pullImage(reference: String, platform: String? = nil, insecure: Bool = false, progress: ProgressUpdateHandler? = nil, onUnpacking: (() -> Void)? = nil) async throws {}
+    func pullImage(reference: String, platform: String? = nil, insecure: Bool = false,
+                   progress: ProgressUpdateHandler? = nil, onUnpacking: (() -> Void)? = nil) async throws {}
     /// Create an additional local reference for an existing image (like `container image tag`).
     /// Returns the reference actually created: normalization can add a default registry host,
     /// a `library/` namespace, or `:latest` — the UI shows the result so that isn't a surprise.
@@ -141,7 +142,8 @@ class ContainerServiceBase {
     /// the image is retagged to that registry-qualified reference before pushing — the native push
     /// requires a registry host in the reference, which a locally-built name like `local/web:1.4`
     /// lacks. Progress mirrors `pullImage`.
-    func pushImage(reference: String, destination: String? = nil, platform: String? = nil, insecure: Bool = false, progress: ProgressUpdateHandler? = nil) async throws {}
+    func pushImage(reference: String, destination: String? = nil, platform: String? = nil,
+                   insecure: Bool = false, progress: ProgressUpdateHandler? = nil) async throws {}
     /// `onLog` reports slow first-run bootstrap steps (kernel/vminit downloads) that otherwise
     /// happen silently inside daemon startup — the guided install flow shows them in its log.
     func startDaemon(onLog: (@MainActor (String) -> Void)? = nil) async {}
@@ -182,12 +184,12 @@ class ContainerServiceBase {
         var combined = PruneResult()
         var failures: [String] = []
         do {
-            combined = combined + (try await pruneImages())
+            combined += try await pruneImages()
         } catch {
             failures.append("Removing unused images failed: \(error.localizedDescription)")
         }
         do {
-            combined = combined + (try await pruneStoppedContainers())
+            combined += try await pruneStoppedContainers()
         } catch {
             failures.append("Removing stopped containers failed: \(error.localizedDescription)")
         }

--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -22,6 +22,10 @@ import TerminalProgress
 internal import ContainerPersistence
 internal import ContainerPlugin
 
+// The one deliberate monolith: every daemon operation lives here so the XPC/client
+// plumbing has a single seam. Splitting it is a known future refactor, not a lint fix.
+// swiftlint:disable file_length type_body_length
+
 @MainActor
 final class LiveContainerService: ContainerServiceBase {
 
@@ -373,7 +377,7 @@ final class LiveContainerService: ContainerServiceBase {
     /// identity, installs fail closed with the verification error until this is re-pinned
     /// (re-check alongside `ContainerCompatibility.requiredVersion` bumps).
     nonisolated static let appleSignatureMarkers = [
-        "Developer ID Installer: Apple Inc. - Containerization (UPBK2H6LZM)",
+        "Developer ID Installer: Apple Inc. - Containerization (UPBK2H6LZM)"
     ]
 
     /// The acceptance predicate for `pkgutil --check-signature`, extracted pure so the
@@ -867,7 +871,7 @@ final class LiveContainerService: ContainerServiceBase {
             guard let raw = h.createdBy, !raw.isEmpty else { return nil }
             var s = raw
             if s.hasPrefix("/bin/sh -c ") { s = String(s.dropFirst("/bin/sh -c ".count)) }
-            if s.hasPrefix("#(nop) ")      { s = String(s.dropFirst("#(nop) ".count)) }
+            if s.hasPrefix("#(nop) ") { s = String(s.dropFirst("#(nop) ".count)) }
             return s.trimmingCharacters(in: .whitespaces)
         }
         return ImageInspectData(
@@ -1304,7 +1308,7 @@ final class LiveContainerService: ContainerServiceBase {
         guard !s.isEmpty else { return nil }
         let multipliers: [Character: Int] = [
             "k": 1_024, "m": 1_048_576, "g": 1_073_741_824,
-            "t": 1_099_511_627_776, "p": 1_125_899_906_842_624,
+            "t": 1_099_511_627_776, "p": 1_125_899_906_842_624
         ]
         let last = s[s.index(before: s.endIndex)]
         if let mult = multipliers[Character(last.lowercased())] {
@@ -1573,19 +1577,19 @@ final class LiveContainerService: ContainerServiceBase {
             let message = error.localizedDescription
             return CleanUpAllResult(failureMessages: [
                 "Removing unused images failed: \(message)",
-                "Removing stopped containers failed: \(message)",
+                "Removing stopped containers failed: \(message)"
             ])
         }
 
         var combined = PruneResult()
         var failures: [String] = []
         do {
-            combined = combined + (try await pruneImages(allContainers: allContainers))
+            combined += try await pruneImages(allContainers: allContainers)
         } catch {
             failures.append("Removing unused images failed: \(error.localizedDescription)")
         }
         do {
-            combined = combined + (try await pruneStoppedContainers(allContainers: allContainers))
+            combined += try await pruneStoppedContainers(allContainers: allContainers)
         } catch {
             failures.append("Removing stopped containers failed: \(error.localizedDescription)")
         }
@@ -1673,7 +1677,7 @@ final class LiveContainerService: ContainerServiceBase {
             SystemProperty(key: "network.subnet", value: config.network.subnet.map { String(describing: $0) } ?? "–"),
             SystemProperty(key: "network.subnetv6", value: config.network.subnetv6.map { String(describing: $0) } ?? "–"),
             SystemProperty(key: "registry.domain", value: config.registry.domain),
-            SystemProperty(key: "vminit.image", value: config.vminit.image),
+            SystemProperty(key: "vminit.image", value: config.vminit.image)
         ]
     }
 
@@ -1872,7 +1876,7 @@ final class LiveContainerService: ContainerServiceBase {
         let (process, pipe) = try Self.launchLogProcess(arguments: [
             "stream", "--info",
             "--style", "ndjson",
-            "--predicate", Self.daemonLogPredicate,
+            "--predicate", Self.daemonLogPredicate
         ])
 
         await withTaskCancellationHandler {
@@ -1899,7 +1903,7 @@ final class LiveContainerService: ContainerServiceBase {
         guard let (_, pipe) = try? Self.launchLogProcess(arguments: [
             "show", "--last", "1h", "--info",
             "--style", "ndjson",
-            "--predicate", daemonLogPredicate,
+            "--predicate", daemonLogPredicate
         ]) else { return [] }
 
         var formatted: [String] = []
@@ -2137,12 +2141,12 @@ final class LiveContainerService: ContainerServiceBase {
         config.resources = resources
         config.labels = [
             ResourceLabelKeys.plugin: "builder",
-            ResourceLabelKeys.role: ResourceRoleValues.builder,
+            ResourceLabelKeys.role: ResourceRoleValues.builder
         ]
         config.capAdd = ["ALL"]
         config.mounts = [
             Filesystem(type: .tmpfs, source: "", destination: "/run", options: []),
-            Filesystem(type: .virtiofs, source: exportsMount, destination: "/var/lib/container-builder-shim/exports", options: []),
+            Filesystem(type: .virtiofs, source: exportsMount, destination: "/var/lib/container-builder-shim/exports", options: [])
         ]
         config.rosetta = useRosetta
 
@@ -2215,7 +2219,9 @@ final class LiveContainerService: ContainerServiceBase {
         let platforms = try Self.buildPlatforms(for: options)
 
         let containerSystemConfig = await resolvedSystemConfig()
-        let builder = try await dialOrStartBuilder(containerSystemConfig: containerSystemConfig, cpus: options.cpus.map { Int64($0) }, memory: options.memory, onLog: onLog)
+        let builder = try await dialOrStartBuilder(containerSystemConfig: containerSystemConfig,
+                                                   cpus: options.cpus.map { Int64($0) },
+                                                   memory: options.memory, onLog: onLog)
 
         let systemHealth = try await ClientHealthCheck.ping(timeout: .seconds(10))
         let buildID = UUID().uuidString
@@ -2688,7 +2694,8 @@ final class LiveContainerService: ContainerServiceBase {
         return snapshot
     }
 
-    override func pullImage(reference: String, platform: String? = nil, insecure: Bool = false, progress: ProgressUpdateHandler? = nil, onUnpacking: (() -> Void)? = nil) async throws {
+    override func pullImage(reference: String, platform: String? = nil, insecure: Bool = false,
+                            progress: ProgressUpdateHandler? = nil, onUnpacking: (() -> Void)? = nil) async throws {
         let config = await resolvedSystemConfig()
         let ociPlatform: Platform? = try {
             guard let p = platform, !p.isEmpty else { return nil }
@@ -2706,7 +2713,8 @@ final class LiveContainerService: ContainerServiceBase {
         await refresh()
     }
 
-    override func pushImage(reference: String, destination: String? = nil, platform: String? = nil, insecure: Bool = false, progress: ProgressUpdateHandler? = nil) async throws {
+    override func pushImage(reference: String, destination: String? = nil, platform: String? = nil,
+                            insecure: Bool = false, progress: ProgressUpdateHandler? = nil) async throws {
         let config = await resolvedSystemConfig()
         let ociPlatform: Platform? = try {
             guard let p = platform, !p.isEmpty else { return nil }
@@ -2790,3 +2798,4 @@ final class LiveContainerService: ContainerServiceBase {
         )
     }
 }
+// swiftlint:enable type_body_length

--- a/Berthly/Core/MenuBarBridge.swift
+++ b/Berthly/Core/MenuBarBridge.swift
@@ -51,14 +51,14 @@ final class MenuBarBridge {
     /// request usually arrives with a *fresh* detail mount) by switching to its Terminal tab, then
     /// clears it. A nil-clearing optional (not a token) so each request fires exactly once and a
     /// new request for a different item always re-fires — same shape as `pendingIntent`.
-    var terminalRequest: ComputeItem? = nil
+    var terminalRequest: ComputeItem?
 
     /// The detail pane a View-menu shortcut (⌘⌥1/2/3) asked the open detail view to show.
     /// Whichever container/machine detail is currently mounted consumes it via `.onChange` and
     /// clears it. Deliberately *not* consumed on `.onAppear` (unlike `terminalRequest`): the
     /// menu items are disabled while no detail is open, and a request that somehow goes
     /// unconsumed should die rather than fire on the next detail the user happens to open.
-    var detailTabRequest: DetailPaneTab? = nil
+    var detailTabRequest: DetailPaneTab?
 
     /// Whether a compute detail pane (container or machine) is currently showing — kept in sync
     /// by `MainWindowView`, read by the View menu to enable the ⌘⌥1/2/3 tab items.

--- a/Berthly/Core/MockContainerService.swift
+++ b/Berthly/Core/MockContainerService.swift
@@ -11,65 +11,68 @@ final class MockContainerService: ContainerServiceBase {
         super.init()
         daemonState = .connected
         installedContainerVersion = ContainerCompatibility.requiredVersion
+        // Fixture literals: one entry per line scans best; wrapping these 15-argument
+        // initializers would triple the section's height for no clarity gain.
+        // swiftlint:disable line_length
         containers = [
-            Container(id: "3f9a2b7c1d", name: "web-frontend",  image: "local/web:1.4",       status: .running, ports: [PortMapping(host: 3000, container: 3000)], cpuPercent: 12, memoryMB: 184,  memoryLimitMB: 1024, networkIOString: "1.2 MB/s", uptime: "2h 41m", command: #"nginx -g "daemon off;""#,   mounts: [ContainerMount(source: "./src", destination: "/app")], networks: ["app-net"], environment: ["NODE_ENV=production", "PORT=3000", "API_URL=http://api-service:8080"], startedDate: Date().addingTimeInterval(-(2*3600 + 41*60))),
-            Container(id: "a17c44e9b2", name: "api-service",   image: "local/api:2.1",       status: .running, ports: [PortMapping(host: 8080, container: 8080)], cpuPercent: 34, memoryMB: 320,  memoryLimitMB: 2048, networkIOString: "3.4 MB/s", uptime: "5h 12m", command: "node server.js",               mounts: [], networks: ["app-net", "data-net"], environment: ["NODE_ENV=production"],                                                                                startedDate: Date().addingTimeInterval(-(5*3600 + 12*60))),
-            Container(id: "c20e81f7a4", name: "datastore",     image: "local/datastore:15",  status: .running, ports: [PortMapping(host: 5432, container: 5432)], cpuPercent:  8, memoryMB: 512,  memoryLimitMB: 1024, networkIOString: "0.8 MB/s", uptime: "1d 3h",  command: "postgres",                       mounts: [], networks: ["data-net"], environment: [],                                                                                                              startedDate: Date().addingTimeInterval(-(27*3600))),
-            Container(id: "7b3d09c5e1", name: "cache",         image: "local/cache:7",       status: .running, ports: [PortMapping(host: 6379, container: 6379)], cpuPercent:  2, memoryMB:  64,  memoryLimitMB:  512, networkIOString: "0.2 MB/s", uptime: "1d 3h",  command: "redis-server",                   mounts: [], networks: ["app-net"], environment: [],                                                                                                               startedDate: Date().addingTimeInterval(-(27*3600))),
-            Container(id: "d4e5f6a7b8", name: "worker",        image: "local/worker:1.0",    status: .stopped, ports: [],                                          cpuPercent:  0, memoryMB:   0,  memoryLimitMB:  512, networkIOString: "–",        uptime: "–",      command: "python worker.py",                mounts: [], networks: ["data-net"], environment: []),
-            Container(id: "b4c8d2e6f0", name: "edge-proxy",    image: "local/proxy:1.25",    status: .error,   ports: [PortMapping(host: 80, container: 80), PortMapping(host: 443, container: 443)], cpuPercent: 0, memoryMB: 0, memoryLimitMB: 256, networkIOString: "–", uptime: "–", command: "nginx", mounts: [], networks: ["default"], environment: []),
-            Container(id: "1a2b3c4d5e", name: "sandbox",       image: "local/base:latest",   status: .paused,  ports: [],                                          cpuPercent:  0, memoryMB:   0,  memoryLimitMB:  512, networkIOString: "–",        uptime: "–",      command: "/bin/bash",                       mounts: [], networks: [],          environment: []),
+            Container(id: "3f9a2b7c1d", name: "web-frontend", image: "local/web:1.4", status: .running, ports: [PortMapping(host: 3000, container: 3000)], cpuPercent: 12, memoryMB: 184, memoryLimitMB: 1024, networkIOString: "1.2 MB/s", uptime: "2h 41m", command: #"nginx -g "daemon off;""#, mounts: [ContainerMount(source: "./src", destination: "/app")], networks: ["app-net"], environment: ["NODE_ENV=production", "PORT=3000", "API_URL=http://api-service:8080"], startedDate: Date().addingTimeInterval(-(2*3600 + 41*60))),
+            Container(id: "a17c44e9b2", name: "api-service", image: "local/api:2.1", status: .running, ports: [PortMapping(host: 8080, container: 8080)], cpuPercent: 34, memoryMB: 320, memoryLimitMB: 2048, networkIOString: "3.4 MB/s", uptime: "5h 12m", command: "node server.js", mounts: [], networks: ["app-net", "data-net"], environment: ["NODE_ENV=production"], startedDate: Date().addingTimeInterval(-(5*3600 + 12*60))),
+            Container(id: "c20e81f7a4", name: "datastore", image: "local/datastore:15", status: .running, ports: [PortMapping(host: 5432, container: 5432)], cpuPercent: 8, memoryMB: 512, memoryLimitMB: 1024, networkIOString: "0.8 MB/s", uptime: "1d 3h", command: "postgres", mounts: [], networks: ["data-net"], environment: [], startedDate: Date().addingTimeInterval(-(27*3600))),
+            Container(id: "7b3d09c5e1", name: "cache", image: "local/cache:7", status: .running, ports: [PortMapping(host: 6379, container: 6379)], cpuPercent: 2, memoryMB: 64, memoryLimitMB: 512, networkIOString: "0.2 MB/s", uptime: "1d 3h", command: "redis-server", mounts: [], networks: ["app-net"], environment: [], startedDate: Date().addingTimeInterval(-(27*3600))),
+            Container(id: "d4e5f6a7b8", name: "worker", image: "local/worker:1.0", status: .stopped, ports: [], cpuPercent: 0, memoryMB: 0, memoryLimitMB: 512, networkIOString: "–", uptime: "–", command: "python worker.py", mounts: [], networks: ["data-net"], environment: []),
+            Container(id: "b4c8d2e6f0", name: "edge-proxy", image: "local/proxy:1.25", status: .error, ports: [PortMapping(host: 80, container: 80), PortMapping(host: 443, container: 443)], cpuPercent: 0, memoryMB: 0, memoryLimitMB: 256, networkIOString: "–", uptime: "–", command: "nginx", mounts: [], networks: ["default"], environment: []),
+            Container(id: "1a2b3c4d5e", name: "sandbox", image: "local/base:latest", status: .paused, ports: [], cpuPercent: 0, memoryMB: 0, memoryLimitMB: 512, networkIOString: "–", uptime: "–", command: "/bin/bash", mounts: [], networks: [], environment: [])
         ]
         images = [
-            ContainerImage(id: "local/web:1.4",       repository: "local/web",       tag: "1.4",    digest: "sha256:3f9a2b7c1d", arch: ["arm64", "amd64"], sizeBytes: 182 * 1_048_576, created: "2h ago",  source: .built,  usage: .usedBy(3)),
-            ContainerImage(id: "local/api:2.1",       repository: "local/api",       tag: "2.1",    digest: "sha256:a17c44e9b2", arch: ["arm64"],          sizeBytes: 240 * 1_048_576, created: "5h ago",  source: .built,  usage: .usedBy(1)),
-            ContainerImage(id: "local/datastore:15",  repository: "local/datastore", tag: "15",     digest: "sha256:c20e81f7a4", arch: ["arm64", "amd64"], sizeBytes: 410 * 1_048_576, created: "1d ago",  source: .built,  usage: .usedBy(1)),
-            ContainerImage(id: "local/cache:7",       repository: "local/cache",     tag: "7",      digest: "sha256:7b3d09c5e1", arch: ["arm64"],          sizeBytes:  38 * 1_048_576, created: "1d ago",  source: .built,  usage: .usedBy(1)),
-            ContainerImage(id: "local/base:latest",   repository: "local/base",      tag: "latest", digest: "sha256:1a2b3c4d5e", arch: ["arm64", "amd64"], sizeBytes:  96 * 1_048_576, created: "3d ago",  source: .pulled, usage: .usedBy(2)),
-            ContainerImage(id: "local/proxy:1.25",    repository: "local/proxy",     tag: "1.25",   digest: "sha256:b4c8d2e6f0", arch: ["amd64"],          sizeBytes:  54 * 1_048_576, created: "2d ago",  source: .built,  usage: .unused),
-            ContainerImage(id: "buildkit:0.13",       repository: "buildkit",        tag: "0.13",   digest: "sha256:9f2c1a7e44", arch: ["arm64", "amd64"], sizeBytes: 160 * 1_048_576, created: "1w ago",  source: .pulled, usage: .builderImage),
+            ContainerImage(id: "local/web:1.4", repository: "local/web", tag: "1.4", digest: "sha256:3f9a2b7c1d", arch: ["arm64", "amd64"], sizeBytes: 182 * 1_048_576, created: "2h ago", source: .built, usage: .usedBy(3)),
+            ContainerImage(id: "local/api:2.1", repository: "local/api", tag: "2.1", digest: "sha256:a17c44e9b2", arch: ["arm64"], sizeBytes: 240 * 1_048_576, created: "5h ago", source: .built, usage: .usedBy(1)),
+            ContainerImage(id: "local/datastore:15", repository: "local/datastore", tag: "15", digest: "sha256:c20e81f7a4", arch: ["arm64", "amd64"], sizeBytes: 410 * 1_048_576, created: "1d ago", source: .built, usage: .usedBy(1)),
+            ContainerImage(id: "local/cache:7", repository: "local/cache", tag: "7", digest: "sha256:7b3d09c5e1", arch: ["arm64"], sizeBytes: 38 * 1_048_576, created: "1d ago", source: .built, usage: .usedBy(1)),
+            ContainerImage(id: "local/base:latest", repository: "local/base", tag: "latest", digest: "sha256:1a2b3c4d5e", arch: ["arm64", "amd64"], sizeBytes: 96 * 1_048_576, created: "3d ago", source: .pulled, usage: .usedBy(2)),
+            ContainerImage(id: "local/proxy:1.25", repository: "local/proxy", tag: "1.25", digest: "sha256:b4c8d2e6f0", arch: ["amd64"], sizeBytes: 54 * 1_048_576, created: "2d ago", source: .built, usage: .unused),
+            ContainerImage(id: "buildkit:0.13", repository: "buildkit", tag: "0.13", digest: "sha256:9f2c1a7e44", arch: ["arm64", "amd64"], sizeBytes: 160 * 1_048_576, created: "1w ago", source: .pulled, usage: .builderImage)
         ]
         let volumesRoot = "~/Library/Application Support/com.apple.container/volumes"
         volumes = [
-            Volume(id: "pgdata",       name: "pgdata",       type: .named,     usedMB: 742,  allocatedMB: 2048, driver: "local", source: "\(volumesRoot)/pgdata/volume.img",       created: "08:58", labels: ["app=datastore"], options: ["size=2G"],   mounts: [VolumeMount(containerName: "datastore",    mountPath: "/var/lib/postgresql/data", mode: "RW")], fs: "ext4", reclaimable: false),
-            Volume(id: "shared",       name: "shared-assets", type: .named,    usedMB: 318,  allocatedMB:  512, driver: "local", source: "\(volumesRoot)/shared-assets/volume.img", created: "08:30", labels: [],                options: ["size=512M"], mounts: [VolumeMount(containerName: "web-frontend", mountPath: "/app/public", mode: "RO"), VolumeMount(containerName: "api-service", mountPath: "/srv/assets", mode: "RO")], fs: "ext4", reclaimable: false),
-            Volume(id: "redis",        name: "redis-data",   type: .named,     usedMB:  48,  allocatedMB:  256, driver: "local", source: "\(volumesRoot)/redis-data/volume.img",   created: "09:00", labels: [],                options: ["size=256M"], mounts: [VolumeMount(containerName: "cache",        mountPath: "/data", mode: "RW")], fs: "ext4", reclaimable: false),
-            Volume(id: "worker-q",     name: "worker-queue", type: .named,     usedMB:  12,  allocatedMB:  128, driver: "local", source: "\(volumesRoot)/worker-queue/volume.img", created: "09:02", labels: ["app=worker"],    options: ["size=128M"], mounts: [VolumeMount(containerName: "worker",       mountPath: "/var/spool/queue", mode: "RW")], fs: "ext4", reclaimable: false),
-            Volume(id: "model",        name: "model-cache",  type: .named,     usedMB: 3481, allocatedMB: 4096, driver: "local", source: "\(volumesRoot)/model-cache/volume.img",  created: "Jun 12", labels: [],               options: ["size=4G"],   mounts: [], fs: "ext4", reclaimable: true),
+            Volume(id: "pgdata", name: "pgdata", type: .named, usedMB: 742, allocatedMB: 2048, driver: "local", source: "\(volumesRoot)/pgdata/volume.img", created: "08:58", labels: ["app=datastore"], options: ["size=2G"], mounts: [VolumeMount(containerName: "datastore", mountPath: "/var/lib/postgresql/data", mode: "RW")], fs: "ext4", reclaimable: false),
+            Volume(id: "shared", name: "shared-assets", type: .named, usedMB: 318, allocatedMB: 512, driver: "local", source: "\(volumesRoot)/shared-assets/volume.img", created: "08:30", labels: [], options: ["size=512M"], mounts: [VolumeMount(containerName: "web-frontend", mountPath: "/app/public", mode: "RO"), VolumeMount(containerName: "api-service", mountPath: "/srv/assets", mode: "RO")], fs: "ext4", reclaimable: false),
+            Volume(id: "redis", name: "redis-data", type: .named, usedMB: 48, allocatedMB: 256, driver: "local", source: "\(volumesRoot)/redis-data/volume.img", created: "09:00", labels: [], options: ["size=256M"], mounts: [VolumeMount(containerName: "cache", mountPath: "/data", mode: "RW")], fs: "ext4", reclaimable: false),
+            Volume(id: "worker-q", name: "worker-queue", type: .named, usedMB: 12, allocatedMB: 128, driver: "local", source: "\(volumesRoot)/worker-queue/volume.img", created: "09:02", labels: ["app=worker"], options: ["size=128M"], mounts: [VolumeMount(containerName: "worker", mountPath: "/var/spool/queue", mode: "RW")], fs: "ext4", reclaimable: false),
+            Volume(id: "model", name: "model-cache", type: .named, usedMB: 3481, allocatedMB: 4096, driver: "local", source: "\(volumesRoot)/model-cache/volume.img", created: "Jun 12", labels: [], options: ["size=4G"], mounts: [], fs: "ext4", reclaimable: true),
             Volume(id: "anon1", name: "8349ab8d-e6db-4e58-98ab-6e34f08f1dae", type: .anonymous, usedMB: 214, allocatedMB: 1024, driver: "local", source: "\(volumesRoot)/8349ab8d-e6db-4e58-98ab-6e34f08f1dae/volume.img", created: "09:14", labels: ["com.apple.container.resource.anonymous=true"], options: [], mounts: [VolumeMount(containerName: "datastore", mountPath: "/var/lib/postgresql/pgdata", mode: "RW")], fs: "ext4", reclaimable: false),
-            Volume(id: "anon2", name: "1c4f0a7e-93b1-4d02-8f6a-25c1de0a7b44", type: .anonymous, usedMB:  96, allocatedMB:  512, driver: "local", source: "\(volumesRoot)/1c4f0a7e-93b1-4d02-8f6a-25c1de0a7b44/volume.img", created: "08:58", labels: ["com.apple.container.resource.anonymous=true"], options: [], mounts: [], fs: "ext4", reclaimable: true),
+            Volume(id: "anon2", name: "1c4f0a7e-93b1-4d02-8f6a-25c1de0a7b44", type: .anonymous, usedMB: 96, allocatedMB: 512, driver: "local", source: "\(volumesRoot)/1c4f0a7e-93b1-4d02-8f6a-25c1de0a7b44/volume.img", created: "08:58", labels: ["com.apple.container.resource.anonymous=true"], options: [], mounts: [], fs: "ext4", reclaimable: true),
             // Created without --size: the daemon's 512 GiB sparse default. Exercises the
             // on-disk-footprint presentation (no meaningful capacity gauge).
-            Volume(id: "logs", name: "logs", type: .named, usedMB: 66, allocatedMB: Volume.defaultSparseCapacityMB, driver: "local", source: "\(volumesRoot)/logs/volume.img", created: "09:20", labels: [], options: [], mounts: [VolumeMount(containerName: "api-service", mountPath: "/var/log/app", mode: "RW")], fs: "ext4", reclaimable: false),
+            Volume(id: "logs", name: "logs", type: .named, usedMB: 66, allocatedMB: Volume.defaultSparseCapacityMB, driver: "local", source: "\(volumesRoot)/logs/volume.img", created: "09:20", labels: [], options: [], mounts: [VolumeMount(containerName: "api-service", mountPath: "/var/log/app", mode: "RW")], fs: "ext4", reclaimable: false)
         ]
         networks = [
-            Network(id: "app-net", name: "app-net", driver: .nat,      subnet: "192.168.65.0/24", gateway: "192.168.65.1", isDefault: false, scope: "local", ipv6Enabled: false, egress: "NAT → en0", attachable: true, backend: "vmnet", endpoints: [NetworkEndpoint(id: "e1", name: "web-frontend", ipv4: "192.168.65.10", kind: "CONTAINER", isRunning: true, aliases: ["web", "frontend"]), NetworkEndpoint(id: "e2", name: "api-service", ipv4: "192.168.65.11", kind: "CONTAINER", isRunning: true, aliases: ["api"]), NetworkEndpoint(id: "e6", name: "cache", ipv4: "192.168.65.12", kind: "CONTAINER", isRunning: true, aliases: ["redis", "cache"])]),
-            Network(id: "data-net", name: "data-net", driver: .hostOnly, subnet: "192.168.66.0/24", gateway: "192.168.66.1", isDefault: false, scope: "local", ipv6Enabled: false, egress: "",          attachable: false, backend: "vmnet", endpoints: [NetworkEndpoint(id: "e7", name: "api-service", ipv4: "192.168.66.20", kind: "CONTAINER", isRunning: true, aliases: ["api"]), NetworkEndpoint(id: "e8", name: "datastore", ipv4: "192.168.66.21", kind: "CONTAINER", isRunning: true, aliases: ["db", "postgres"]), NetworkEndpoint(id: "e9", name: "worker", ipv4: "192.168.66.22", kind: "CONTAINER", isRunning: false, aliases: ["worker"])]),
-            Network(id: "default",  name: "default",  driver: .nat,      subnet: "192.168.64.0/24", gateway: "192.168.64.1", isDefault: true,  scope: "local", ipv6Enabled: false, egress: "NAT → en0", attachable: true, backend: "vmnet", endpoints: [NetworkEndpoint(id: "e3", name: "dev",        ipv4: "192.168.64.3", kind: "MACHINE",   isRunning: true,  aliases: ["machine"]), NetworkEndpoint(id: "e4", name: "ci-runner", ipv4: "192.168.64.4", kind: "MACHINE", isRunning: false, aliases: ["machine"]), NetworkEndpoint(id: "e5", name: "default", ipv4: "192.168.64.2", kind: "MACHINE", isRunning: true, aliases: ["machine", "utility VM"]), NetworkEndpoint(id: "e10", name: "edge-proxy", ipv4: "192.168.64.10", kind: "CONTAINER", isRunning: false, aliases: ["edge", "proxy"])]),
+            Network(id: "app-net", name: "app-net", driver: .nat, subnet: "192.168.65.0/24", gateway: "192.168.65.1", isDefault: false, scope: "local", ipv6Enabled: false, egress: "NAT → en0", attachable: true, backend: "vmnet", endpoints: [NetworkEndpoint(id: "e1", name: "web-frontend", ipv4: "192.168.65.10", kind: "CONTAINER", isRunning: true, aliases: ["web", "frontend"]), NetworkEndpoint(id: "e2", name: "api-service", ipv4: "192.168.65.11", kind: "CONTAINER", isRunning: true, aliases: ["api"]), NetworkEndpoint(id: "e6", name: "cache", ipv4: "192.168.65.12", kind: "CONTAINER", isRunning: true, aliases: ["redis", "cache"])]),
+            Network(id: "data-net", name: "data-net", driver: .hostOnly, subnet: "192.168.66.0/24", gateway: "192.168.66.1", isDefault: false, scope: "local", ipv6Enabled: false, egress: "", attachable: false, backend: "vmnet", endpoints: [NetworkEndpoint(id: "e7", name: "api-service", ipv4: "192.168.66.20", kind: "CONTAINER", isRunning: true, aliases: ["api"]), NetworkEndpoint(id: "e8", name: "datastore", ipv4: "192.168.66.21", kind: "CONTAINER", isRunning: true, aliases: ["db", "postgres"]), NetworkEndpoint(id: "e9", name: "worker", ipv4: "192.168.66.22", kind: "CONTAINER", isRunning: false, aliases: ["worker"])]),
+            Network(id: "default", name: "default", driver: .nat, subnet: "192.168.64.0/24", gateway: "192.168.64.1", isDefault: true, scope: "local", ipv6Enabled: false, egress: "NAT → en0", attachable: true, backend: "vmnet", endpoints: [NetworkEndpoint(id: "e3", name: "dev", ipv4: "192.168.64.3", kind: "MACHINE", isRunning: true, aliases: ["machine"]), NetworkEndpoint(id: "e4", name: "ci-runner", ipv4: "192.168.64.4", kind: "MACHINE", isRunning: false, aliases: ["machine"]), NetworkEndpoint(id: "e5", name: "default", ipv4: "192.168.64.2", kind: "MACHINE", isRunning: true, aliases: ["machine", "utility VM"]), NetworkEndpoint(id: "e10", name: "edge-proxy", ipv4: "192.168.64.10", kind: "CONTAINER", isRunning: false, aliases: ["edge", "proxy"])])
         ]
         machines = [
-            Machine(id: "dev",       name: "dev",       image: "ubuntu:24.04", status: .running, isUtility: false, diskUsedGB: 3.1, diskTotalGB: 8.0, uptimeString: "1h 12m", kernel: "6.12.4-arm64", resources: "4 vCPU · 4 GB", created: "Jun 20", homeMount: .readWrite, isDefault: true),
-            Machine(id: "ci-runner", name: "ci-runner", image: "alpine:3.22",  status: .stopped, isUtility: false, diskUsedGB: 0.48, diskTotalGB: 2.0, uptimeString: "–",      kernel: "6.12.4-arm64", resources: "2 vCPU · 2 GB", created: "Jun 22", homeMount: .readOnly),
-            Machine(id: "default",   name: "default",   image: "debian:12",    status: .running, isUtility: true,  diskUsedGB: 1.2,  diskTotalGB: 4.0, uptimeString: "6d 4h",  kernel: "6.12.4-arm64", resources: "2 vCPU · 4 GB", created: "Jun 15", homeMount: .none),
+            Machine(id: "dev", name: "dev", image: "ubuntu:24.04", status: .running, isUtility: false, diskUsedGB: 3.1, diskTotalGB: 8.0, uptimeString: "1h 12m", kernel: "6.12.4-arm64", resources: "4 vCPU · 4 GB", created: "Jun 20", homeMount: .readWrite, isDefault: true),
+            Machine(id: "ci-runner", name: "ci-runner", image: "alpine:3.22", status: .stopped, isUtility: false, diskUsedGB: 0.48, diskTotalGB: 2.0, uptimeString: "–", kernel: "6.12.4-arm64", resources: "2 vCPU · 2 GB", created: "Jun 22", homeMount: .readOnly),
+            Machine(id: "default", name: "default", image: "debian:12", status: .running, isUtility: true, diskUsedGB: 1.2, diskTotalGB: 4.0, uptimeString: "6d 4h", kernel: "6.12.4-arm64", resources: "2 vCPU · 4 GB", created: "Jun 15", homeMount: .none)
         ]
         builders = [
-            Builder(id: "default", name: "default", image: "buildkit:0.13", status: .running, autoStarted: true, cpus: 2, memoryGB: 2),
+            Builder(id: "default", name: "default", image: "buildkit:0.13", status: .running, autoStarted: true, cpus: 2, memoryGB: 2)
         ]
         registries = [
             Registry(host: "ghcr.io", username: "apple-bot"),
-            Registry(host: "registry-1.docker.io", username: "berthly"),
+            Registry(host: "registry-1.docker.io", username: "berthly")
         ]
         imageInspectData = Self.mockInspectData()
         buildContexts = [
             "local/web:1.4": BuildContext(contextPath: "/Users/dev/projects/web", dockerfilePath: nil),
-            "local/api:2.1": BuildContext(contextPath: "/Users/dev/projects/api", dockerfilePath: "Containerfile"),
+            "local/api:2.1": BuildContext(contextPath: "/Users/dev/projects/api", dockerfilePath: "Containerfile")
         ]
     }
 
     private static func mockInspectData() -> [String: ImageInspectData] {
         let webVariants = [
             ImageVariantInfo(arch: "arm64", archVariant: "v8", sizeBytes: 182 * 1_048_576, digest: "sha256:arm64variant001"),
-            ImageVariantInfo(arch: "amd64", archVariant: nil,  sizeBytes: 188 * 1_048_576, digest: "sha256:amd64variant001"),
+            ImageVariantInfo(arch: "amd64", archVariant: nil, sizeBytes: 188 * 1_048_576, digest: "sha256:amd64variant001")
         ]
         let webEnv = ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "NODE_ENV=production", "PORT=3000", "NGINX_VERSION=1.25.4"]
         let webLabels: [String: String] = ["maintainer": "berthly@example.com", "version": "1.4", "org.opencontainers.image.title": "web-frontend"]
@@ -80,7 +83,7 @@ final class MockContainerService: ContainerServiceBase {
             "npm ci --omit=dev",
             "COPY . .",
             "EXPOSE 3000",
-            "CMD [\"nginx\",\"-g\",\"daemon off;\"]",
+            "CMD [\"nginx\",\"-g\",\"daemon off;\"]"
         ]
 
         let apiVariants = [ImageVariantInfo(arch: "arm64", archVariant: "v8", sizeBytes: 240 * 1_048_576, digest: "sha256:apiarm64variant001")]
@@ -89,9 +92,10 @@ final class MockContainerService: ContainerServiceBase {
 
         return [
             "sha256:3f9a2b7c1d": ImageInspectData(variants: webVariants, command: "nginx -g daemon off;", workDir: "/app", user: "www-data", stopSignal: "SIGTERM", env: webEnv, labels: webLabels, history: webHistory),
-            "sha256:a17c44e9b2": ImageInspectData(variants: apiVariants, command: "node server.js", workDir: "/srv", user: "", stopSignal: "", env: apiEnv, labels: [:], history: apiHistory),
+            "sha256:a17c44e9b2": ImageInspectData(variants: apiVariants, command: "node server.js", workDir: "/srv", user: "", stopSignal: "", env: apiEnv, labels: [:], history: apiHistory)
         ]
     }
+    // swiftlint:enable line_length
 
     // MARK: - Operations (simulated in mock)
 
@@ -101,14 +105,22 @@ final class MockContainerService: ContainerServiceBase {
         try? await Task.sleep(for: .milliseconds(600))
         guard let i = containers.firstIndex(where: { $0.id == id }) else { return }
         let c = containers[i]
-        containers[i] = Container(id: c.id, name: c.name, image: c.image, status: .running, ports: c.ports, cpuPercent: 0, memoryMB: 0, memoryLimitMB: c.memoryLimitMB, networkIOString: "–", uptime: "0m", command: c.command, mounts: c.mounts, networks: c.networks, environment: c.environment)
+        containers[i] = Container(id: c.id, name: c.name, image: c.image, status: .running,
+                                  ports: c.ports, cpuPercent: 0, memoryMB: 0,
+                                  memoryLimitMB: c.memoryLimitMB, networkIOString: "–", uptime: "0m",
+                                  command: c.command, mounts: c.mounts, networks: c.networks,
+                                  environment: c.environment)
     }
 
     override func stopContainer(_ id: String) async throws {
         try? await Task.sleep(for: .milliseconds(600))
         guard let i = containers.firstIndex(where: { $0.id == id }) else { return }
         let c = containers[i]
-        containers[i] = Container(id: c.id, name: c.name, image: c.image, status: .stopped, ports: c.ports, cpuPercent: 0, memoryMB: 0, memoryLimitMB: c.memoryLimitMB, networkIOString: "–", uptime: "–", command: c.command, mounts: c.mounts, networks: c.networks, environment: c.environment)
+        containers[i] = Container(id: c.id, name: c.name, image: c.image, status: .stopped,
+                                  ports: c.ports, cpuPercent: 0, memoryMB: 0,
+                                  memoryLimitMB: c.memoryLimitMB, networkIOString: "–", uptime: "–",
+                                  command: c.command, mounts: c.mounts, networks: c.networks,
+                                  environment: c.environment)
     }
 
     override func restartContainer(_ id: String) async throws {
@@ -120,7 +132,11 @@ final class MockContainerService: ContainerServiceBase {
         // No simulated latency, unlike stopContainer: SIGKILL is immediate — that's its point.
         guard let i = containers.firstIndex(where: { $0.id == id }) else { return }
         let c = containers[i]
-        containers[i] = Container(id: c.id, name: c.name, image: c.image, status: .stopped, ports: c.ports, cpuPercent: 0, memoryMB: 0, memoryLimitMB: c.memoryLimitMB, networkIOString: "–", uptime: "–", command: c.command, mounts: c.mounts, networks: c.networks, environment: c.environment)
+        containers[i] = Container(id: c.id, name: c.name, image: c.image, status: .stopped,
+                                  ports: c.ports, cpuPercent: 0, memoryMB: 0,
+                                  memoryLimitMB: c.memoryLimitMB, networkIOString: "–", uptime: "–",
+                                  command: c.command, mounts: c.mounts, networks: c.networks,
+                                  environment: c.environment)
     }
 
     override func deleteContainer(_ id: String) async throws {
@@ -128,8 +144,9 @@ final class MockContainerService: ContainerServiceBase {
         pinnedContainerIDs.remove(id)
     }
 
-    /// Records the arguments of the last copy so tests and previews can assert what the UI asked
-    /// for without a daemon. There's no host/guest filesystem to actually move bytes between here.
+    // Records the arguments of the last copy so tests and previews can assert what the UI asked
+    // for without a daemon. There's no host/guest filesystem to actually move bytes between here.
+    // swiftlint:disable:next large_tuple
     private(set) var lastCopy: (direction: CopyDirection, containerID: String, hostPath: String, containerPath: String)?
 
     override func copyFiles(direction: CopyDirection, containerID: String, hostPath: String, containerPath: String) async throws {
@@ -370,7 +387,7 @@ final class MockContainerService: ContainerServiceBase {
             SystemProperty(key: "network.subnet", value: "192.168.64.0/24"),
             SystemProperty(key: "network.subnetv6", value: "–"),
             SystemProperty(key: "registry.domain", value: "docker.io"),
-            SystemProperty(key: "vminit.image", value: "ghcr.io/apple/containerization/vminit:latest"),
+            SystemProperty(key: "vminit.image", value: "ghcr.io/apple/containerization/vminit:latest")
         ]
     }
 
@@ -411,7 +428,7 @@ final class MockContainerService: ContainerServiceBase {
         for line in [
             "08:00:00.000\tInfo\tapiserver started",
             "08:00:01.000\tInfo\tlistening on com.apple.container.apiserver",
-            "08:00:02.481\tError\txpc client handler connection error [error=Connection invalid]",
+            "08:00:02.481\tError\txpc client handler connection error [error=Connection invalid]"
         ] {
             onLine(line)
         }
@@ -437,7 +454,7 @@ final class MockContainerService: ContainerServiceBase {
             "#7 exporting to image",
             "#7 exporting layers done",
             "#7 writing image sha256:abc123 done",
-            "#7 naming to \(options.reference) done",
+            "#7 naming to \(options.reference) done"
         ]
         for line in lines {
             try? await Task.sleep(for: .milliseconds(300))
@@ -583,7 +600,8 @@ final class MockContainerService: ContainerServiceBase {
         await startDaemon()
     }
 
-    override func pullImage(reference: String, platform: String? = nil, insecure: Bool = false, progress: ProgressUpdateHandler? = nil, onUnpacking: (() -> Void)? = nil) async throws {
+    override func pullImage(reference: String, platform: String? = nil, insecure: Bool = false,
+                            progress: ProgressUpdateHandler? = nil, onUnpacking: (() -> Void)? = nil) async throws {
         let layerCount = 8
         let totalBytes: Int64 = 145_000_000
         let bytesPerLayer = totalBytes / Int64(layerCount)
@@ -660,7 +678,8 @@ final class MockContainerService: ContainerServiceBase {
         return ImageLoadSummary(loadedReferences: [full], rejectedMembers: [])
     }
 
-    override func pushImage(reference: String, destination: String? = nil, platform: String? = nil, insecure: Bool = false, progress: ProgressUpdateHandler? = nil) async throws {
+    override func pushImage(reference: String, destination: String? = nil, platform: String? = nil,
+                            insecure: Bool = false, progress: ProgressUpdateHandler? = nil) async throws {
         let source = images.first { $0.fullName == reference }
         let layerCount = 6
         let totalBytes = source?.sizeBytes ?? 120_000_000

--- a/Berthly/Core/Models.swift
+++ b/Berthly/Core/Models.swift
@@ -56,7 +56,7 @@ struct ContainerMount: Hashable {
     let destination: String
     /// Name of the named/anonymous volume backing this mount; `nil` for bind/virtiofs/tmpfs
     /// mounts. Lets `Volume.resolvingMounts` reconstruct volume→container attachments.
-    var volumeName: String? = nil
+    var volumeName: String?
     var isReadOnly: Bool = false
 
     var displayString: String { "\(source) → \(destination)" }
@@ -77,7 +77,7 @@ struct Container: Identifiable, Hashable {
     let mounts: [ContainerMount]
     let networks: [String]
     let environment: [String]
-    var startedDate: Date? = nil
+    var startedDate: Date?
 
     // Include status and image so SwiftUI detects section changes and late-arriving image data.
     // Hash by id only for stable Set membership across status/image transitions.
@@ -470,6 +470,10 @@ struct PruneResult: Sendable, Equatable {
             deletedNetworkCount: lhs.deletedNetworkCount + rhs.deletedNetworkCount,
             failedCount: lhs.failedCount + rhs.failedCount
         )
+    }
+
+    static func += (lhs: inout PruneResult, rhs: PruneResult) {
+        lhs = lhs + rhs
     }
 
     /// Formats this result for display, whether it came from a single-category cleanup or the

--- a/Berthly/Core/SizeFormatting.swift
+++ b/Berthly/Core/SizeFormatting.swift
@@ -8,9 +8,9 @@ import Foundation
 func formatSize(_ bytes: Int64) -> String {
     let mb = Double(bytes) / 1_048_576
     if mb >= 1024 { return String(format: "%.1f GB", mb / 1024) }
-    if mb >= 1    { return String(format: "%.0f MB", mb) }
+    if mb >= 1 { return String(format: "%.0f MB", mb) }
     let kb = Double(bytes) / 1024
-    if kb >= 1    { return String(format: "%.0f KB", kb) }
+    if kb >= 1 { return String(format: "%.0f KB", kb) }
     return "\(bytes) B"
 }
 

--- a/Berthly/Core/TerminalSession.swift
+++ b/Berthly/Core/TerminalSession.swift
@@ -86,7 +86,7 @@ final class TerminalSession {
         let keepFd    = policy.handOffIsReadEnd ? writeEnd : readEnd
         return (
             handOff: FileHandle(fileDescriptor: handOffFd, closeOnDealloc: policy.handOffOwnsClose),
-            keep:    FileHandle(fileDescriptor: keepFd,    closeOnDealloc: policy.keepOwnsClose)
+            keep: FileHandle(fileDescriptor: keepFd, closeOnDealloc: policy.keepOwnsClose)
         )
     }
 

--- a/Berthly/Design/BerthlyColors.swift
+++ b/Berthly/Design/BerthlyColors.swift
@@ -21,9 +21,9 @@ extension Color {
         var int: UInt64 = 0
         Scanner(string: hex).scanHexInt64(&int)
         self.init(
-            red:   Double((int >> 16) & 0xFF) / 255,
+            red: Double((int >> 16) & 0xFF) / 255,
             green: Double((int >>  8) & 0xFF) / 255,
-            blue:  Double( int        & 0xFF) / 255
+            blue: Double( int        & 0xFF) / 255
         )
     }
 }

--- a/Berthly/Design/HoverIconButtonStyle.swift
+++ b/Berthly/Design/HoverIconButtonStyle.swift
@@ -1,7 +1,6 @@
 // Copyright 2026 Berthly Contributors
 // Licensed under the Apache License, Version 2.0
 
-
 import SwiftUI
 
 /// Button style for icon-only row actions (delete, run, etc.) that only become

--- a/Berthly/Design/TerminalTheme.swift
+++ b/Berthly/Design/TerminalTheme.swift
@@ -49,28 +49,28 @@ extension TerminalColorSet {
         background: "282A36", foreground: "F8F8F2", cursor: "F8F8F2", selection: "44475A",
         ansi: [
             "21222C", "FF5555", "50FA7B", "F1FA8C", "BD93F9", "FF79C6", "8BE9FD", "F8F8F2",
-            "6272A4", "FF6E6E", "69FF94", "FFFFA5", "D6ACFF", "FF92DF", "A4FFFF", "FFFFFF",
+            "6272A4", "FF6E6E", "69FF94", "FFFFA5", "D6ACFF", "FF92DF", "A4FFFF", "FFFFFF"
         ])
 
     static let solarizedDark = TerminalColorSet(
         background: "002B36", foreground: "839496", cursor: "93A1A1", selection: "073642",
         ansi: [
             "073642", "DC322F", "859900", "B58900", "268BD2", "D33682", "2AA198", "EEE8D5",
-            "002B36", "CB4B16", "586E75", "657B83", "839496", "6C71C4", "93A1A1", "FDF6E3",
+            "002B36", "CB4B16", "586E75", "657B83", "839496", "6C71C4", "93A1A1", "FDF6E3"
         ])
 
     static let nord = TerminalColorSet(
         background: "2E3440", foreground: "D8DEE9", cursor: "D8DEE9", selection: "434C5E",
         ansi: [
             "3B4252", "BF616A", "A3BE8C", "EBCB8B", "81A1C1", "B48EAD", "88C0D0", "E5E9F0",
-            "4C566A", "BF616A", "A3BE8C", "EBCB8B", "81A1C1", "B48EAD", "88C0D0", "ECEFF4",
+            "4C566A", "BF616A", "A3BE8C", "EBCB8B", "81A1C1", "B48EAD", "88C0D0", "ECEFF4"
         ])
 
     static let oneDark = TerminalColorSet(
         background: "282C34", foreground: "ABB2BF", cursor: "528BFF", selection: "3E4451",
         ansi: [
             "282C34", "E06C75", "98C379", "E5C07B", "61AFEF", "C678DD", "56B6C2", "ABB2BF",
-            "5C6370", "E06C75", "98C379", "E5C07B", "61AFEF", "C678DD", "56B6C2", "FFFFFF",
+            "5C6370", "E06C75", "98C379", "E5C07B", "61AFEF", "C678DD", "56B6C2", "FFFFFF"
         ])
 }
 

--- a/Berthly/Views/AddRegistrySheet.swift
+++ b/Berthly/Views/AddRegistrySheet.swift
@@ -105,7 +105,10 @@ struct AddRegistrySheet: View {
                             Text("Reused on next push & pull · never written to config.toml")
                                 .font(.caption2)
                                 .foregroundStyle(.tertiary)
-                            Text("While signed in, macOS may also confirm Keychain access on pulls from this host — even public images. Sign out from Registries when you're done to stop it.")
+                            Text("""
+                                While signed in, macOS may also confirm Keychain access on pulls from this \
+                                host — even public images. Sign out from Registries when you're done to stop it.
+                                """)
                                 .font(.caption2)
                                 .foregroundStyle(.tertiary)
                         }

--- a/Berthly/Views/ComputeListView.swift
+++ b/Berthly/Views/ComputeListView.swift
@@ -287,8 +287,7 @@ private struct ContainerComputeRow: View {
                 isDeleting = true
                 if selection == .container(container.id) { selection = nil }
                 Task {
-                    do { try await service.deleteContainer(container.id) }
-                    catch { errorMessage = error.localizedDescription }
+                    do { try await service.deleteContainer(container.id) } catch { errorMessage = error.localizedDescription }
                     isDeleting = false
                 }
             }
@@ -304,8 +303,7 @@ private struct ContainerComputeRow: View {
         guard !isWorking else { return }
         isWorking = true
         Task {
-            do { try await action() }
-            catch { errorMessage = error.localizedDescription }
+            do { try await action() } catch { errorMessage = error.localizedDescription }
             isWorking = false
         }
     }
@@ -426,8 +424,7 @@ private struct MachineComputeRow: View {
                 isDeleting = true
                 if selection == .machine(machine.id) { selection = nil }
                 Task {
-                    do { try await service.deleteMachine(machine.id) }
-                    catch { errorMessage = error.localizedDescription }
+                    do { try await service.deleteMachine(machine.id) } catch { errorMessage = error.localizedDescription }
                     isDeleting = false
                 }
             }
@@ -443,8 +440,7 @@ private struct MachineComputeRow: View {
         guard !isWorking else { return }
         isWorking = true
         Task {
-            do { try await action() }
-            catch { errorMessage = error.localizedDescription }
+            do { try await action() } catch { errorMessage = error.localizedDescription }
             isWorking = false
         }
     }
@@ -475,7 +471,7 @@ private struct ComputeSectionHeader: View {
 // Wrapped in NavigationStack so `.searchable` has a navigation container to place its field in,
 // matching the NavigationSplitView the real app provides.
 #Preview {
-    @Previewable @State var selection: ComputeItem? = nil
+    @Previewable @State var selection: ComputeItem?
     NavigationStack {
         ComputeListView(selection: $selection)
     }
@@ -485,7 +481,7 @@ private struct ComputeSectionHeader: View {
 }
 
 #Preview("Empty") {
-    @Previewable @State var selection: ComputeItem? = nil
+    @Previewable @State var selection: ComputeItem?
     let mock = MockContainerService()
     mock.containers.removeAll()
     mock.machines.removeAll()

--- a/Berthly/Views/ContainerDetailView.swift
+++ b/Berthly/Views/ContainerDetailView.swift
@@ -213,7 +213,7 @@ private struct OverviewTab: View {
 
     struct StatsPoint: Identifiable {
         let id    = UUID()
-        let cpu:   Double
+        let cpu: Double
         let memMB: Double
         let netMBs: Double
     }
@@ -296,15 +296,15 @@ private struct InspectSection: View {
     private var rows: [(String, String)] {
         let mountStr = container.mounts.map(\.displayString).joined(separator: "\n")
         return [
-            ("Status",       "\(container.status.label)\(container.status == .running ? " · up \(container.uptime)" : "")"),
-            ("Image",        container.image),
+            ("Status", "\(container.status.label)\(container.status == .running ? " · up \(container.uptime)" : "")"),
+            ("Image", container.image),
             ("Container ID", container.id),
-            ("Command",      container.command),
-            ("Ports",        container.ports.isEmpty ? "–" : container.ports.map(\.displayString).joined(separator: ", ")),
-            ("Mounts",       mountStr.isEmpty ? "–" : mountStr),
-            ("Networks",     container.networks.isEmpty ? "–" : container.networks.joined(separator: ", ")),
-            ("Environment",  container.environment.isEmpty ? "–"
-                             : "\(container.environment[0])\(container.environment.count > 1 ? " (+\(container.environment.count - 1))" : "")"),
+            ("Command", container.command),
+            ("Ports", container.ports.isEmpty ? "–" : container.ports.map(\.displayString).joined(separator: ", ")),
+            ("Mounts", mountStr.isEmpty ? "–" : mountStr),
+            ("Networks", container.networks.isEmpty ? "–" : container.networks.joined(separator: ", ")),
+            ("Environment", container.environment.isEmpty ? "–"
+                             : "\(container.environment[0])\(container.environment.count > 1 ? " (+\(container.environment.count - 1))" : "")")
         ]
     }
 
@@ -361,12 +361,12 @@ private struct LogsTab: View {
 }
 
 private struct MetricCard: View {
-    let label:      String
-    let value:      String
-    let trend:      String
+    let label: String
+    let value: String
+    let trend: String
     let trendColor: Color
-    let data:       [Double]
-    let lineColor:  Color
+    let data: [Double]
+    let lineColor: Color
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {

--- a/Berthly/Views/DaemonGateView.swift
+++ b/Berthly/Views/DaemonGateView.swift
@@ -219,7 +219,10 @@ struct DaemonGateView<Content: View>: View {
                 Button("Update", role: .destructive) { onConfirm() }
                 Button("Cancel", role: .cancel) {}
             } message: {
-                Text("This stops every running container on this Mac, not just ones Berthly manages, while the update runs. You'll be asked for your admin password.")
+                Text("""
+                    This stops every running container on this Mac, not just ones Berthly manages, \
+                    while the update runs. You'll be asked for your admin password.
+                    """)
             }
         }
     }
@@ -365,7 +368,7 @@ struct DaemonGateView<Content: View>: View {
         logLines: [
             "Updating to release version 1.1.0",
             "Downloading package from: https://github.com/apple/container/releases/…",
-            "Installing package to /usr/local…",
+            "Installing package to /usr/local…"
         ],
         onCancel: {}
     )

--- a/Berthly/Views/ImageDetailView.swift
+++ b/Berthly/Views/ImageDetailView.swift
@@ -1,7 +1,6 @@
 // Copyright 2026 Berthly Contributors
 // Licensed under the Apache License, Version 2.0
 
-
 import SwiftUI
 
 // MARK: - ImageDetailView
@@ -105,9 +104,9 @@ private struct ImageDetailContent: View {
 
     private func configRows(_ d: ImageInspectData) -> [(String, String)] {
         var rows: [(String, String)] = []
-        if !d.command.isEmpty   { rows.append(("Command",     d.command)) }
-        if !d.workDir.isEmpty   { rows.append(("Work Dir",    d.workDir)) }
-        if !d.user.isEmpty      { rows.append(("User",        d.user)) }
+        if !d.command.isEmpty { rows.append(("Command", d.command)) }
+        if !d.workDir.isEmpty { rows.append(("Work Dir", d.workDir)) }
+        if !d.user.isEmpty { rows.append(("User", d.user)) }
         if !d.stopSignal.isEmpty { rows.append(("Stop Signal", d.stopSignal)) }
         return rows
     }
@@ -294,7 +293,7 @@ private struct PlatformsSection: View {
     private func variantSize(_ bytes: Int64) -> String {
         let mb = Double(bytes) / 1_048_576
         if mb >= 1024 { return String(format: "%.1f GB", mb / 1024) }
-        if mb >= 1    { return String(format: "%.0f MB", mb) }
+        if mb >= 1 { return String(format: "%.0f MB", mb) }
         return "<1 MB"
     }
 }

--- a/Berthly/Views/ImagesListView.swift
+++ b/Berthly/Views/ImagesListView.swift
@@ -39,7 +39,7 @@ struct ImagesListView: View {
         }
     }
 
-    private var local:  [ContainerImage] { filtered.filter { $0.source == .built } }
+    private var local: [ContainerImage] { filtered.filter { $0.source == .built } }
     private var pulled: [ContainerImage] { filtered.filter { $0.source == .pulled } }
 
     // Summarizes all images, not `filtered` — like the Volumes bar, it reports disk state,
@@ -66,7 +66,7 @@ struct ImagesListView: View {
                 List(selection: $selectedID) {
                     if !local.isEmpty {
                         Section {
-                            ForEach(local)  { img in ImageRow(imageID: img.id, selectedID: $selectedID).tag(img.id).listRowSeparator(.hidden) }
+                            ForEach(local) { img in ImageRow(imageID: img.id, selectedID: $selectedID).tag(img.id).listRowSeparator(.hidden) }
                         // "BUILT", not "LOCAL": pulled images live locally too, so "local" didn't
                         // distinguish anything — the split is how the image got here.
                         } header: { LibrarySectionHeader("BUILT \(local.count)") }
@@ -168,8 +168,7 @@ struct ImagesListView: View {
         guard let image = deleteTarget else { return }
         deleteTargetID = nil
         Task {
-            do { try await service.deleteImage(image.fullName) }
-            catch { deleteErrorMessage = error.localizedDescription }
+            do { try await service.deleteImage(image.fullName) } catch { deleteErrorMessage = error.localizedDescription }
         }
     }
 
@@ -292,8 +291,7 @@ private struct ImageRow: View {
                     isDeleting = true
                     if selectedID == image.id { selectedID = nil }
                     Task {
-                        do { try await service.deleteImage(image.fullName) }
-                        catch { errorMessage = error.localizedDescription }
+                        do { try await service.deleteImage(image.fullName) } catch { errorMessage = error.localizedDescription }
                         isDeleting = false
                     }
                 }
@@ -374,7 +372,7 @@ struct LibrarySortMenu: View {
 }
 
 #Preview {
-    @Previewable @State var selectedID: String? = nil
+    @Previewable @State var selectedID: String?
     ImagesListView(selectedID: $selectedID)
         .environment(MockContainerService() as ContainerServiceBase)
         .environment(MenuBarBridge())
@@ -382,7 +380,7 @@ struct LibrarySortMenu: View {
 }
 
 #Preview("Empty") {
-    @Previewable @State var selectedID: String? = nil
+    @Previewable @State var selectedID: String?
     let mock = MockContainerService()
     mock.images.removeAll()
     return ImagesListView(selectedID: $selectedID)

--- a/Berthly/Views/LogStreamView.swift
+++ b/Berthly/Views/LogStreamView.swift
@@ -16,7 +16,7 @@ struct LogStreamView: View {
     /// source — the GUI equivalent of the CLI's `logs --boot` flag. The caller must fold the
     /// source into `id` so switching restarts the stream task. `nil` hides the picker (Daemon
     /// Logs and other single-source streams).
-    var source: Binding<LogStreamer.LogSource>? = nil
+    var source: Binding<LogStreamer.LogSource>?
 
     struct LogLine: Identifiable {
         let id = UUID()
@@ -278,7 +278,7 @@ private struct LogStreamLineRow: View {
             "09:01:12 INFO server listening on :8080",
             "09:01:13 WARN slow query took 812ms",
             "09:01:14 ERROR connection refused: db:5432",
-            "added 1423 packages in 12s",
+            "added 1423 packages in 12s"
         ] {
             await MainActor.run { onLine(raw) }
         }
@@ -291,7 +291,7 @@ private struct LogStreamLineRow: View {
         for raw in [
             "vminit: mounting rootfs",
             "vminit: starting init process",
-            "vminit: ready",
+            "vminit: ready"
         ] {
             await MainActor.run { onLine(raw) }
         }
@@ -302,15 +302,15 @@ private struct LogStreamLineRow: View {
 #Preview("Log rows — structured / mixed / plain") {
     let lines: [LogStreamView.LogLine] = [
         // Fully structured: time + level columns
-        .init(timestamp: "09:01:12", level: .info,  message: "server listening on :8080"),
-        .init(timestamp: "09:01:13", level: .warn,  message: "slow query took 812ms"),
+        .init(timestamp: "09:01:12", level: .info, message: "server listening on :8080"),
+        .init(timestamp: "09:01:13", level: .warn, message: "slow query took 812ms"),
         .init(timestamp: "09:01:14", level: .error, message: "connection refused: db:5432"),
         // Time only (level column empty but grid kept)
         .init(timestamp: "09:01:15", level: .other, message: "GET /health 200"),
         // Pure plain stdout — should be flush-left, no gutter
         .init(timestamp: "", level: .other, message: "added 1423 packages in 12s"),
         .init(timestamp: "", level: .other, message: "  at Object.<anonymous> (/app/index.js:42:11)"),
-        .init(timestamp: "", level: .other, message: "Building wheel for numpy (pyproject.toml) ..."),
+        .init(timestamp: "", level: .other, message: "Building wheel for numpy (pyproject.toml) ...")
     ]
     return VStack(alignment: .leading, spacing: 0) {
         ForEach(lines) { LogStreamLineRow(line: $0, wrapText: false) }

--- a/Berthly/Views/MachineCreateSheet.swift
+++ b/Berthly/Views/MachineCreateSheet.swift
@@ -14,8 +14,8 @@ private final class MachineCreateState {
     }
 
     var isRunning = false
-    var result: Result? = nil
-    var runTask: Task<Void, Never>? = nil
+    var result: Result?
+    var runTask: Task<Void, Never>?
 }
 
 private enum HomeMountChoice: String, CaseIterable {

--- a/Berthly/Views/MachineDetailView.swift
+++ b/Berthly/Views/MachineDetailView.swift
@@ -179,8 +179,7 @@ private struct MachineDetailContent: View {
         guard !isWorking else { return }
         isWorking = true
         Task {
-            do { try await action() }
-            catch { errorMessage = error.localizedDescription }
+            do { try await action() } catch { errorMessage = error.localizedDescription }
             isWorking = false
         }
     }
@@ -250,7 +249,7 @@ private struct PipelineBox: View {
     let title: String
     let caption: String
     var accented: Bool = false
-    var statusRunning: Bool? = nil
+    var statusRunning: Bool?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -411,13 +410,13 @@ private struct InspectSection: View {
 
     private var rows: [(String, String)] {
         [
-            ("Status",    machine.status.label),
-            ("Image",     machine.image),
+            ("Status", machine.status.label),
+            ("Image", machine.image),
             ("Machine ID", machine.id),
             ("Resources", machine.resources),
-            ("Kernel",    machine.kernel),
-            ("Created",   machine.created),
-            ("Disk",      String(format: "%.1f / %.1f GB", machine.diskUsedGB, machine.diskTotalGB)),
+            ("Kernel", machine.kernel),
+            ("Created", machine.created),
+            ("Disk", String(format: "%.1f / %.1f GB", machine.diskUsedGB, machine.diskTotalGB))
         ]
     }
 

--- a/Berthly/Views/MainWindowView.swift
+++ b/Berthly/Views/MainWindowView.swift
@@ -389,8 +389,8 @@ struct MainWindowView: View {
     /// The create action for the selected sidebar section, if it has one.
     private var contextualAddAction: (title: String, action: () -> Void)? {
         switch sidebarSelection {
-        case .volumes:    ("Add Volume…",   { showVolumeCreateSheet = true })
-        case .networks:   ("Add Network…",  { showNetworkCreateSheet = true })
+        case .volumes:    ("Add Volume…", { showVolumeCreateSheet = true })
+        case .networks:   ("Add Network…", { showNetworkCreateSheet = true })
         case .registries: ("Add Registry…", { showAddRegistrySheet = true })
         default:          nil
         }

--- a/Berthly/Views/NetworkDetailView.swift
+++ b/Berthly/Views/NetworkDetailView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 struct NetworkDetailView: View {
     let networkID: String
-    var onDelete: (() -> Void)? = nil
+    var onDelete: (() -> Void)?
     @Environment(ContainerServiceBase.self) private var service
 
     var body: some View {
@@ -289,14 +289,14 @@ private struct NetworkDetailContent: View {
 
     private func configurationSection(_ network: Network) -> some View {
         let rows: [(String, String)] = [
-            ("Driver",     network.driver.rawValue),
-            ("Scope",      network.scope),
-            ("Subnet",     network.subnet),
-            ("Gateway",    network.gateway),
-            ("IPv6",       network.ipv6Enabled ? "enabled" : "disabled"),
-            ("Egress",     NetworkPresentation.egressDescription(for: network)),
+            ("Driver", network.driver.rawValue),
+            ("Scope", network.scope),
+            ("Subnet", network.subnet),
+            ("Gateway", network.gateway),
+            ("IPv6", network.ipv6Enabled ? "enabled" : "disabled"),
+            ("Egress", NetworkPresentation.egressDescription(for: network)),
             ("Attachable", network.attachable ? "yes" : "no"),
-            ("Backend",    network.backend),
+            ("Backend", network.backend)
         ]
         return DetailSection(title: "Configuration") {
             KeyValueRows(rows: rows, monoKeys: ["Subnet", "Gateway", "Egress", "Backend"])

--- a/Berthly/Views/NetworksListView.swift
+++ b/Berthly/Views/NetworksListView.swift
@@ -151,8 +151,7 @@ struct NetworksListView: View {
         deleteTargetID = nil
         if selectedID == network.id { selectedID = nil }
         Task {
-            do { try await service.deleteNetwork(network.id) }
-            catch { deleteErrorMessage = error.localizedDescription }
+            do { try await service.deleteNetwork(network.id) } catch { deleteErrorMessage = error.localizedDescription }
         }
     }
 }
@@ -231,8 +230,7 @@ private struct NetworkRow: View {
                     isDeleting = true
                     if selectedID == network.id { selectedID = nil }
                     Task {
-                        do { try await service.deleteNetwork(network.id) }
-                        catch { errorMessage = error.localizedDescription }
+                        do { try await service.deleteNetwork(network.id) } catch { errorMessage = error.localizedDescription }
                         isDeleting = false
                     }
                 }
@@ -289,7 +287,7 @@ private struct RowChip: View {
 }
 
 #Preview {
-    @Previewable @State var selectedID: String? = nil
+    @Previewable @State var selectedID: String?
     NetworksListView(selectedID: $selectedID)
         .environment(MockContainerService() as ContainerServiceBase)
         .environment(MenuBarBridge())

--- a/Berthly/Views/RegistriesListView.swift
+++ b/Berthly/Views/RegistriesListView.swift
@@ -104,7 +104,12 @@ struct RegistriesListView: View {
             Image(systemName: "lock.fill")
                 .foregroundStyle(.blue)
                 .padding(.top, 1)
-            Text("Credentials are stored in the **macOS Keychain**, never written to `config.toml` in plaintext. Signing in or out maps to `container registry login` / `logout` — no daemon restart. While signed in, macOS may confirm Keychain access on pulls from that host too, even for public images — sign out below to stop it.")
+            Text("""
+                Credentials are stored in the **macOS Keychain**, never written to `config.toml` \
+                in plaintext. Signing in or out maps to `container registry login` / `logout` — \
+                no daemon restart. While signed in, macOS may confirm Keychain access on pulls \
+                from that host too, even for public images — sign out below to stop it.
+                """)
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/Berthly/Views/RunContainerSheet.swift
+++ b/Berthly/Views/RunContainerSheet.swift
@@ -17,8 +17,8 @@ private final class RunState {
     }
 
     var isRunning = false
-    var result: Result? = nil
-    var runTask: Task<Void, Never>? = nil
+    var result: Result?
+    var runTask: Task<Void, Never>?
 }
 
 // MARK: - Sheet
@@ -371,7 +371,10 @@ struct RunContainerSheet: View {
             Toggle(isOn: $attachAndShowOutput) {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Attach and show output")
-                    Text("For one-shot commands that exit, e.g. pwd — waits for the command to finish and shows what it printed. Don't use with a long-running service.")
+                    Text("""
+                        For one-shot commands that exit, e.g. pwd — waits for the command to finish \
+                        and shows what it printed. Don't use with a long-running service.
+                        """)
                         .font(.caption)
                         .foregroundStyle(.tertiary)
                 }

--- a/Berthly/Views/SetKernelSheet.swift
+++ b/Berthly/Views/SetKernelSheet.swift
@@ -11,7 +11,7 @@ import TerminalProgress
 private final class KernelInstallState {
     var isInstalling = false
     var statusText = ""
-    var fraction: Double? = nil
+    var fraction: Double?
     var errorMessage: String?
 
     private var totalBytes: Int64 = 0

--- a/Berthly/Views/SheetChrome.swift
+++ b/Berthly/Views/SheetChrome.swift
@@ -165,7 +165,7 @@ struct SheetCalloutDetail: View {
     let text: String
     var monospaced: Bool = true
     var selectable: Bool = false
-    var lineLimit: Int? = nil
+    var lineLimit: Int?
 
     var body: some View {
         let base = Text(text)
@@ -201,11 +201,11 @@ struct SheetSubmitFooter: View {
     var doneLabel: LocalizedStringKey = "Done"
     var canSubmit: Bool = true
     /// Accessibility identifier for the idle submit button (UI/E2E tests drive it).
-    var submitIdentifier: String? = nil
+    var submitIdentifier: String?
     /// Hide the disabled spinner button for work that only offers Cancel (save/load).
     var showsBusyButton: Bool = true
     /// Working-phase Cancel action; `nil` keeps the idle behavior of dismissing the sheet.
-    var onCancel: (() -> Void)? = nil
+    var onCancel: (() -> Void)?
     var onSubmit: () -> Void = {}
 
     @Environment(\.dismiss) private var dismiss

--- a/Berthly/Views/SheetFormEditors.swift
+++ b/Berthly/Views/SheetFormEditors.swift
@@ -19,7 +19,7 @@ struct KeyValueEditor: View {
     /// "runEnvKeyField"/"runEnvValueField"/"runEnvAddButton". Applied to leaf controls only —
     /// an identifier on a container would override every child's own id. Rows share ids, so
     /// tests that add multiple rows must scope queries; E2E journeys add one row per editor.
-    var identifierPrefix: String? = nil
+    var identifierPrefix: String?
     @Binding var pairs: [KeyValuePair]
 
     var body: some View {
@@ -73,9 +73,9 @@ struct StringEntry: Identifiable {
 struct StringListEditor: View {
     let title: LocalizedStringKey
     let placeholder: String
-    var helpText: String? = nil
+    var helpText: String?
     /// Test-identifier prefix (see KeyValueEditor): "runVolume" → "runVolumeField"/"runVolumeAddButton".
-    var identifierPrefix: String? = nil
+    var identifierPrefix: String?
     @Binding var entries: [StringEntry]
 
     var body: some View {
@@ -123,10 +123,10 @@ struct StringListEditor: View {
 
 struct NetworkListEditor: View {
     let title: LocalizedStringKey
-    var helpText: String? = nil
+    var helpText: String?
     let availableNetworks: [Network]
     /// Test-identifier prefix (see KeyValueEditor): "runNetwork" → "runNetworkPicker"/"runNetworkAddButton".
-    var identifierPrefix: String? = nil
+    var identifierPrefix: String?
     @Binding var entries: [StringEntry]
 
     /// New rows start on the standard network rather than blank, since that's what an empty
@@ -198,7 +198,7 @@ struct PortEntry: Identifiable {
 struct PortRowsEditor: View {
     let title: LocalizedStringKey
     /// Test-identifier prefix (see KeyValueEditor): "runPort" → "runPortHostField"/"runPortContainerField"/"runPortAddButton".
-    var identifierPrefix: String? = nil
+    var identifierPrefix: String?
     @Binding var entries: [PortEntry]
 
     var body: some View {
@@ -370,7 +370,7 @@ struct LocalImageReferenceField: View {
     let images: [ContainerImage]
     /// Test identifier for the inner TextField (on the leaf, not this container — a container
     /// id would override the field's). Distinct per host sheet: "runImageField" vs machine's.
-    var fieldIdentifier: String? = nil
+    var fieldIdentifier: String?
 
     var body: some View {
         HStack(spacing: 6) {

--- a/Berthly/Views/Sidebar/SidebarView.swift
+++ b/Berthly/Views/Sidebar/SidebarView.swift
@@ -33,13 +33,13 @@ struct SidebarView: View {
                       : "No containers or machines running")
 
             Section("LIBRARY") {
-                SidebarRow(icon: "cylinder",              label: "Volumes",    badge: service.volumes.count)
+                SidebarRow(icon: "cylinder", label: "Volumes", badge: service.volumes.count)
                     .tag(SidebarSelection.volumes)
-                SidebarRow(icon: "arrow.triangle.branch", label: "Networks",   badge: service.networks.count)
+                SidebarRow(icon: "arrow.triangle.branch", label: "Networks", badge: service.networks.count)
                     .tag(SidebarSelection.networks)
-                SidebarRow(icon: "square.stack.3d.up",   label: "Images",     badge: service.images.count)
+                SidebarRow(icon: "square.stack.3d.up", label: "Images", badge: service.images.count)
                     .tag(SidebarSelection.images)
-                SidebarRow(icon: "building.columns",      label: "Registries", badge: service.registries.count)
+                SidebarRow(icon: "building.columns", label: "Registries", badge: service.registries.count)
                     .tag(SidebarSelection.registries)
             }
 
@@ -69,11 +69,11 @@ struct SidebarView: View {
 private struct SidebarRow: View {
     let icon: String
     let label: LocalizedStringKey
-    var badge: Int? = nil
-    var badgeText: String? = nil
+    var badge: Int?
+    var badgeText: String?
     /// Colors the badge count (`Text.foregroundColor` survives into `.badge()` rendering).
     /// Used to mark a badge that means "currently running" rather than "total".
-    var badgeTint: Color? = nil
+    var badgeTint: Color?
     var indent: Bool = false
 
     var body: some View {
@@ -100,7 +100,7 @@ struct DaemonStatusBar: View {
     let state: DaemonState
     /// Non-nil when the daemon connected fine but a background bootstrap step
     /// (vminit image / default kernel install) failed. Only shown while `.connected`.
-    var warning: String? = nil
+    var warning: String?
 
     var body: some View {
         HStack {

--- a/Berthly/Views/SystemView.swift
+++ b/Berthly/Views/SystemView.swift
@@ -203,7 +203,10 @@ private struct DiskUsageSection: View {
                     DiskUsageGridRow(name: "Containers", category: usage.containers, cleanup: .init(
                         confirmTitle: "Remove stopped containers?",
                         confirmButton: "Remove",
-                        confirmMessage: "Deletes every stopped container and its writable layer. Running containers, machines, and builders are left alone. This can't be undone.",
+                        confirmMessage: """
+                            Deletes every stopped container and its writable layer. Running \
+                            containers, machines, and builders are left alone. This can't be undone.
+                            """,
                         isDestructive: true,
                         run: { try await service.pruneStoppedContainers() }
                     ))
@@ -214,7 +217,11 @@ private struct DiskUsageSection: View {
                     DiskUsageGridRow(name: "Volumes", category: usage.volumes, cleanup: .init(
                         confirmTitle: "Remove unused volumes?",
                         confirmButton: "Remove",
-                        confirmMessage: "Deletes every volume not attached to any container, including all data inside. Volumes a container still references — even a stopped one — are left alone. This can't be undone.",
+                        confirmMessage: """
+                            Deletes every volume not attached to any container, including all data \
+                            inside. Volumes a container still references — even a stopped one — are \
+                            left alone. This can't be undone.
+                            """,
                         isDestructive: true,
                         run: { try await service.pruneVolumes() }
                     ))
@@ -263,7 +270,10 @@ private struct DiskUsageSection: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("Removes unused images and stopped containers in one step. Volumes are never touched here — use the Volumes row's own Prune if you're sure you don't need their data.")
+            Text("""
+                Removes unused images and stopped containers in one step. Volumes are never touched \
+                here — use the Volumes row's own Prune if you're sure you don't need their data.
+                """)
         }
         .alert("Done", isPresented: Binding(
             get: { allResult != nil },
@@ -346,8 +356,7 @@ private struct DiskUsageGridRow: View {
                 Button(cleanup.confirmButton, role: cleanup.isDestructive ? .destructive : nil) {
                     isBusy = true
                     Task {
-                        do { result = try await cleanup.run() }
-                        catch { errorMessage = error.localizedDescription }
+                        do { result = try await cleanup.run() } catch { errorMessage = error.localizedDescription }
                         isBusy = false
                     }
                 }
@@ -417,7 +426,10 @@ private struct SystemConfigSection: View {
         } header: {
             sectionHeader("Infrastructure Images", systemImage: "cube")
         } footer: {
-            Text("The exact vminit and builder image versions this install of Berthly is built against — these must match what the installed container CLI expects.")
+            Text("""
+                The exact vminit and builder image versions this install of Berthly is built \
+                against — these must match what the installed container CLI expects.
+                """)
         }
     }
 
@@ -496,7 +508,10 @@ private struct SystemPropertiesSection: View {
         } header: {
             sectionHeader("Properties", systemImage: "list.bullet.rectangle")
         } footer: {
-            Text("Everything `container system property list` reports, defaults included. To change a value, edit config.toml (revealed above) and restart the daemon.")
+            Text("""
+                Everything `container system property list` reports, defaults included. To change \
+                a value, edit config.toml (revealed above) and restart the daemon.
+                """)
         }
     }
 }
@@ -541,7 +556,11 @@ private struct LocalDNSSection: View {
         } header: {
             sectionHeader("Local DNS", systemImage: "globe")
         } footer: {
-            Text("A local domain lets this Mac resolve containers by name under it (e.g. web.test). Adding or removing one modifies /etc/resolver, so macOS asks for an administrator password.")
+            Text("""
+                A local domain lets this Mac resolve containers by name under it (e.g. web.test). \
+                Adding or removing one modifies /etc/resolver, so macOS asks for an administrator \
+                password.
+                """)
         }
         .alert("Add a local DNS domain", isPresented: $showAddPrompt) {
             TextField("Domain (e.g. test)", text: $newDomain)
@@ -557,9 +576,13 @@ private struct LocalDNSSection: View {
         let domain = newDomain
         isCreating = true
         Task {
-            do { try await service.createDNSDomain(domain) }
-            catch is CancellationError { /* dismissed the admin prompt — not an error */ }
-            catch { errorMessage = error.localizedDescription }
+            do {
+                try await service.createDNSDomain(domain)
+            } catch is CancellationError {
+                // Dismissed the admin prompt — not an error.
+            } catch {
+                errorMessage = error.localizedDescription
+            }
             isCreating = false
         }
     }
@@ -594,9 +617,13 @@ private struct DNSDomainRow: View {
             Button("Delete", role: .destructive) {
                 isDeleting = true
                 Task {
-                    do { try await service.deleteDNSDomain(domain) }
-                    catch is CancellationError { /* dismissed the admin prompt */ }
-                    catch { errorMessage = error.localizedDescription }
+                    do {
+                        try await service.deleteDNSDomain(domain)
+                    } catch is CancellationError {
+                        // Dismissed the admin prompt — not an error.
+                    } catch {
+                        errorMessage = error.localizedDescription
+                    }
                     isDeleting = false
                 }
             }
@@ -667,8 +694,7 @@ private struct BuilderRow: View {
                     Button {
                         isStarting = true
                         Task {
-                            do { try await service.startBuilder(builder.id) }
-                            catch { errorMessage = error.localizedDescription }
+                            do { try await service.startBuilder(builder.id) } catch { errorMessage = error.localizedDescription }
                             isStarting = false
                         }
                     } label: {
@@ -708,8 +734,7 @@ private struct BuilderRow: View {
             Button("Stop", role: .destructive) {
                 isStopping = true
                 Task {
-                    do { try await service.stopBuilder(builder.id) }
-                    catch { errorMessage = error.localizedDescription }
+                    do { try await service.stopBuilder(builder.id) } catch { errorMessage = error.localizedDescription }
                     isStopping = false
                 }
             }
@@ -721,8 +746,7 @@ private struct BuilderRow: View {
             Button("Delete", role: .destructive) {
                 isDeleting = true
                 Task {
-                    do { try await service.deleteBuilder(builder.id) }
-                    catch { errorMessage = error.localizedDescription }
+                    do { try await service.deleteBuilder(builder.id) } catch { errorMessage = error.localizedDescription }
                     isDeleting = false
                 }
             }
@@ -850,7 +874,7 @@ private struct DaemonLogView: View {
         Builder(id: "running", name: "buildkit", image: "buildkit:0.13", status: .running,
                 autoStarted: true, cpus: 2, memoryGB: 2),
         Builder(id: "stopped", name: "buildkit", image: "buildkit:0.13", status: .stopped,
-                autoStarted: false, cpus: 2, memoryGB: 2),
+                autoStarted: false, cpus: 2, memoryGB: 2)
     ]
     return Form {
         BuilderSection()
@@ -865,7 +889,7 @@ private struct DaemonLogView: View {
         for raw in [
             "09:01:12.031\tinfo\tdaemon started",
             "09:01:13.114\tinfo\tapiserver ready",
-            "09:01:14.980\twarn\tbuilder image missing, pulling",
+            "09:01:14.980\twarn\tbuilder image missing, pulling"
         ] {
             await MainActor.run { onLine(raw) }
         }
@@ -889,7 +913,7 @@ private struct DaemonLogView: View {
     mock.systemProperties = [
         SystemProperty(key: "build.rosetta", value: "true"),
         SystemProperty(key: "dns.domain", value: "test"),
-        SystemProperty(key: "registry.domain", value: "docker.io"),
+        SystemProperty(key: "registry.domain", value: "docker.io")
     ]
     mock.kernelInfo = KernelInfo(path: "/opt/kata/share/kata-containers/vmlinux-6.18.15-186", platform: "linux/arm64")
     mock.systemConfigInfo = SystemConfigInfo(

--- a/Berthly/Views/VolumeDetailView.swift
+++ b/Berthly/Views/VolumeDetailView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 struct VolumeDetailView: View {
     let volumeID: String
-    var onDelete: (() -> Void)? = nil
+    var onDelete: (() -> Void)?
     @Environment(ContainerServiceBase.self) private var service
 
     var body: some View {
@@ -304,8 +304,8 @@ private struct VolumeDetailContent: View {
 
     private func configurationSection(_ volume: Volume) -> some View {
         var rows: [(String, String)] = [
-            ("Type",   volume.type == .named ? "named" : "anonymous"),
-            ("Driver", volume.driver),
+            ("Type", volume.type == .named ? "named" : "anonymous"),
+            ("Driver", volume.driver)
         ]
         if !volume.source.isEmpty { rows.append(("Source", volume.source)) }
         rows.append(("Created", volume.created))

--- a/Berthly/Views/VolumesListView.swift
+++ b/Berthly/Views/VolumesListView.swift
@@ -27,7 +27,7 @@ struct VolumesListView: View {
         }
     }
 
-    private var named:     [Volume] { filtered.filter { $0.type == .named     } }
+    private var named: [Volume] { filtered.filter { $0.type == .named     } }
     private var anonymous: [Volume] { filtered.filter { $0.type == .anonymous } }
 
     private var totalUsedMB: Int { service.volumes.reduce(0) { $0 + $1.usedMB } }
@@ -54,7 +54,7 @@ struct VolumesListView: View {
                 List(selection: $selectedID) {
                     if !named.isEmpty {
                         Section {
-                            ForEach(named)     { v in VolumeRow(volumeID: v.id, selectedID: $selectedID).tag(v.id).listRowSeparator(.hidden) }
+                            ForEach(named) { v in VolumeRow(volumeID: v.id, selectedID: $selectedID).tag(v.id).listRowSeparator(.hidden) }
                         } header: { LibrarySectionHeader("NAMED \(named.count)") }
                     }
                     if !anonymous.isEmpty {
@@ -125,8 +125,7 @@ struct VolumesListView: View {
         deleteTargetID = nil
         if selectedID == volume.id { selectedID = nil }
         Task {
-            do { try await service.deleteVolume(volume.name) }
-            catch { deleteErrorMessage = error.localizedDescription }
+            do { try await service.deleteVolume(volume.name) } catch { deleteErrorMessage = error.localizedDescription }
         }
     }
 }
@@ -201,8 +200,7 @@ private struct VolumeRow: View {
                     isDeleting = true
                     if selectedID == volume.id { selectedID = nil }
                     Task {
-                        do { try await service.deleteVolume(volume.name) }
-                        catch { errorMessage = error.localizedDescription }
+                        do { try await service.deleteVolume(volume.name) } catch { errorMessage = error.localizedDescription }
                         isDeleting = false
                     }
                 }
@@ -258,7 +256,7 @@ private struct VolumeRow: View {
 }
 
 #Preview {
-    @Previewable @State var selectedID: String? = nil
+    @Previewable @State var selectedID: String?
     VolumesListView(selectedID: $selectedID)
         .environment(MockContainerService() as ContainerServiceBase)
         .environment(MenuBarBridge())

--- a/BerthlyE2ETests/BerthlyE2ETests.swift
+++ b/BerthlyE2ETests/BerthlyE2ETests.swift
@@ -508,6 +508,7 @@ final class MachineJourneyTests: BerthlyE2ETestCase {
             .appendingPathComponent("\(Self.resourcePrefix)-mctx-\(UUID().uuidString.prefix(8))")
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
+        // swiftlint:disable line_length
         let dockerfile = """
         FROM quay.io/fedora/fedora:44
         RUN dnf update -y && dnf install -y systemd
@@ -515,6 +516,7 @@ final class MachineJourneyTests: BerthlyE2ETestCase {
         VOLUME [ "/sys/fs/cgroup" ]
         CMD ["/usr/sbin/init"]
         """
+        // swiftlint:enable line_length
         try dockerfile.write(to: dir.appendingPathComponent("Dockerfile"),
                              atomically: true, encoding: .utf8)
         let tag = "\(Self.resourcePrefix)/machine-\(UUID().uuidString.prefix(8).lowercased()):1"

--- a/BerthlyE2ETests/E2ESupport.swift
+++ b/BerthlyE2ETests/E2ESupport.swift
@@ -86,10 +86,13 @@ enum ContainerCLI {
         if process.isRunning {
             process.terminate()
             throw NSError(domain: "ContainerCLI", code: 1, userInfo: [
-                NSLocalizedDescriptionKey: "`container \(arguments.joined(separator: " "))` timed out after \(Int(timeout))s",
+                NSLocalizedDescriptionKey: "`container \(arguments.joined(separator: " "))` timed out after \(Int(timeout))s"
             ])
         }
         let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        // Lossy decode on purpose: CLI output with a stray non-UTF-8 byte should still
+        // surface the rest, not become nil.
+        // swiftlint:disable:next optional_data_string_conversion
         return Result(status: process.terminationStatus, output: String(decoding: data, as: UTF8.self))
     }
 
@@ -111,7 +114,7 @@ enum ContainerCLI {
         let pull = try run(["image", "pull", reference], timeout: 600)
         guard pull.status == 0 else {
             throw NSError(domain: "ContainerCLI", code: 2, userInfo: [
-                NSLocalizedDescriptionKey: "pull \(reference) failed: \(pull.output)",
+                NSLocalizedDescriptionKey: "pull \(reference) failed: \(pull.output)"
             ])
         }
     }
@@ -130,7 +133,7 @@ enum ContainerCLI {
         let result = try run(["inspect", name], timeout: 30)
         guard result.status == 0 else {
             throw NSError(domain: "ContainerCLI", code: 3, userInfo: [
-                NSLocalizedDescriptionKey: "inspect \(name) failed: \(result.output)",
+                NSLocalizedDescriptionKey: "inspect \(name) failed: \(result.output)"
             ])
         }
         let data = Data(result.output.utf8)
@@ -138,7 +141,7 @@ enum ContainerCLI {
         if let array = parsed as? [[String: Any]], let first = array.first { return first }
         if let object = parsed as? [String: Any] { return object }
         throw NSError(domain: "ContainerCLI", code: 4, userInfo: [
-            NSLocalizedDescriptionKey: "unexpected inspect JSON shape: \(result.output.prefix(200))",
+            NSLocalizedDescriptionKey: "unexpected inspect JSON shape: \(result.output.prefix(200))"
         ])
     }
 

--- a/BerthlyTests/BerthlyTests.swift
+++ b/BerthlyTests/BerthlyTests.swift
@@ -1281,7 +1281,7 @@ struct ContainerServiceBaseSummaryTests {
         mock.containers = [
             makeContainer(id: "1", status: .running),
             makeContainer(id: "2", status: .stopped),
-            makeContainer(id: "3", status: .error),
+            makeContainer(id: "3", status: .error)
         ]
         #expect(mock.runningContainers.map(\.id) == ["1"])
         #expect(mock.errorContainerCount == 1)
@@ -1292,7 +1292,7 @@ struct ContainerServiceBaseSummaryTests {
         mock.machines = [
             makeMachine(id: "m1", status: .running),
             makeMachine(id: "m2", status: .stopped),
-            makeMachine(id: "m3", status: .error),
+            makeMachine(id: "m3", status: .error)
         ]
         #expect(mock.runningMachines.map(\.id) == ["m1"])
         #expect(mock.errorMachineCount == 1)
@@ -1303,7 +1303,7 @@ struct ContainerServiceBaseSummaryTests {
         mock.machines = [
             makeMachine(id: "m1", status: .running),
             makeMachine(id: "util-running", status: .running, isUtility: true),
-            makeMachine(id: "util-error", status: .error, isUtility: true),
+            makeMachine(id: "util-error", status: .error, isUtility: true)
         ]
         #expect(mock.runningMachines.map(\.id) == ["m1"])
         #expect(mock.errorMachineCount == 0)
@@ -1314,7 +1314,7 @@ struct ContainerServiceBaseSummaryTests {
         mock.containers = [
             makeContainer(id: "1", status: .running),
             makeContainer(id: "2", status: .stopped),
-            makeContainer(id: "3", status: .running),
+            makeContainer(id: "3", status: .running)
         ]
         mock.pinnedContainerIDs = ["2", "3"]
         #expect(Set(mock.pinnedContainers.map(\.id)) == ["2", "3"])
@@ -1324,7 +1324,7 @@ struct ContainerServiceBaseSummaryTests {
         let mock = MockContainerService()
         mock.machines = [
             makeMachine(id: "m1", status: .stopped),
-            makeMachine(id: "util", status: .running, isUtility: true),
+            makeMachine(id: "util", status: .running, isUtility: true)
         ]
         mock.pinnedMachineIDs = ["m1", "util"]
         #expect(mock.pinnedMachines.map(\.id) == ["m1"])

--- a/BerthlyTests/CommandPaletteTests.swift
+++ b/BerthlyTests/CommandPaletteTests.swift
@@ -28,7 +28,7 @@ import Testing
         let commands = [
             cmd("prefix", "Runner"),      // "run" is a prefix
             cmd("exact", "Run"),          // exact
-            cmd("substr", "Prerun task"), // "run" is a substring mid-string
+            cmd("substr", "Prerun task") // "run" is a substring mid-string
         ]
         let ranked = rankedPaletteCommands(commands, query: "run")
         #expect(ranked.first?.id == "exact")
@@ -38,7 +38,7 @@ import Testing
         let commands = [
             cmd("sub", "docker-nginx"),   // "dn" is a subsequence
             cmd("substr", "abc-dn-xyz"),  // "dn" is a contiguous substring
-            cmd("pre", "dns settings"),   // "dn" is a prefix
+            cmd("pre", "dns settings")   // "dn" is a prefix
         ]
         let ranked = rankedPaletteCommands(commands, query: "dn")
         #expect(ranked.map(\.id) == ["pre", "substr", "sub"])
@@ -58,7 +58,7 @@ import Testing
     @Test func keywordMatchesButRanksBelowTitleMatch() {
         let commands = [
             cmd("kw", "Add Registry…", keywords: ["login"]), // matches only via keyword
-            cmd("title", "Login window"),                    // matches in the title
+            cmd("title", "Login window")                    // matches in the title
         ]
         let ranked = rankedPaletteCommands(commands, query: "login")
         #expect(ranked.map(\.id) == ["title", "kw"])

--- a/BerthlyTests/DNSDomainTests.swift
+++ b/BerthlyTests/DNSDomainTests.swift
@@ -18,7 +18,7 @@ struct DNSDomainTests {
             "containerization.test",
             "containerization.dev.internal",
             "corp-vpn",           // someone else's resolver file
-            "openvpn.split",      // no containerization prefix
+            "openvpn.split"      // no containerization prefix
         ])
         #expect(domains == ["dev.internal", "test"])  // ours only, sorted
     }

--- a/BerthlyTests/ImageUsageResolverTests.swift
+++ b/BerthlyTests/ImageUsageResolverTests.swift
@@ -9,7 +9,7 @@ import Testing
 struct ImageUsageResolverTests {
 
     private func makeImage(id: String = "local/web:1.4", repository: String = "local/web",
-                            tag: String = "1.4", digest: String = "sha256:abc") -> ContainerImage {
+                           tag: String = "1.4", digest: String = "sha256:abc") -> ContainerImage {
         ContainerImage(id: id, repository: repository, tag: tag, digest: digest, arch: ["arm64"],
                         sizeBytes: 100, created: "–", source: .pulled, usage: .unused)
     }
@@ -77,7 +77,7 @@ struct ImageUsageResolverTests {
     @Test func diskUsageSumsDistinctDigests() {
         let usage = ContainerImage.diskUsage(of: [
             makeSizedImage(id: "a", digest: "sha256:a", sizeBytes: 100, usage: .usedBy(1)),
-            makeSizedImage(id: "b", digest: "sha256:b", sizeBytes: 250, usage: .unused),
+            makeSizedImage(id: "b", digest: "sha256:b", sizeBytes: 250, usage: .unused)
         ])
         #expect(usage.totalBytes == 350)
         #expect(usage.reclaimableBytes == 250)
@@ -87,7 +87,7 @@ struct ImageUsageResolverTests {
         // Two names for the same digest are one copy on disk, not two.
         let usage = ContainerImage.diskUsage(of: [
             makeSizedImage(id: "a", digest: "sha256:same", sizeBytes: 100, usage: .unused),
-            makeSizedImage(id: "b", digest: "sha256:same", sizeBytes: 100, usage: .unused),
+            makeSizedImage(id: "b", digest: "sha256:same", sizeBytes: 100, usage: .unused)
         ])
         #expect(usage.totalBytes == 100)
         #expect(usage.reclaimableBytes == 100)
@@ -97,7 +97,7 @@ struct ImageUsageResolverTests {
         // Deleting the unused tag frees nothing while another name still references the bytes.
         let usage = ContainerImage.diskUsage(of: [
             makeSizedImage(id: "a", digest: "sha256:same", sizeBytes: 100, usage: .usedBy(2)),
-            makeSizedImage(id: "b", digest: "sha256:same", sizeBytes: 100, usage: .unused),
+            makeSizedImage(id: "b", digest: "sha256:same", sizeBytes: 100, usage: .unused)
         ])
         #expect(usage.totalBytes == 100)
         #expect(usage.reclaimableBytes == 0)
@@ -105,7 +105,7 @@ struct ImageUsageResolverTests {
 
     @Test func builderImageIsNotReclaimable() {
         let usage = ContainerImage.diskUsage(of: [
-            makeSizedImage(id: "builder", digest: "sha256:builder", sizeBytes: 500, usage: .builderImage),
+            makeSizedImage(id: "builder", digest: "sha256:builder", sizeBytes: 500, usage: .builderImage)
         ])
         #expect(usage.totalBytes == 500)
         #expect(usage.reclaimableBytes == 0)

--- a/BerthlyTests/LogStreamClipboardTests.swift
+++ b/BerthlyTests/LogStreamClipboardTests.swift
@@ -30,7 +30,7 @@ struct LogStreamClipboardTests {
         let text = LogStreamView.clipboardText(for: [
             line("09:01:12", .info, "server up"),
             line("", .other, "plain stdout"),
-            line("09:01:14", .error, "boom"),
+            line("09:01:14", .error, "boom")
         ])
         #expect(text == "09:01:12 INFO server up\nplain stdout\n09:01:14 ERROR boom")
     }

--- a/BerthlyTests/NetworkPresentationTests.swift
+++ b/BerthlyTests/NetworkPresentationTests.swift
@@ -33,8 +33,8 @@ struct NetworkPresentationTests {
         // The live daemon reports no endpoints — attached containers must still show up.
         let containers = [
             makeContainer(name: "web", status: .running, networks: ["net"]),
-            makeContainer(name: "db",  status: .stopped, networks: ["net"]),
-            makeContainer(name: "other", status: .running, networks: ["elsewhere"]),
+            makeContainer(name: "db", status: .stopped, networks: ["net"]),
+            makeContainer(name: "other", status: .running, networks: ["elsewhere"])
         ]
         let resolved = NetworkPresentation.resolvedEndpoints(for: makeNetwork(), containers: containers)
         #expect(resolved.map(\.name) == ["db", "web"]) // sorted by name

--- a/BerthlyTests/PinnedStatusChangeTests.swift
+++ b/BerthlyTests/PinnedStatusChangeTests.swift
@@ -96,7 +96,7 @@ struct PinnedStatusChangeTextTests {
             (.running, "Container Started", "web is now running."),
             (.stopped, "Container Stopped", "web has stopped."),
             (.error, "Container Error", "web is in an error state."),
-            (.paused, "Container Paused", "web has been paused."),
+            (.paused, "Container Paused", "web has been paused.")
         ]
         for (newStatus, title, body) in cases {
             let change = PinnedStatusChange(

--- a/BerthlyTests/PruneSelectionTests.swift
+++ b/BerthlyTests/PruneSelectionTests.swift
@@ -58,7 +58,7 @@ struct PruneSelectionTests {
         let ids = LiveContainerService.deletableStoppedContainerIDs([
             PruneContainerInfo(id: "running", imageReference: "a", isStopped: false, isInfrastructure: false),
             PruneContainerInfo(id: "stopped1", imageReference: "b", isStopped: true, isInfrastructure: false),
-            PruneContainerInfo(id: "stopped2", imageReference: "c", isStopped: true, isInfrastructure: false),
+            PruneContainerInfo(id: "stopped2", imageReference: "c", isStopped: true, isInfrastructure: false)
         ])
         #expect(ids == ["stopped1", "stopped2"])
     }
@@ -69,7 +69,7 @@ struct PruneSelectionTests {
         let ids = LiveContainerService.deletableStoppedContainerIDs([
             PruneContainerInfo(id: "vm1", imageReference: "vmlinux:machine", isStopped: true, isInfrastructure: true),
             PruneContainerInfo(id: "builder1", imageReference: "buildkit:0.13", isStopped: true, isInfrastructure: true),
-            PruneContainerInfo(id: "job1", imageReference: "workload:1.0", isStopped: true, isInfrastructure: false),
+            PruneContainerInfo(id: "job1", imageReference: "workload:1.0", isStopped: true, isInfrastructure: false)
         ])
         #expect(ids == ["job1"])
         #expect(!ids.contains("vm1"))
@@ -114,7 +114,7 @@ struct PruneSelectionTests {
             [
                 PruneNetworkInfo(id: "app-net", isBuiltin: false),
                 PruneNetworkInfo(id: "old-net", isBuiltin: false),
-                PruneNetworkInfo(id: "default", isBuiltin: true),
+                PruneNetworkInfo(id: "default", isBuiltin: true)
             ],
             connectedNetworkIDs: ["app-net"]
         )
@@ -179,6 +179,16 @@ struct PruneSelectionTests {
         #expect(combined.failedCount == 1)
         #expect(combined.totalFreedBytes == 1_190_000_000)
         #expect(combined.deletedCount == 12)
+    }
+
+    @Test func inPlaceCombineMatchesBinaryCombine() {
+        let images = PruneResult(imagesFreedBytes: 1_100_000_000, deletedImageCount: 8, failedCount: 1)
+        let containers = PruneResult(containersFreedBytes: 90_000_000, deletedContainerCount: 4)
+
+        var accumulated = images
+        accumulated += containers
+
+        #expect(accumulated == images + containers)
     }
 
     // MARK: - summaryText
@@ -271,7 +281,7 @@ struct PruneSelectionTests {
     @Test func errorAlertMessageJoinsMultipleFailures() {
         let outcome = CleanUpAllResult(result: PruneResult(), failureMessages: [
             "Removing unused images failed: boom",
-            "Removing stopped containers failed: bang",
+            "Removing stopped containers failed: bang"
         ])
         #expect(outcome.errorAlertMessage == "Removing unused images failed: boom\nRemoving stopped containers failed: bang")
     }

--- a/BerthlyTests/RegistryTests.swift
+++ b/BerthlyTests/RegistryTests.swift
@@ -9,7 +9,7 @@ struct MapRegistriesTests {
     @Test func mapsEachKeychainEntryToASignedInRow() {
         let registries = LiveContainerService.mapRegistries(keychainEntries: [
             (hostname: "ghcr.io", username: "apple-bot"),
-            (hostname: "registry-1.docker.io", username: "berthly"),
+            (hostname: "registry-1.docker.io", username: "berthly")
         ])
         #expect(registries.count == 2)
         #expect(registries.first { $0.host == "ghcr.io" }?.username == "apple-bot")
@@ -29,7 +29,7 @@ struct MapRegistriesTests {
         let registries = LiveContainerService.mapRegistries(keychainEntries: [
             (hostname: "quay.io", username: "a"),
             (hostname: "ghcr.io", username: "b"),
-            (hostname: "docker.io", username: "c"),
+            (hostname: "docker.io", username: "c")
         ])
         #expect(registries.map(\.host) == ["docker.io", "ghcr.io", "quay.io"])
     }

--- a/BerthlyTests/SystemPageMappingTests.swift
+++ b/BerthlyTests/SystemPageMappingTests.swift
@@ -128,9 +128,12 @@ struct SystemConfigMappingTests {
 struct DaemonLogEventFormattingTests {
 
     @Test func joinsTimeLevelAndMessageWithTabs() {
+        // One NDJSON event is by definition one line; splitting it would change the input.
+        // swiftlint:disable line_length
         let ndjson = """
             {"timestamp":"2026-07-05 03:36:02.423830-0400","messageType":"Error","eventMessage":"xpc client handler connection error [error=Connection invalid]"}
             """
+        // swiftlint:enable line_length
         let formatted = LiveContainerService.formatDaemonLogEvent(ndjson)
 
         #expect(formatted == "03:36:02.423\tError\txpc client handler connection error [error=Connection invalid]")

--- a/BerthlyTests/VolumeMountResolverTests.swift
+++ b/BerthlyTests/VolumeMountResolverTests.swift
@@ -74,7 +74,7 @@ struct VolumeMountResolverTests {
                 ]),
                 makeContainer(name: "api", mounts: [
                     ContainerMount(source: "x", destination: "/srv/assets", volumeName: "shared", isReadOnly: true)
-                ]),
+                ])
             ]
         )
         #expect(resolved[0].mounts.map(\.containerName) == ["web", "api"])

--- a/BerthlyUITests/BerthlyUITestsLaunchTests.swift
+++ b/BerthlyUITests/BerthlyUITestsLaunchTests.swift
@@ -5,6 +5,8 @@ import XCTest
 
 final class BerthlyUITestsLaunchTests: XCTestCase {
 
+    // An override can't be `static`; the rule doesn't see the XCTestCase superclass.
+    // swiftlint:disable:next static_over_final_class
     override class var runsForEachTargetApplicationUIConfiguration: Bool {
         true
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,22 @@
+# Linting — run before every commit
+
+Before committing, run and get clean output from:
+
+- `swiftlint lint --strict` — config in `.swiftlint.yml`; the repo is at zero
+  findings, so `--strict` treats any new warning as a failure. CI runs the
+  same command with the same pinned SwiftLint version (`ci.yml`'s `swiftlint`
+  job), so a locally-clean run is authoritative.
+- `shellcheck scripts/*.sh design/icon/build.sh` — whenever a shell script
+  changed.
+
+Fix findings rather than suppressing them. A `swiftlint:disable` needs a
+one-line justification comment and the narrowest possible scope (`:next` /
+`:this`, or a `disable`/`enable` pair around a fixture block) — see
+`MockContainerService.swift` and `LiveContainerService.swift` for the
+existing precedents. Size-metric thresholds in `.swiftlint.yml` are a
+ratchet set just above the current largest offender: don't raise them to
+absorb growth.
+
 # Testing
 
 Changes to `Berthly/Core/` (services, models, argument/mapping logic) need a


### PR DESCRIPTION
## What

- **`.swiftlint.yml`** tuned for this codebase, not the defaults: bug-catching rules stay strict; `identifier_name` min length drops to 1 (short names in tight closure/loop scopes are idiomatic Swift); size metrics (`file_length`, `type_body_length`, …) are a **ratchet** set just above the current largest offender — existing code is green, meaningful growth trips the gate. `LiveContainerService`, the one deliberate monolith, carries a scoped file-level disable instead of stretching the thresholds to cover it.
- **Fixed all 766 findings** → repo is at **zero**:
  - `swiftlint --fix` cleaned ~340 mechanical ones (comma/colon spacing, trailing commas, `= nil` initializations, statement position).
  - Over-long signatures and UI copy wrapped by hand. UI strings use multiline literals with `\` continuation, which keeps the string **byte-identical** — `LocalizedStringKey`/markdown behavior unchanged.
  - `PruneResult` gains `+=` so prune accumulation uses the shorthand operator (unit test added per CLAUDE.md).
  - Fixture literals that must stay one physical line (mock seed data, an NDJSON log event, a Dockerfile `RUN`) get narrowly-scoped `swiftlint:disable` pragmas, each with a justification comment.
- **CI**: new `swiftlint` job runs `swiftlint lint --strict` in the official container pinned to **0.65.0** (same version as local) so findings can never differ by environment — the ShellCheck SC2317/SC2329 version-skew lesson applied preemptively.
- **CLAUDE.md**: linting section requiring a clean `swiftlint lint --strict` (and ShellCheck when scripts change) before every commit, plus rules for when a `disable` pragma is acceptable.

## Verification

- `swiftlint lint --strict` → exit 0, zero findings
- `xcodebuild test -only-testing:BerthlyTests` → **TEST SUCCEEDED**, 0 compiler warnings
- Both workflow YAMLs parse cleanly