### PR TITLE
test: add Copy Files, log streaming, and restart/kill E2E journeys

### DIFF
--- a/Berthly/Views/LogStreamView.swift
+++ b/Berthly/Views/LogStreamView.swift
@@ -79,6 +79,7 @@ struct LogStreamView: View {
                 .help(streamEnded ? "The log stream ended unexpectedly — the daemon connection may have been lost." : "")
 
                 TextField("Filter logs", text: $filterText)
+                    .accessibilityIdentifier("logFilterField")
                     .textFieldStyle(.roundedBorder)
                     .frame(maxWidth: 300)
 

--- a/BerthlyE2ETests/BerthlyE2ETests.swift
+++ b/BerthlyE2ETests/BerthlyE2ETests.swift
@@ -318,7 +318,10 @@ final class RunContainerJourneyTests: BerthlyE2ETestCase {
             XCTFail("could not read /proc/uptime before restart"); return
         }
         row.rightClick()
-        let restartItem = app.menuItems["Restart"]
+        // Scoped to the window: a bare app.menuItems["Restart"] also matches the Apple menu's
+        // system-wide Restart item (confirmed here — "multiple matching elements" with the menu
+        // open), unlike "Delete…"/"Force Kill" elsewhere in this file, which have no such collision.
+        let restartItem = app.windows.menuItems["Restart"]
         XCTAssertTrue(restartItem.waitForExistence(timeout: 5))
         restartItem.click()
 

--- a/BerthlyE2ETests/BerthlyE2ETests.swift
+++ b/BerthlyE2ETests/BerthlyE2ETests.swift
@@ -264,7 +264,11 @@ final class RunContainerJourneyTests: BerthlyE2ETestCase {
 
     /// Tier-1 lifecycle journey (PLAN/E2E-TEST.md §1.3): stop/start/delete buttons' real
     /// effect, verified through the CLI after each transition. The container is created via
-    /// CLI — this journey tests the lifecycle actions, not the Run sheet.
+    /// CLI — this journey tests the lifecycle actions, not the Run sheet. Extended
+    /// 2026-07-18 (§6.3, W12) with restart/kill — the two remaining lifecycle verbs that had
+    /// no daemon-level proof, reached via the row's context menu (same label-query pattern as
+    /// Delete, since `.accessibilityIdentifier` on a contextMenu Button doesn't survive the
+    /// SwiftUI→NSMenu bridge).
     @MainActor
     func testContainerLifecycleFromUI() throws {
         try ContainerCLI.ensureImage(Self.fixtureImage)
@@ -301,9 +305,46 @@ final class RunContainerJourneyTests: BerthlyE2ETestCase {
         let running = try ContainerCLI.run(["ls"], timeout: 30)
         XCTAssertTrue(running.output.contains(containerName), "daemon should report it running")
 
-        // Stop once more — delete is only offered for stopped containers.
-        stopButton.click()
-        XCTAssertTrue(startButton.waitForExistence(timeout: 60))
+        // Restart: proves the button is a real reboot, not a no-op — the daemon runs each
+        // container in its own lightweight VM, so a restart resets the VM's kernel clock even
+        // though the UI's Stop/Start button never flips (both states read "running" throughout,
+        // unlike Stop→Start above). /proc/uptime is the oracle that distinguishes them.
+        func uptimeSeconds() -> Double? {
+            guard let result = try? ContainerCLI.exec(containerName, ["cat", "/proc/uptime"]),
+                  result.status == 0 else { return nil }
+            return result.output.split(separator: " ").first.flatMap { Double($0) }
+        }
+        guard let uptimeBeforeRestart = uptimeSeconds() else {
+            XCTFail("could not read /proc/uptime before restart"); return
+        }
+        row.rightClick()
+        let restartItem = app.menuItems["Restart"]
+        XCTAssertTrue(restartItem.waitForExistence(timeout: 5))
+        restartItem.click()
+
+        var uptimeAfterRestart: Double?
+        let restartDeadline = Date(timeIntervalSinceNow: 60)
+        repeat {
+            uptimeAfterRestart = uptimeSeconds()
+            if let u = uptimeAfterRestart, u < uptimeBeforeRestart { break }
+            Thread.sleep(forTimeInterval: 1)
+        } while Date() < restartDeadline
+        XCTAssertNotNil(uptimeAfterRestart, "container should be reachable again after restart")
+        XCTAssertLessThan(uptimeAfterRestart ?? .infinity, uptimeBeforeRestart,
+                          "restart should reboot the container's VM, resetting /proc/uptime")
+        let stillRunning = try ContainerCLI.run(["ls"], timeout: 30)
+        XCTAssertTrue(stillRunning.output.contains(containerName), "restarted container should be running")
+
+        // Force Kill: the unwedge path when a graceful Stop is ignored (SIGKILL, not SIGTERM) —
+        // the daemon should report it no longer running. This also leaves the container stopped,
+        // which is what Delete below requires, so no extra Stop click is needed.
+        row.rightClick()
+        let killItem = app.menuItems["Force Kill"]
+        XCTAssertTrue(killItem.waitForExistence(timeout: 5))
+        killItem.click()
+        XCTAssertTrue(startButton.waitForExistence(timeout: 60), "UI should show Start after a force kill")
+        let killed = try ContainerCLI.run(["ls"], timeout: 30)
+        XCTAssertFalse(killed.output.contains(containerName), "daemon should report it stopped after a force kill")
 
         // Delete via the row's context menu + confirmation alert. Query the menu item by
         // label: .accessibilityIdentifier on a contextMenu Button does NOT survive the

--- a/BerthlyE2ETests/ContainerDetailJourneyTests.swift
+++ b/BerthlyE2ETests/ContainerDetailJourneyTests.swift
@@ -1,0 +1,157 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+//
+//  ContainerDetailJourneyTests.swift
+//  BerthlyE2ETests
+//
+//  Container detail-view journeys added in the 2026-07-18 gap review (PLAN/E2E-TEST.md §6):
+//  Copy Files and Log streaming. Split out of BerthlyE2ETests.swift once that file hit the
+//  file_length lint ceiling — see BerthlyE2ETests.swift for the suite's style contract and
+//  shared helpers (BerthlyE2ETestCase, ContainerCLI, XCUIApplication.berthlyE2E()).
+//
+
+import XCTest
+
+/// Copy Files journey (PLAN/E2E-TEST.md §6.1, added 2026-07-18): drives both copy directions
+/// through the sheet — host→container and container→host — verified via the CLI/filesystem
+/// oracle on each side. No product change was needed: `CopyFilesSheet` already exposes
+/// `copyHostPathField`/`copyContainerPathField`/`copyFilesSubmitButton`, and
+/// `ContainerDetailView` already exposes `copyFilesButton`; the direction segmented Picker's
+/// segments are queried by label (`radioButtons["Out of Container"]`), same as every other
+/// segmented control in this suite (e.g. the Terminal/Logs tab picker).
+final class CopyFilesJourneyTests: BerthlyE2ETestCase {
+    private static let fixtureImage = "alpine:latest"
+
+    @MainActor
+    func testCopyFilesBothDirectionsViaSheet() throws {
+        try ContainerCLI.ensureImage(Self.fixtureImage)
+        let create = try ContainerCLI.run(
+            ["run", "-d", "--name", containerName, Self.fixtureImage, "sleep", "300"],
+            timeout: 120
+        )
+        XCTAssertEqual(create.status, 0, "container run failed:\n\(create.output)")
+
+        // Host fixture for the into-container direction; also the destination folder for the
+        // out-of-container direction (both sides of the round trip share one temp dir).
+        let hostDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(Self.resourcePrefix)-cpctx-\(UUID().uuidString.prefix(8))")
+        try FileManager.default.createDirectory(at: hostDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: hostDir) }
+        let inFile = hostDir.appendingPathComponent("in-marker.txt")
+        try "into-container-marker".write(to: inFile, atomically: true, encoding: .utf8)
+
+        let app = XCUIApplication.berthlyE2E()
+        app.launch()
+
+        let row = app.staticTexts["computeRow-\(containerName)"]
+        XCTAssertTrue(row.waitForExistence(timeout: 30))
+        row.click()
+
+        // ── 1. Into container: a host file → a container path. ──
+        let copyButton = app.buttons["copyFilesButton"]
+        XCTAssertTrue(copyButton.waitForExistence(timeout: 10))
+        copyButton.click()
+
+        typeField(app, inFile.path, into: "copyHostPathField")
+        typeField(app, "/tmp/berthly-e2e-in", into: "copyContainerPathField")
+        app.buttons["copyFilesSubmitButton"].click()
+
+        let inDone = app.buttons["Done"]
+        XCTAssertTrue(inDone.waitForExistence(timeout: 30), "copy into container should succeed")
+        inDone.click()
+
+        let inCheck = try ContainerCLI.exec(containerName, ["cat", "/tmp/berthly-e2e-in"])
+        XCTAssertTrue(inCheck.output.contains("into-container-marker"),
+                      "file copied into the container should be readable:\n\(inCheck.output)")
+
+        // ── 2. Out of container: a container-written file → a host folder. ──
+        let outMarker = try ContainerCLI.exec(
+            containerName, ["sh", "-c", "echo out-of-container-marker > /tmp/berthly-e2e-out"])
+        XCTAssertEqual(outMarker.status, 0,
+                       "writing the out-marker inside the container failed:\n\(outMarker.output)")
+
+        copyButton.click()
+        let containerPathField = app.windows.textFields["copyContainerPathField"]
+        XCTAssertTrue(containerPathField.waitForExistence(timeout: 5), "sheet should reopen")
+        // Switching direction clears both fields (CopyFilesSheet.onChange(of: direction)), so the
+        // direction must be selected before typing.
+        app.radioButtons["Out of Container"].click()
+
+        typeField(app, "/tmp/berthly-e2e-out", into: "copyContainerPathField")
+        typeField(app, hostDir.path, into: "copyHostPathField")
+        app.buttons["copyFilesSubmitButton"].click()
+
+        let outDone = app.buttons["Done"]
+        XCTAssertTrue(outDone.waitForExistence(timeout: 30), "copy out of container should succeed")
+        outDone.click()
+
+        // Oracle: resolvedHostDestination appends the container source's last path component to
+        // the chosen folder — the file lands at hostDir/berthly-e2e-out, not hostDir itself.
+        let landedPath = hostDir.appendingPathComponent("berthly-e2e-out")
+        let landed = try String(contentsOf: landedPath, encoding: .utf8)
+        XCTAssertTrue(landed.contains("out-of-container-marker"),
+                      "the copied-out file should exist on the host with the container's bytes: \(landed)")
+    }
+}
+
+/// Log streaming journey (PLAN/E2E-TEST.md §6.2, added 2026-07-18): the Logs tab had zero E2E
+/// coverage despite being the one path with a known real-daemon-only regression class — the XPC
+/// `set(FileHandle)` fd-reuse bug that once surfaced as a spurious "Stream ended" banner (see the
+/// `feedback_container_native_api` project memory: a `Pipe` double-close clobbered a reused log
+/// fd). Boots a container emitting a unique marker on a loop, opens the Logs tab, and proves both
+/// that live stdout actually renders and that the filter field narrows/restores against real
+/// streamed data — the mock suite already covers filter *logic*, but only against static lines.
+/// Needed one product change: `logFilterField` (nothing else in `LogStreamView` had an
+/// identifier besides the source picker).
+final class LogStreamJourneyTests: BerthlyE2ETestCase {
+    private static let fixtureImage = "alpine:latest"
+
+    @MainActor
+    func testContainerLogsStreamIntoLogsTab() throws {
+        try ContainerCLI.ensureImage(Self.fixtureImage)
+        let marker = "berthly-e2e-log-\(UUID().uuidString.prefix(8).lowercased())"
+        let create = try ContainerCLI.run(
+            ["run", "-d", "--name", containerName, Self.fixtureImage,
+             "sh", "-c", "while true; do echo \(marker); sleep 1; done"],
+            timeout: 120
+        )
+        XCTAssertEqual(create.status, 0, "container run failed:\n\(create.output)")
+
+        let app = XCUIApplication.berthlyE2E()
+        app.launch()
+
+        let row = app.staticTexts["computeRow-\(containerName)"]
+        XCTAssertTrue(row.waitForExistence(timeout: 30))
+        row.click()
+
+        // Segmented tab picker: "Logs" surfaces as a radioButton by label, same as the
+        // "Terminal" tab elsewhere in this suite (runInTerminal).
+        let logsTab = app.radioButtons["Logs"]
+        XCTAssertTrue(logsTab.waitForExistence(timeout: 10))
+        logsTab.click()
+
+        func markerText() -> XCUIElement {
+            app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", marker)).firstMatch
+        }
+
+        // ── 1. Live stdout actually renders — the stream-attach + parse + render path. ──
+        XCTAssertTrue(markerText().waitForExistence(timeout: 30),
+                      "the container's stdout marker should appear in the Logs tab")
+
+        // ── 2. Filter narrows against the real streamed lines, not a static fixture. ──
+        let filterField = app.windows.textFields["logFilterField"]
+        XCTAssertTrue(filterField.waitForExistence(timeout: 5))
+        filterField.click()
+        filterField.typeText("berthly-e2e-no-such-marker")
+        XCTAssertTrue(markerText().waitForNonExistence(timeout: 10),
+                      "an unmatched filter should hide the marker lines")
+
+        // ── 3. Clearing the filter restores them. ──
+        filterField.click()
+        app.typeKey("a", modifierFlags: .command)
+        app.typeKey(.delete, modifierFlags: [])
+        XCTAssertTrue(markerText().waitForExistence(timeout: 10),
+                      "clearing the filter should restore the marker lines")
+    }
+}

--- a/BerthlyE2ETests/ContainerDetailJourneyTests.swift
+++ b/BerthlyE2ETests/ContainerDetailJourneyTests.swift
@@ -131,8 +131,15 @@ final class LogStreamJourneyTests: BerthlyE2ETestCase {
         XCTAssertTrue(logsTab.waitForExistence(timeout: 10))
         logsTab.click()
 
+        // `.textSelection(.enabled)` on the log list (LogStreamView) surfaces each line's text
+        // as the accessibility *value*, not the label — confirmed via an xcresult hierarchy dump
+        // after a first attempt with `label CONTAINS` alone found nothing despite the marker text
+        // being present in the snapshot. Same label-OR-value pattern as the sidebar-observation
+        // and System Properties checks elsewhere in this suite.
         func markerText() -> XCUIElement {
-            app.staticTexts.matching(NSPredicate(format: "label CONTAINS %@", marker)).firstMatch
+            app.staticTexts
+                .matching(NSPredicate(format: "label CONTAINS %@ OR value CONTAINS %@", marker, marker))
+                .firstMatch
         }
 
         // ── 1. Live stdout actually renders — the stream-attach + parse + render path. ──


### PR DESCRIPTION
## Summary
- Adds three real-daemon E2E journeys identified in a gap-review pass over `ContainerServiceBase`'s daemon surface: `CopyFilesJourneyTests` (both copy directions through the sheet), `LogStreamJourneyTests` (live stdout rendering + filter narrowing in the Logs tab, guarding the XPC fd-reuse "Stream ended" regression class), and restart/kill coverage folded into the existing `testContainerLifecycleFromUI`.
- One product change: `logFilterField` accessibility identifier on `LogStreamView`.
- Split the two new classes into `ContainerDetailJourneyTests.swift` since `BerthlyE2ETests.swift` was at the `file_length` SwiftLint ceiling (ratchet, not raised per CLAUDE.md).
- Two real bugs found only by running against a live daemon: a "Restart" menu-item query collided with the macOS Apple-menu item of the same name (now scoped to the window), and log lines expose their text as the accessibility *value*, not label, due to `.textSelection(.enabled)` (now queried with the same label-OR-value pattern used elsewhere in the suite).

## Test plan
- [x] `swiftlint lint --strict` — 0 violations
- [x] `xcodebuild build-for-testing` — compiles clean, no warnings
- [x] Full E2E suite via `scripts/e2e.sh` (all 16 journeys) — 0 failures, ~11.2 min warm
- [x] Verified zero `berthly-e2e-*` leftovers (containers/volumes/networks/machines/images) after the full run