### PR TITLE
fix: prevent crash when deleting a network row via context menu

### DIFF
--- a/Berthly/Views/NetworksListView.swift
+++ b/Berthly/Views/NetworksListView.swift
@@ -199,7 +199,24 @@ private struct NetworkRow: View {
 
                 Spacer()
 
-                if isHovered {
+                // Both branches stay mounted (opacity swap, not an if/else view-identity swap) —
+                // an if/else here reproducibly crashed the app when the row was removed via
+                // context-menu delete: AppKit throws "layout engine changed during its own layout
+                // pass" from the List's row-height recompute racing the row's removal animation.
+                // Confirmed by bisection (2026-07-19): the crash disappeared once this became
+                // static content, and reappeared with the if/else restored. Root cause of *why*
+                // the view-identity churn triggers it isn't fully understood (VolumesListView's
+                // row has the identical if/else pattern and doesn't crash), but this shape avoids
+                // it entirely while keeping identical visual behavior.
+                ZStack(alignment: .trailing) {
+                    VStack(alignment: .trailing, spacing: 3) {
+                        RowChip(text: network.driver.rawValue,
+                                color: network.driver == .nat ? .berthlyAccent : .statusPaused)
+                        endpointStatus(endpoints)
+                    }
+                    .opacity(isHovered ? 0 : 1)
+                    .allowsHitTesting(!isHovered)
+
                     Button(role: .destructive) { showDeleteConfirm = true } label: {
                         Image(systemName: "trash")
                             .foregroundStyle(network.isDefault ? Color.secondary : Color.red)
@@ -207,12 +224,8 @@ private struct NetworkRow: View {
                     .buttonStyle(.hoverIcon)
                     .disabled(network.isDefault)
                     .help(network.isDefault ? "The default network can't be deleted" : "Delete Network")
-                } else {
-                    VStack(alignment: .trailing, spacing: 3) {
-                        RowChip(text: network.driver.rawValue,
-                                color: network.driver == .nat ? .berthlyAccent : .statusPaused)
-                        endpointStatus(endpoints)
-                    }
+                    .opacity(isHovered ? 1 : 0)
+                    .allowsHitTesting(isHovered)
                 }
             }
             .padding(.vertical, 2)

--- a/BerthlyUITests/ContextMenuTests.swift
+++ b/BerthlyUITests/ContextMenuTests.swift
@@ -309,31 +309,34 @@ final class ContextMenuTests: XCTestCase {
         app.typeKey(.escape, modifierFlags: [])
     }
 
-    /// KNOWN CRASH — filed as a real product bug, not a test-writing mistake. Deleting a
-    /// non-default network row through its context menu (confirmed on both "data-net" and
-    /// "app-net", not row-specific) deterministically crashes the app: 3/3 isolated runs threw
-    /// the same AppKit exception, `-[NSWindow(NSDisplayCycle) _postWindowNeedsUpdateConstraints]`
-    /// called re-entrantly from `OutlineListCoordinator.listTableCellView(_:didUpdateIdealHeight:)`
-    /// during the row-removal layout pass ("attempted to change the layout engine while it is
-    /// executing"). A minimal right-click-only repro (open the menu, no delete) is clean 3/3, so
-    /// the trigger is specifically the row being removed from the List mid-transaction, not the
-    /// menu itself. Confirmed NOT mock-specific: reproduces identically (same exception codes)
-    /// against a real daemon in `BerthlyE2ETests`, deleting a freshly created network with zero
-    /// attached containers — rules out both mock-timing and endpoint count as factors. Also ruled
-    /// out: wrapping the List in a `Section` (matching Volumes/Images/Compute's structure) and
-    /// pre-selecting a different row before right-clicking the target (right-click reselects it
-    /// regardless). VolumesListView's row/`.alert`/hover-trash pattern is structurally almost
-    /// identical and deletes cleanly, so root cause is still open — needs its own investigation.
-    /// Skipped rather than deleted so the coverage gap and the bug both stay visible; un-skip once
-    /// NetworksListView's delete path is fixed.
+    /// FIXED CRASH (2026-07-19), formerly known/skipped — deleting a non-default network row
+    /// through its context menu used to deterministically crash the app: AppKit's "layout engine
+    /// changed during its own layout pass" exception, thrown re-entrantly from
+    /// `OutlineListCoordinator.listTableCellView(_:didUpdateIdealHeight:)` while the row was being
+    /// removed. Confirmed not mock-specific (reproduced against a real daemon too) and not
+    /// row-specific (both "data-net" and "app-net"). Bisected to `NetworkRow`'s trailing content
+    /// swapping view identity on hover (`if isHovered { trashButton } else { chips }`): replacing
+    /// it with a `ZStack` + opacity toggle (both branches always mounted, same identity) resolved
+    /// it — confirmed clean 3/3 in mock mode and against a real daemon. Why the identical
+    /// if/else pattern in `VolumesListView`'s row doesn't hit the same bug is still not
+    /// understood, but the fix here is verified rather than theoretical.
     @MainActor
     func testNetworkContextMenuShowsActionsAndDeletes() throws {
-        throw XCTSkip("""
-            Reliably crashes the app (AppKit \"layout engine changed during its own layout pass\" \
-            exception via OutlineListCoordinator.listTableCellView(_:didUpdateIdealHeight:)) when a \
-            non-default network row is deleted via its context menu. Confirmed deterministic \
-            (3/3 data-net, 2/2 app-net, and reproduces against a real daemon) and not row- or \
-            data-specific. See the doc comment above.
-            """)
+        let app = launchMock()
+        app.staticTexts["Networks"].click()
+        let row = app.staticTexts["data-net"]
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
+        row.rightClick()
+
+        XCTAssertTrue(app.menuItems["Copy Subnet"].waitForExistence(timeout: 5))
+        let deleteItem = app.menuItems["Delete…"]
+        XCTAssertTrue(deleteItem.isEnabled)
+        deleteItem.click()
+
+        let confirm = app.windows.buttons["Delete"].firstMatch
+        XCTAssertTrue(confirm.waitForExistence(timeout: 5))
+        confirm.click()
+
+        XCTAssertTrue(row.waitForNonExistence(timeout: 5))
     }
 }

--- a/BerthlyUITests/ContextMenuTests.swift
+++ b/BerthlyUITests/ContextMenuTests.swift
@@ -317,18 +317,23 @@ final class ContextMenuTests: XCTestCase {
     /// during the row-removal layout pass ("attempted to change the layout engine while it is
     /// executing"). A minimal right-click-only repro (open the menu, no delete) is clean 3/3, so
     /// the trigger is specifically the row being removed from the List mid-transaction, not the
-    /// menu itself. VolumesListView's row/`.alert`/hover-trash pattern is structurally almost
-    /// identical and deletes cleanly, so root cause isn't obvious from inspection — needs its own
-    /// investigation, out of scope for this context-menu test pass. Skipped rather than deleted so
-    /// the coverage gap and the bug both stay visible; un-skip once NetworksListView's delete path
-    /// is fixed.
+    /// menu itself. Confirmed NOT mock-specific: reproduces identically (same exception codes)
+    /// against a real daemon in `BerthlyE2ETests`, deleting a freshly created network with zero
+    /// attached containers — rules out both mock-timing and endpoint count as factors. Also ruled
+    /// out: wrapping the List in a `Section` (matching Volumes/Images/Compute's structure) and
+    /// pre-selecting a different row before right-clicking the target (right-click reselects it
+    /// regardless). VolumesListView's row/`.alert`/hover-trash pattern is structurally almost
+    /// identical and deletes cleanly, so root cause is still open — needs its own investigation.
+    /// Skipped rather than deleted so the coverage gap and the bug both stay visible; un-skip once
+    /// NetworksListView's delete path is fixed.
     @MainActor
     func testNetworkContextMenuShowsActionsAndDeletes() throws {
         throw XCTSkip("""
             Reliably crashes the app (AppKit \"layout engine changed during its own layout pass\" \
             exception via OutlineListCoordinator.listTableCellView(_:didUpdateIdealHeight:)) when a \
             non-default network row is deleted via its context menu. Confirmed deterministic \
-            (3/3 data-net, 2/2 app-net) and not row-specific. See the doc comment above.
+            (3/3 data-net, 2/2 app-net, and reproduces against a real daemon) and not row- or \
+            data-specific. See the doc comment above.
             """)
     }
 }


### PR DESCRIPTION
## Summary
- Fixes a real, deterministic crash found while writing `BerthlyUITests/ContextMenuTests.swift` (#7): deleting any non-default network row via its context menu crashed the app with AppKit's "layout engine changed during its own layout pass" exception (`_postWindowNeedsUpdateConstraints`), thrown while the row was being removed from the sidebar List.
- Confirmed the crash was real, not a mock artifact: it reproduced identically (same exception codes) against a real daemon, deleting a freshly created network with zero attached containers.

## Root cause
Bisected by stubbing suspect views and rerunning the (deterministic) crash test 3x each time:
- Stubbed `NetworkDetailContent` (the topology diagram, the one thing structurally unique to Networks vs. other detail panes) → crash persisted. Detail pane exonerated.
- Stubbed `NetworkRow`'s trailing content to remove the `if isHovered { trashButton } else { chips }` swap → crash gone, 3/3 clean.

The `if/else` swapped view *identity* on hover. Removing the row from the List while that identity churn was mid-flight raced the row-removal's own layout pass and threw.

## Fix
Replaced the `if/else` with a `ZStack` where both branches stay always mounted, toggling `.opacity`/`.allowsHitTesting` instead of swapping which view exists. Same visual behavior, no identity churn.

**Open question, documented in the fix's comment:** `VolumesListView`'s row has the *identical* `if/else` hover-swap pattern and has never crashed. Why Networks hit this and Volumes didn't is still not understood.

## Test plan
- [x] `testNetworkContextMenuShowsActionsAndDeletes` un-skipped, passes 3/3 in isolation
- [x] Full `ContextMenuTests` suite (15 tests) passes 2 full runs, 0 flakes
- [x] Confirmed fix holds against a real daemon (temporary E2E diagnostic, removed after confirming)
- [x] Other network-related mock UI tests (`testNetworkSelectionOpensAndSwapsDetailPane`, `testReturnSubmitsNetworkCreateFromAnyField`) unaffected
- [x] `swiftlint lint --strict` — 0 violations across all 112 files