### PR TITLE
test: add System page and image archive sheet mock-mode coverage

### DIFF
--- a/Berthly/Views/SystemView.swift
+++ b/Berthly/Views/SystemView.swift
@@ -346,6 +346,7 @@ private struct DiskUsageGridRow: View {
                     } else {
                         Button("Prune") { showConfirm = true }
                             .controlSize(.small)
+                            .accessibilityIdentifier("prune-\(name)")
                     }
                 }
             }
@@ -606,6 +607,7 @@ private struct DNSDomainRow: View {
                 .buttonStyle(.bordered)
                 .controlSize(.small)
                 .help("Delete Domain")
+                .accessibilityIdentifier("dnsDeleteButton-\(domain)")
             }
         } label: {
             Text(domain)

--- a/BerthlyUITests/SecondaryViewTests.swift
+++ b/BerthlyUITests/SecondaryViewTests.swift
@@ -5,14 +5,18 @@ import XCTest
 
 /// Mock-mode coverage for secondary sheets and detail panes reached through a menu, overflow
 /// action, or list-row selection rather than a toolbar button: Settings, machine detail/edit/logs,
-/// copy/tag/push on containers and images, and the Registries list. Same conventions as
-/// BerthlyUITests.swift: `XCUIApplication.berthly()`, `UITEST_USE_MOCK_SERVICE`, Escape/Return key
-/// dismissal over coordinate clicks, identifiers over label text where one exists.
+/// copy/tag/push on containers and images, the Registries list, and Save/Load image archive
+/// sheets. Same conventions as BerthlyUITests.swift: `XCUIApplication.berthly()`,
+/// `UITEST_USE_MOCK_SERVICE`, Escape/Return key dismissal over coordinate clicks, identifiers over
+/// label text where one exists.
 ///
-/// LoadImageSheet and SaveImageSheet are deliberately not covered here: both are gated behind a
-/// synchronous NSOpenPanel/NSSavePanel `runModal()` before the sheet body ever renders, and
-/// driving native panels from XCUITest is a known flake source for no coverage payoff — a
-/// cancel-only interaction would dismiss the panel without the sheet ever appearing.
+/// LoadImageSheet and SaveImageSheet are reachable here via `UITEST_SAVE_DESTINATION` /
+/// `UITEST_LOAD_SOURCE` — the same test-only launch-env bypass added for `BerthlyE2ETests`'
+/// `ImageArchiveJourneyTests` (see `promptForArchiveDestination`/`promptForArchiveToLoad`'s doc
+/// comments) — rather than driving the native NSSavePanel/NSOpenPanel these sheets are otherwise
+/// gated behind. `MockContainerService.saveImages`/`loadImages` don't touch real disk (`saveImages`
+/// just records the call; `loadImages` derives a fake reference from the path's filename stem), so
+/// the paths below don't need to exist.
 final class SecondaryViewTests: XCTestCase {
 
     override func setUpWithError() throws {
@@ -261,5 +265,59 @@ final class SecondaryViewTests: XCTestCase {
 
         XCTAssertTrue(app.staticTexts["ghcr.io"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["registry-1.docker.io"].exists)
+    }
+
+    // MARK: - Image archive (Save/Load)
+
+    /// SaveImageSheet, reached from the row's context menu; the native NSSavePanel is bypassed via
+    /// `UITEST_SAVE_DESTINATION` so the sheet renders immediately in its "writing" state. The mock
+    /// adds a small delay before completing, matching the real save's non-instant nature.
+    @MainActor
+    func testSaveImageSheetSavesImage() throws {
+        let app = XCUIApplication.berthly()
+        app.launchEnvironment["UITEST_USE_MOCK_SERVICE"] = "1"
+        app.launchEnvironment["UITEST_SAVE_DESTINATION"] = "/tmp/berthly-uitest-web_1.4.tar"
+        app.launch()
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+        app.staticTexts["Images"].click()
+        let imageRow = app.staticTexts["local/web:1.4"]
+        XCTAssertTrue(imageRow.waitForExistence(timeout: 10))
+        imageRow.rightClick()
+
+        let saveItem = app.menuItems["Save to Disk…"]
+        XCTAssertTrue(saveItem.waitForExistence(timeout: 5))
+        saveItem.click()
+
+        let done = app.buttons["Done"]
+        XCTAssertTrue(done.waitForExistence(timeout: 10), "save should complete")
+        done.click()
+    }
+
+    /// LoadImageSheet, reached via the command palette; the native NSOpenPanel is bypassed via
+    /// `UITEST_LOAD_SOURCE`. The mock derives the loaded reference from the path's filename stem
+    /// (`name_tag.tar` → `name:tag`), so a made-up path is enough to prove the load path end to
+    /// end without any real archive on disk.
+    @MainActor
+    func testLoadImageSheetLoadsImage() throws {
+        let app = XCUIApplication.berthly()
+        app.launchEnvironment["UITEST_USE_MOCK_SERVICE"] = "1"
+        app.launchEnvironment["UITEST_LOAD_SOURCE"] = "/tmp/loaded_9.9.tar"
+        app.launch()
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+        app.typeKey("k", modifierFlags: .command)
+        let searchField = app.textFields["commandPaletteSearchField"]
+        XCTAssertTrue(searchField.waitForExistence(timeout: 5))
+        searchField.typeText("Load Image")
+        app.typeKey(.return, modifierFlags: [])
+
+        let done = app.buttons["Done"]
+        XCTAssertTrue(done.waitForExistence(timeout: 10), "load should complete")
+        done.click()
+
+        app.staticTexts["Images"].click()
+        XCTAssertTrue(app.staticTexts["loaded:9.9"].waitForExistence(timeout: 5),
+                      "the loaded image should appear in the sidebar")
     }
 }

--- a/BerthlyUITests/SystemViewTests.swift
+++ b/BerthlyUITests/SystemViewTests.swift
@@ -1,0 +1,146 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import XCTest
+
+/// Mock-mode coverage for the System page's mutating actions — disk-usage prune rows, "Clean Up
+/// All", and local DNS domain add/delete — none of which had UI-layer coverage despite being
+/// fully reachable through `MockContainerService` (unlike the E2E suite, where `prune` is
+/// permanently descoped as too destructive to run against a real daemon; see PLAN/E2E-TEST.md
+/// §6.4). Same conventions as BerthlyUITests.swift/SecondaryViewTests.swift:
+/// `XCUIApplication.berthly()`, `UITEST_USE_MOCK_SERVICE`. These rows previously had no
+/// accessibility identifiers and their action buttons only carried `.help()` tooltip text (not a
+/// usable XCUITest label) — added `.accessibilityIdentifier` to each (`prune-<name>`,
+/// `dnsDeleteButton-<domain>`) rather than guess at ordering or scope tricks. Alert-driven confirm
+/// buttons are queried via `app.sheets`, not `app.windows` — the latter can't disambiguate a
+/// trigger button from its own same-labeled confirm button when both are visible at once.
+///
+/// Builder stop/delete is NOT covered here: in this session's runs, `MockContainerService
+/// .stopBuilder` demonstrably executed (confirmed via a temporary file-based side channel) but
+/// the row's UI never reflected the state change across two separate XCUITest invocations
+/// (`.click()` and `.typeKey(.return)` on the confirmation alert). Unconfirmed whether this is a
+/// real `@Observable`/SwiftUI reactivity bug or an XCUITest-specific artifact of how it drives
+/// this destructive alert — sibling tests in this same file rule out the two most obvious
+/// mechanism theories (plain value-capture rows and self-observing sections both update fine
+/// elsewhere), so the differentiator isn't understood. Deferred rather than asserted as a bug;
+/// start any follow-up from a manual or real-daemon repro, not more automation-only theorizing.
+final class SystemViewTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        let killer = Process()
+        killer.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
+        killer.arguments = ["-9", "Berthly"]
+        killer.standardOutput = FileHandle.nullDevice
+        killer.standardError = FileHandle.nullDevice
+        if (try? killer.run()) != nil { killer.waitUntilExit() }
+    }
+
+    private func launchMock() -> XCUIApplication {
+        let app = XCUIApplication.berthly()
+        app.launchEnvironment["UITEST_USE_MOCK_SERVICE"] = "1"
+        app.launch()
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+        app.staticTexts["System"].click()
+        return app
+    }
+
+    // MARK: - Disk usage prune rows
+
+    /// Images row: mock seeds reclaimable bytes > 0, so "Prune" is present; confirms via "Clean
+    /// Up" (non-destructive alert role — pruning re-pullable image cache), then the row's own
+    /// "Prune" button disappears once reclaimableBytes drops to 0.
+    @MainActor
+    func testDiskUsagePruneImagesRemovesTheButtonOnceReclaimed() throws {
+        let app = launchMock()
+        let pruneImages = app.buttons["prune-Images"]
+        XCTAssertTrue(pruneImages.waitForExistence(timeout: 5), "Images row should offer Prune")
+        pruneImages.click()
+
+        let confirm = app.sheets.buttons["Clean Up"]
+        XCTAssertTrue(confirm.waitForExistence(timeout: 5))
+        confirm.click()
+
+        let done = app.sheets.buttons["OK"]
+        XCTAssertTrue(done.waitForExistence(timeout: 10), "prune should report a Done alert")
+        done.click()
+        XCTAssertTrue(pruneImages.waitForNonExistence(timeout: 5), "Prune should disappear once reclaimed")
+    }
+
+    /// Containers row: same shape as Images but a destructive confirm role ("Remove") since a
+    /// deleted stopped container isn't re-pullable.
+    @MainActor
+    func testDiskUsagePruneStoppedContainersRequiresConfirmation() throws {
+        let app = launchMock()
+        let pruneContainers = app.buttons["prune-Containers"]
+        XCTAssertTrue(pruneContainers.waitForExistence(timeout: 5), "Containers row should offer Prune")
+        pruneContainers.click()
+
+        let confirm = app.sheets.buttons["Remove"]
+        XCTAssertTrue(confirm.waitForExistence(timeout: 5))
+        confirm.click()
+
+        let done = app.sheets.buttons["OK"]
+        XCTAssertTrue(done.waitForExistence(timeout: 10), "prune should report a Done alert")
+        done.click()
+    }
+
+    /// "Clean Up All" prunes images + stopped containers together, independent of the per-row
+    /// actions above — a separate test proves it isn't just an alias for clicking both rows.
+    @MainActor
+    func testDiskUsageCleanUpAllShowsSummary() throws {
+        let app = launchMock()
+        let cleanUpAll = app.buttons["Clean Up All"]
+        XCTAssertTrue(cleanUpAll.waitForExistence(timeout: 5))
+        cleanUpAll.click()
+
+        // Scoped to app.sheets: the trigger button ("Clean Up All") stays on screen while its
+        // own confirm alert (same label) is showing — app.windows can't disambiguate them.
+        let confirm = app.sheets.buttons["Clean Up All"]
+        XCTAssertTrue(confirm.waitForExistence(timeout: 5))
+        confirm.click()
+
+        let done = app.sheets.buttons["OK"]
+        XCTAssertTrue(done.waitForExistence(timeout: 10), "Clean Up All should report a Done alert")
+        done.click()
+    }
+
+    // MARK: - Local DNS
+
+    /// Mock seeds one domain ("test"); adding a second proves the create path end-to-end, no
+    /// admin-password prompt to drive since MockContainerService never shells out.
+    @MainActor
+    func testLocalDNSAddDomainAppendsToTheList() throws {
+        let app = launchMock()
+        let addButton = app.buttons["Add Domain…"]
+        XCTAssertTrue(addButton.waitForExistence(timeout: 5))
+        addButton.click()
+
+        let field = app.sheets.textFields.firstMatch
+        XCTAssertTrue(field.waitForExistence(timeout: 5), "add-domain alert should appear")
+        field.click()
+        field.typeText("example")
+        app.sheets.buttons["Add"].click()
+
+        XCTAssertTrue(app.staticTexts["example"].waitForExistence(timeout: 5),
+                      "the new domain should appear in the list")
+    }
+
+    /// Deleting the seeded "test" domain requires confirmation, then it's gone from the list.
+    @MainActor
+    func testLocalDNSDeleteDomainRequiresConfirmation() throws {
+        let app = launchMock()
+        let row = app.staticTexts["test"]
+        XCTAssertTrue(row.waitForExistence(timeout: 5), "mock should seed a \"test\" domain")
+
+        app.buttons["dnsDeleteButton-test"].click()
+        // Scoped to app.sheets: the builder row's own Delete button (once stopped) would share
+        // this exact label too, though it's not stopped in this test — scoped consistently with
+        // every other confirm click in this file regardless.
+        let confirm = app.sheets.buttons["Delete"]
+        XCTAssertTrue(confirm.waitForExistence(timeout: 5))
+        confirm.click()
+
+        XCTAssertTrue(row.waitForNonExistence(timeout: 5))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `BerthlyUITests/SystemViewTests.swift` (5 tests): disk-usage prune rows (Images, Containers), "Clean Up All", and local DNS domain add/delete — all previously uncovered at the UI layer despite being fully reachable through `MockContainerService`.
- Extends `SecondaryViewTests.swift` (+2 tests): Save/Load image archive sheets, previously explicitly excluded (stale comment cited native-panel driving as a flake source). The `UITEST_SAVE_DESTINATION`/`UITEST_LOAD_SOURCE` env-var seam added earlier for `BerthlyE2ETests` unblocks mock-mode coverage the same way it unblocked E2E.
- Added accessibility identifiers to a few System-page buttons that previously only carried `.help()` tooltip text (not usable XCUITest labels): `prune-<name>`, `dnsDeleteButton-<domain>`.

## Dropped, not shipped: Builder stop/delete
Attempted the same coverage for the Builder section's Stop → Delete transition. Hit a genuinely confusing result: a file-based side channel confirmed `MockContainerService.stopBuilder` really executes and flips the model's status, yet the row's UI never reflected it across two separate XCUITest runs. Sibling tests in the same file rule out the two obvious theories (plain value-capture rows and self-observing sections both update fine elsewhere), so the differentiator isn't understood.

This session already had a false negative from invisible `print()` output that looked like solid evidence until checked via a file side-channel — automation-only evidence isn't trustworthy enough here to assert a product bug. Cut entirely rather than shipped as a misleading "known bug" `XCTSkip`. Documented in `PLAN/E2E-TEST.md` §8 (gitignored, local) as a follow-up that should start from a manual or real-daemon repro, matching how the Networks delete crash (#8) went from suspicion to confirmed bug.

## Test plan
- [x] `xcodebuild build-for-testing` clean for the whole `BerthlyUITests` target
- [x] `SystemViewTests` (5 tests) run 2x, 0 flakes
- [x] `SecondaryViewTests` (10 tests, incl. 2 new) run 2x, 0 flakes
- [x] `swiftlint lint --strict` — 0 violations across all 113 files