### PR TITLE
feat: branded drag-to-install DMG layout

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,9 +22,11 @@ Releases. `scripts/release.sh` runs the whole pipeline.
    - preflight: `gh` authenticated, Developer ID identity present, Sparkle
      tools in DerivedData, tag `v<version>` not already released
    - `xcodebuild archive` + `-exportArchive` with the Developer ID method
-   - build `Berthly-<version>.dmg` (app + `/Applications` symlink), sign it,
-     notarize it (`notarytool --wait`, typically a few minutes), staple the
-     ticket to the DMG, verify with `spctl`
+   - build `Berthly-<version>.dmg` via `scripts/dmg.sh` — branded
+     drag-to-install window (background, icon positions, volume icon; assets
+     from `design/dmg/`; needs Finder Automation permission on first run) —
+     then sign it, notarize it (`notarytool --wait`, typically a few
+     minutes), staple the ticket to the DMG
    - `generate_appcast` — signs the DMG with the Sparkle EdDSA key from the
      login keychain and writes a single-entry `appcast.xml` whose download
      URL points at this release's assets

--- a/design/dmg/.gitignore
+++ b/design/dmg/.gitignore
@@ -1,0 +1,5 @@
+# Rendered artifacts — regenerate with ./build.sh
+*.png
+*.tiff
+*.icns
+build/

--- a/design/dmg/README.md
+++ b/design/dmg/README.md
@@ -1,0 +1,31 @@
+# Berthly DMG — drag-to-install window
+
+Assets for the branded install window `scripts/dmg.sh` assembles: a brand-blue
+background with a dotted "mooring line" arrow (the icon's rope motif) pointing
+from the app to the Applications symlink, plus the mounted-volume icon.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `background.svg` | Background source, authored at 2x (window is 660×420 pt, art is 1320×840). |
+| `render_bg.swift` | Non-square NSImage/CoreSVG rasterizer (width×height variant of `../icon/render_svg.swift`). |
+| `build.sh` | Renders `background.tiff` (1x + 2x HiDPI TIFF via `tiffutil -cathidpicheck`) and `Berthly-volume.icns` from the margined icon masters. |
+
+Rendered artifacts (`*.png`, `*.tiff`, `*.icns`, `build/`) are gitignored —
+`scripts/dmg.sh` runs `build.sh` on demand.
+
+## Design notes
+
+- **Mid-luminance blue, deliberately.** Finder draws icon labels black in
+  light mode and white in dark mode, and the background picture can't adapt.
+  The brand gradient (`#3F82EC → #1D4FA8`) keeps ≥3.3:1 contrast against
+  both, so the layout survives either appearance. Don't swap in a very light
+  or very dark background without rechecking that.
+- **No `<filter>`, no `rotate()`, absolute coordinates only** — CoreSVG drops
+  filters and mishandles rotate transforms (see rendering notes in
+  `../icon/README.md` and `build.sh`).
+- **Geometry contract with `scripts/dmg.sh`**: window content 660×420, icons
+  128 px centered at (170, 195) and (490, 195). The arrow and text in
+  `background.svg` are positioned for exactly that layout — change one, change
+  both.

--- a/design/dmg/background.svg
+++ b/design/dmg/background.svg
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Berthly DMG background — authored at 2x (window is 660x420 pt).
+     Rendered via qlmanage (canvas >= 512 rule); no <filter> used, but
+     qlmanage is also the renderer that honors <text>. -->
+<svg width="1320" height="840" viewBox="0 0 1320 840" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#3F82EC"/>
+      <stop offset="1" stop-color="#1D4FA8"/>
+    </linearGradient>
+  </defs>
+
+  <rect width="1320" height="840" fill="url(#bg)"/>
+
+  <!-- water: two soft wave bands along the bottom -->
+  <path d="M0 700 Q 165 670 330 700 T 660 700 T 990 700 T 1320 700 L 1320 840 L 0 840 Z"
+        fill="#FFFFFF" opacity="0.07"/>
+  <path d="M0 756 Q 165 730 330 756 T 660 756 T 990 756 T 1320 756 L 1320 840 L 0 840 Z"
+        fill="#FFFFFF" opacity="0.09"/>
+
+  <!-- instruction -->
+  <text x="660" y="142" text-anchor="middle"
+        font-family="Helvetica Neue, Helvetica, Arial, sans-serif"
+        font-size="34" font-weight="600" fill="#FFFFFF" opacity="0.95">
+    Drag Berthly to Applications
+  </text>
+
+  <!-- mooring line: a dotted rope that sags from the app, levels out, and
+       ends in a right-pointing arrowhead at Applications. The curve's last
+       control point shares the end's y so the tangent is horizontal — a
+       tilted arrowhead reads as pointing down, not right. -->
+  <path d="M 486 372 C 570 452, 690 382, 792 382"
+        fill="none" stroke="#FFFFFF" opacity="0.9"
+        stroke-width="10" stroke-linecap="round"
+        stroke-dasharray="0.1 34"/>
+  <path d="M 846 380 L 810 363 L 810 397 Z" fill="#FFFFFF" opacity="0.9"/>
+</svg>

--- a/design/dmg/build.sh
+++ b/design/dmg/build.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Render the DMG assets consumed by scripts/dmg.sh:
+#   background.tiff     — drag-to-install window background (1x + 2x HiDPI TIFF)
+#   Berthly-volume.icns — mounted-volume icon
+#
+# Background renders through the NSImage/CoreSVG helper, not qlmanage:
+# qlmanage square-pads a non-square canvas (this art is 1320x840), and
+# CoreSVG both honors <text> and needs no <filter> here. Note CoreSVG
+# mishandles rotate() transforms — background.svg keeps all geometry in
+# absolute coordinates.
+#
+# The volume icon uses the margined Big Sur-style masters (see
+# ../icon/README.md): Finder still renders volume icons the pre-Tahoe way,
+# so full-bleed art would show unmasked square corners. The masters render
+# here from their SVGs (render_volume_icon.swift), NOT from ../icon's
+# qlmanage PNGs — qlmanage composites onto opaque white, which puts a white
+# square behind the squircle.
+set -e
+cd "$(dirname "$0")"
+ICON="../icon"
+
+# ── background: 1x + 2x combined into one HiDPI TIFF ────────────────────────
+swift render_bg.swift background.svg background@2x.png 1320 840
+sips -z 420 660 background@2x.png --out background.png >/dev/null
+tiffutil -cathidpicheck background.png background@2x.png -out background.tiff
+
+# ── volume icon ─────────────────────────────────────────────────────────────
+MASTER="build/volume-master-1024.png"
+SMALL="build/volume-small-512.png"
+IS="build/BerthlyVolume.iconset"
+mkdir -p "$IS"
+swift render_volume_icon.swift "$ICON/berthly-master-1024.svg" "$MASTER" 1024
+swift render_volume_icon.swift "$ICON/berthly-small-512.svg"   "$SMALL"  512
+cp "$MASTER" "$IS/icon_512x512@2x.png"
+sips -z 512 512 "$MASTER" --out "$IS/icon_512x512.png"  >/dev/null
+cp "$IS/icon_512x512.png" "$IS/icon_256x256@2x.png"
+sips -z 256 256 "$MASTER" --out "$IS/icon_256x256.png"  >/dev/null
+cp "$IS/icon_256x256.png" "$IS/icon_128x128@2x.png"
+sips -z 128 128 "$MASTER" --out "$IS/icon_128x128.png"  >/dev/null
+sips -z 64  64  "$SMALL"  --out "$IS/icon_32x32@2x.png" >/dev/null
+sips -z 32  32  "$SMALL"  --out "$IS/icon_32x32.png"    >/dev/null
+cp "$IS/icon_32x32.png" "$IS/icon_16x16@2x.png"
+sips -z 16  16  "$SMALL"  --out "$IS/icon_16x16.png"    >/dev/null
+iconutil -c icns "$IS" -o Berthly-volume.icns
+
+echo "DMG assets rebuilt: background.tiff, Berthly-volume.icns"

--- a/design/dmg/render_bg.swift
+++ b/design/dmg/render_bg.swift
@@ -1,0 +1,27 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import AppKit
+
+// usage: swift render_bg.swift <in.svg> <out.png> <width> <height>
+// Non-square variant of ../icon/render_svg.swift for the DMG background.
+let args = CommandLine.arguments
+guard args.count == 5, let width = Int(args[3]), let height = Int(args[4]) else {
+    FileHandle.standardError.write("usage: render_bg <in.svg> <out.png> <width> <height>\n".data(using: .utf8)!)
+    exit(1)
+}
+guard let img = NSImage(contentsOfFile: args[1]) else {
+    FileHandle.standardError.write("failed to load \(args[1])\n".data(using: .utf8)!)
+    exit(1)
+}
+let rep = NSBitmapImageRep(
+    bitmapDataPlanes: nil, pixelsWide: width, pixelsHigh: height,
+    bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+    colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0
+)!
+rep.size = NSSize(width: width, height: height)
+NSGraphicsContext.saveGraphicsState()
+NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+img.draw(in: NSRect(x: 0, y: 0, width: width, height: height), from: .zero, operation: .copy, fraction: 1.0)
+NSGraphicsContext.restoreGraphicsState()
+try! rep.representation(using: .png, properties: [:])!.write(to: URL(fileURLWithPath: args[2]))

--- a/design/dmg/render_volume_icon.swift
+++ b/design/dmg/render_volume_icon.swift
@@ -1,0 +1,40 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import AppKit
+
+// usage: swift render_volume_icon.swift <in.svg> <out.png> <size>
+//
+// Renders a margined icon master with a transparent background. qlmanage
+// honors the SVG's feDropShadow but composites onto opaque white — a white
+// square around the squircle everywhere the volume icon shows. CoreSVG keeps
+// transparency but silently drops <filter>, so this draws through CoreSVG and
+// re-applies the master's shadow (feDropShadow dx=0 dy=10 stdDeviation=10
+// flood-opacity=0.3, authored at 1024) in CoreGraphics, scaled to the
+// requested size.
+let args = CommandLine.arguments
+guard args.count == 4, let size = Int(args[3]) else {
+    FileHandle.standardError.write("usage: render_volume_icon <in.svg> <out.png> <size>\n".data(using: .utf8)!)
+    exit(1)
+}
+guard let img = NSImage(contentsOfFile: args[1]) else {
+    FileHandle.standardError.write("failed to load \(args[1])\n".data(using: .utf8)!)
+    exit(1)
+}
+let rep = NSBitmapImageRep(
+    bitmapDataPlanes: nil, pixelsWide: size, pixelsHigh: size,
+    bitsPerSample: 8, samplesPerPixel: 4, hasAlpha: true, isPlanar: false,
+    colorSpaceName: .deviceRGB, bytesPerRow: 0, bitsPerPixel: 0
+)!
+rep.size = NSSize(width: size, height: size)
+NSGraphicsContext.saveGraphicsState()
+NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: rep)
+let scale = CGFloat(size) / 1024
+let shadow = NSShadow()
+shadow.shadowOffset = NSSize(width: 0, height: -10 * scale)  // SVG dy=10 is downward
+shadow.shadowBlurRadius = 20 * scale                          // ~ feDropShadow stdDeviation 10
+shadow.shadowColor = NSColor.black.withAlphaComponent(0.3)
+shadow.set()
+img.draw(in: NSRect(x: 0, y: 0, width: size, height: size), from: .zero, operation: .sourceOver, fraction: 1.0)
+NSGraphicsContext.restoreGraphicsState()
+try! rep.representation(using: .png, properties: [:])!.write(to: URL(fileURLWithPath: args[2]))

--- a/design/icon/README.md
+++ b/design/icon/README.md
@@ -51,11 +51,15 @@ the catalog PNGs.
 No `rsvg`/`inkscape`/`imagemagick` on the machine — macOS's two built-in SVG
 rasterizers have complementary bugs:
 
-- **`qlmanage -t`** honors SVG `<filter>` (the `feDropShadow` on the app icon)
-  but mis-lays-out canvases below ~512px.
-- **NSImage/CoreSVG** (`render_svg.swift`) scales correctly at any size but
-  silently ignores `<filter>`.
+- **`qlmanage -t`** honors SVG `<filter>` (the `feDropShadow` on the margined
+  masters) but mis-lays-out canvases below ~512px, square-pads non-square
+  canvases, and composites onto **opaque white** — no transparency survives.
+- **NSImage/CoreSVG** (`render_svg.swift`) scales correctly at any size and
+  keeps transparency, but silently ignores `<filter>` and mishandles
+  `rotate()` transforms.
 
-So the shadowed dmg masters render through `qlmanage` at ≥512 and downsample
-with `sips`; all filter-free art (app icon, menu bar, favicon, touch) renders
-through the Swift helper. `build.sh` already routes each file correctly.
+All art rendered by `build.sh` is filter-free and goes through the Swift
+helper. The shadowed dmg masters are rendered by `../dmg/build.sh` instead:
+CoreSVG for the artwork, with the master's `feDropShadow` re-applied in
+CoreGraphics (`../dmg/render_volume_icon.swift`) — the qlmanage route would
+bake a white square behind the squircle.

--- a/design/icon/build.sh
+++ b/design/icon/build.sh
@@ -4,10 +4,11 @@
 #
 # Rendering note: with no rsvg/inkscape/imagemagick on the machine, macOS gives
 # two built-in SVG rasterizers with complementary bugs —
-#   - qlmanage honors SVG <filter> (feDropShadow) but mis-lays-out canvases <512px
-#   - NSImage/CoreSVG (render_svg.swift) scales at any size but drops <filter>
-# So: shadowed masters go through qlmanage at >=512 then downsample; filter-free
-# small art (menu bar, favicon) goes through the Swift renderer.
+#   - qlmanage honors SVG <filter> (feDropShadow) but mis-lays-out canvases
+#     <512px, square-pads non-square canvases, and composites onto opaque white
+#   - NSImage/CoreSVG (render_svg.swift) scales at any size, keeps
+#     transparency, but drops <filter> (and mishandles rotate() transforms)
+# All art rendered here is filter-free full-bleed -> the Swift renderer.
 set -e
 cd "$(dirname "$0")"
 DIR="$(pwd)"
@@ -28,10 +29,12 @@ render berthly-dock-1024.svg   berthly-dock-1024.png   1024
 render berthly-favicon-512.svg berthly-favicon-512.png 512
 render berthly-touch-512.svg   berthly-touch-512.png   512
 render berthly-menubar-36.svg  berthly-menubar-144.png 144
-#    margined Big Sur-style masters (dmg volume icon only) -> qlmanage
-#    (>=512, honors the baked feDropShadow)
-qlmanage -t -s 1024 -o . berthly-master-1024.svg >/dev/null 2>&1 && mv -f berthly-master-1024.svg.png berthly-master-1024.png
-qlmanage -t -s 512  -o . berthly-small-512.svg   >/dev/null 2>&1 && mv -f berthly-small-512.svg.png   berthly-small-512.png
+#    The margined Big Sur-style masters (berthly-master-1024.svg,
+#    berthly-small-512.svg) are NOT rasterized here: their only consumer is
+#    the DMG volume icon, and ../dmg/build.sh renders them itself (CoreSVG +
+#    CoreGraphics shadow). qlmanage — the only local renderer that honors
+#    their feDropShadow — composites onto opaque white, which puts a white
+#    square behind the squircle.
 
 # 3. app icon set + .icns (staged in build/)
 IS="$DIR/build/Berthly.iconset"

--- a/scripts/dmg.sh
+++ b/scripts/dmg.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# Assemble the branded drag-to-install DMG.
+#
+#   usage: scripts/dmg.sh <Berthly.app> <version> <output.dmg>
+#
+# Window: 660x420 content, no toolbar/statusbar, 128px icons —
+# Berthly.app at (170,195), Applications symlink at (490,195), brand-blue
+# background with a dotted mooring-line arrow between them, custom volume
+# icon. Assets render from design/dmg (geometry contract documented there).
+#
+# Finder persists the layout in the volume's .DS_Store, which can only be
+# written on a mounted read-write image — hence: staging folder → UDRW image
+# → attach → Finder AppleScript → detach → convert to compressed UDZO.
+# The AppleScript step needs Automation permission for Finder (one-time TCC
+# prompt on first run from a given terminal).
+set -euo pipefail
+
+if [[ $# -ne 3 ]]; then
+  echo "usage: $0 <Berthly.app> <version> <output.dmg>" >&2
+  exit 1
+fi
+APP="$1"
+VERSION="$2"
+OUT="$3"
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+ASSETS="$REPO/design/dmg"
+VOLNAME="Berthly $VERSION"
+
+"$ASSETS/build.sh" >/dev/null
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+STAGING="$WORK/staging"
+RW_DMG="$WORK/rw.dmg"
+
+mkdir -p "$STAGING/.background"
+ditto "$APP" "$STAGING/Berthly.app"
+ln -s /Applications "$STAGING/Applications"
+cp "$ASSETS/background.tiff" "$STAGING/.background/background.tiff"
+
+hdiutil create -volname "$VOLNAME" -srcfolder "$STAGING" -ov -format UDRW "$RW_DMG"
+
+# A stale mount from a crashed run would make this one mount at
+# "<volname> 1", desyncing the AppleScript's disk name — clear it first.
+if [[ -d "/Volumes/$VOLNAME" ]]; then
+  hdiutil detach "/Volumes/$VOLNAME" -force
+fi
+ATTACH_OUT="$(hdiutil attach "$RW_DMG" -readwrite -noverify -noautoopen)"
+MOUNT="$(grep -o '/Volumes/.*' <<<"$ATTACH_OUT" | head -1)"
+
+osascript <<EOF
+tell application "Finder"
+  tell disk "$(basename "$MOUNT")"
+    open
+    delay 1
+    set current view of container window to icon view
+    set toolbar visible of container window to false
+    set statusbar visible of container window to false
+    -- bounds include the ~28pt title bar; content area is 660x420
+    set the bounds of container window to {200, 120, 860, 568}
+    set opts to the icon view options of container window
+    set arrangement of opts to not arranged
+    set icon size of opts to 128
+    set text size of opts to 13
+    set background picture of opts to file ".background:background.tiff"
+    set position of item "Berthly.app" of container window to {170, 195}
+    set position of item "Applications" of container window to {490, 195}
+    update without registering applications
+    delay 1
+    -- again: Finder drops a bounds set that lands mid-open-animation
+    set the bounds of container window to {200, 120, 860, 568}
+    delay 1
+    close
+  end tell
+end tell
+EOF
+
+# Volume icon: .VolumeIcon.icns on the mounted volume plus the
+# kHasCustomIcon Finder flag on its root (FinderInfo byte 8 = 0x04; SetFile
+# is deprecated, the xattr is not). Both must happen *after* the layout
+# pass — hdiutil create -srcfolder drops a staged .VolumeIcon.icns, and the
+# Finder AppleScript above deletes the file and rewrites the root's
+# FinderInfo when it saves the window state (verified empirically).
+cp "$ASSETS/Berthly-volume.icns" "$MOUNT/.VolumeIcon.icns"
+xattr -wx com.apple.FinderInfo \
+  "0000000000000000040000000000000000000000000000000000000000000000" "$MOUNT"
+
+sync
+hdiutil detach "$MOUNT"
+hdiutil convert "$RW_DMG" -format UDZO -imagekey zlib-level=9 -ov -o "$OUT"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -145,15 +145,11 @@ xcodebuild -exportArchive \
 APP="$DIST/export/Berthly.app"
 
 # ── DMG, notarize, staple ─────────────────────────────────────────────────
-# Standard drag-to-install layout: the app plus an /Applications symlink.
+# Branded drag-to-install layout (background, icon positions, volume icon):
+# scripts/dmg.sh, with assets from design/dmg.
 DMG_NAME="Berthly-$VERSION.dmg"
 DMG_PATH="$DIST/$DMG_NAME"
-STAGING="$DIST/dmg-staging"
-mkdir -p "$STAGING"
-ditto "$APP" "$STAGING/Berthly.app"
-ln -s /Applications "$STAGING/Applications"
-hdiutil create -volname "Berthly $VERSION" -srcfolder "$STAGING" -ov -format UDZO "$DMG_PATH"
-rm -rf "$STAGING"
+scripts/dmg.sh "$APP" "$VERSION" "$DMG_PATH"
 
 codesign --force --sign "$DEVID_IDENTITY" "$DMG_PATH"
 echo "──> Notarizing (waits for Apple; typically a few minutes)…"


### PR DESCRIPTION
## Summary
- Replace the bare `hdiutil -srcfolder` DMG (default Finder window, unplaced icons) with a designed install window: brand-blue gradient background, dotted mooring-line arrow motif, fixed 660x420 window, 128px icons at set positions, and a custom (transparent-background) volume icon.
- New `scripts/dmg.sh` assembles the DMG via staging → UDRW → Finder AppleScript layout → UDZO; `scripts/release.sh` now delegates to it instead of the old bare `hdiutil create` call.
- New `design/dmg/` holds the background/volume-icon sources and a `build.sh` that renders them (CoreSVG with the shadow re-baked via `NSShadow`, since qlmanage composites onto opaque white and would leave a white square behind the icon squircle).

## Test plan
- [x] `shellcheck` clean on `scripts/dmg.sh`, `design/dmg/build.sh`, `design/icon/build.sh`
- [x] Built a test DMG (`scripts/dmg.sh dist/export/Berthly.app <version> dist/Berthly-test.dmg`) and visually verified the window: background, arrow, icon positions, title
- [x] Queried the live mounted volume's icon via `NSWorkspace` and confirmed fully transparent corners (no white border)
- [x] `design/icon/build.sh` still runs green after removing its now-unused qlmanage master rendering step