### PR TITLE
fix: builder row stays "Running" after Stop due to narrow Equatable

### DIFF
--- a/Berthly/Core/Models.swift
+++ b/Berthly/Core/Models.swift
@@ -311,7 +311,9 @@ struct Network: Identifiable, Hashable {
     let backend: String
     let endpoints: [NetworkEndpoint]
 
-    static func == (lhs: Self, rhs: Self) -> Bool { lhs.id == rhs.id }
+    // Include endpoints so SwiftUI detects the row needing to redraw as containers attach/detach
+    // (same class of fix as Container/Machine's status, Builder's status — see their comments).
+    static func == (lhs: Self, rhs: Self) -> Bool { lhs.id == rhs.id && lhs.endpoints == rhs.endpoints }
     func hash(into hasher: inout Hasher) { hasher.combine(id) }
 }
 
@@ -355,7 +357,7 @@ struct Machine: Identifiable, Hashable {
 
 // MARK: - Builder
 
-enum BuilderStatus { case running, stopped }
+enum BuilderStatus: Equatable { case running, stopped }
 
 struct Builder: Identifiable, Hashable {
     let id: String
@@ -366,7 +368,10 @@ struct Builder: Identifiable, Hashable {
     var cpus: Int
     var memoryGB: Int
 
-    static func == (lhs: Self, rhs: Self) -> Bool { lhs.id == rhs.id }
+    // Include status so SwiftUI detects the row needing to redraw after Stop/Start — same reason
+    // Container/Machine include theirs. Hash by id only for stable Set membership across
+    // status transitions.
+    static func == (lhs: Self, rhs: Self) -> Bool { lhs.id == rhs.id && lhs.status == rhs.status }
     func hash(into hasher: inout Hasher) { hasher.combine(id) }
 }
 

--- a/Berthly/Views/SystemView.swift
+++ b/Berthly/Views/SystemView.swift
@@ -689,6 +689,7 @@ private struct BuilderRow: View {
                     .controlSize(.small)
                     .disabled(isStopping)
                     .help("Stop Builder")
+                    .accessibilityIdentifier("builderStopButton-\(builder.id)")
                 } else {
                     // Benign and instantly reversible, so no confirmation alert — like
                     // `container builder start`, this just boots the builder VM so the next
@@ -706,6 +707,7 @@ private struct BuilderRow: View {
                     .controlSize(.small)
                     .disabled(isStarting || isDeleting)
                     .help("Start Builder")
+                    .accessibilityIdentifier("builderStartButton-\(builder.id)")
 
                     // Delete only offered once stopped — same stop-first gate as container rows
                     // (the CLI needs --force to delete a running builder; the GUI doesn't offer
@@ -718,6 +720,7 @@ private struct BuilderRow: View {
                     .controlSize(.small)
                     .disabled(isDeleting || isStarting)
                     .help("Delete Builder")
+                    .accessibilityIdentifier("builderDeleteButton-\(builder.id)")
                 }
             }
         } label: {

--- a/BerthlyUITests/SystemViewTests.swift
+++ b/BerthlyUITests/SystemViewTests.swift
@@ -4,26 +4,30 @@
 import XCTest
 
 /// Mock-mode coverage for the System page's mutating actions — disk-usage prune rows, "Clean Up
-/// All", and local DNS domain add/delete — none of which had UI-layer coverage despite being
-/// fully reachable through `MockContainerService` (unlike the E2E suite, where `prune` is
-/// permanently descoped as too destructive to run against a real daemon; see PLAN/E2E-TEST.md
-/// §6.4). Same conventions as BerthlyUITests.swift/SecondaryViewTests.swift:
-/// `XCUIApplication.berthly()`, `UITEST_USE_MOCK_SERVICE`. These rows previously had no
-/// accessibility identifiers and their action buttons only carried `.help()` tooltip text (not a
-/// usable XCUITest label) — added `.accessibilityIdentifier` to each (`prune-<name>`,
-/// `dnsDeleteButton-<domain>`) rather than guess at ordering or scope tricks. Alert-driven confirm
-/// buttons are queried via `app.sheets`, not `app.windows` — the latter can't disambiguate a
-/// trigger button from its own same-labeled confirm button when both are visible at once.
+/// All", local DNS domain add/delete, and the builder Stop/Start/Delete lifecycle — none of which
+/// had UI-layer coverage despite being fully reachable through `MockContainerService` (unlike the
+/// E2E suite, where `prune` is permanently descoped as too destructive to run against a real
+/// daemon; see PLAN/E2E-TEST.md §6.4). Same conventions as
+/// BerthlyUITests.swift/SecondaryViewTests.swift: `XCUIApplication.berthly()`,
+/// `UITEST_USE_MOCK_SERVICE`. These rows previously had no accessibility identifiers and their
+/// action buttons only carried `.help()` tooltip text (not a usable XCUITest label) — worse, both
+/// the DNS row and the builder row have their own "Delete" button with the identical label, always
+/// on screen simultaneously (the DNS row's is unconditional), so a bare label query for one can
+/// silently match the other. Added `.accessibilityIdentifier` to each (`prune-<name>`,
+/// `dnsDeleteButton-<domain>`, `builder{Stop,Start,Delete}Button-<id>`) rather than guess at
+/// ordering or scope tricks. Alert-driven confirm buttons are queried via `app.sheets`, not
+/// `app.windows` — the latter can't disambiguate a trigger button from its own same-labeled
+/// confirm button when both are visible at once.
 ///
-/// Builder stop/delete is NOT covered here: in this session's runs, `MockContainerService
-/// .stopBuilder` demonstrably executed (confirmed via a temporary file-based side channel) but
-/// the row's UI never reflected the state change across two separate XCUITest invocations
-/// (`.click()` and `.typeKey(.return)` on the confirmation alert). Unconfirmed whether this is a
-/// real `@Observable`/SwiftUI reactivity bug or an XCUITest-specific artifact of how it drives
-/// this destructive alert — sibling tests in this same file rule out the two most obvious
-/// mechanism theories (plain value-capture rows and self-observing sections both update fine
-/// elsewhere), so the differentiator isn't understood. Deferred rather than asserted as a bug;
-/// start any follow-up from a manual or real-daemon repro, not more automation-only theorizing.
+/// Builder stop/delete was originally dropped from this file (this session found the row's UI
+/// never reflected a confirmed-successful model change, but couldn't tell whether that was a real
+/// bug or an XCUITest artifact). The user reproduced it manually in the real app and confirmed the
+/// daemon-side stop succeeded while the UI stayed wrong until navigating away and back — proving
+/// it was a real SwiftUI reactivity bug: `Builder`'s custom `Equatable` compared only `id`, so
+/// `ForEach(service.builders)` treated a running and a stopped `Builder` with the same id as
+/// unchanged and never redrew the row. Fixed in `Models.swift` (widened `Builder.==` to include
+/// `status`, matching the existing `Container`/`Machine` precedent). The test below is the
+/// regression guard for that fix.
 final class SystemViewTests: XCTestCase {
 
     override func setUpWithError() throws {
@@ -142,5 +146,56 @@ final class SystemViewTests: XCTestCase {
         confirm.click()
 
         XCTAssertTrue(row.waitForNonExistence(timeout: 5))
+    }
+
+    // MARK: - Builder
+
+    /// Regression guard for the Equatable-diffing bug described in this file's header comment.
+    /// Exercises the full lifecycle — Stop → Start → Stop → Delete — entirely without navigating
+    /// away, since that's exactly the scenario that reproduced the bug (navigating away and back
+    /// always "fixed" the display by forcing a full view reconstruction, which would mask a
+    /// regression here). Covers both directions of the status flip (Stop *and* Start) since the
+    /// fix could plausibly have been one-directional, plus Delete to prove the row is removed
+    /// entirely, not just its buttons.
+    @MainActor
+    func testBuilderLifecycleUpdatesRowWithoutNavigatingAway() throws {
+        let app = launchMock()
+
+        let stopButton = app.buttons["builderStopButton-default"]
+        XCTAssertTrue(stopButton.waitForExistence(timeout: 5), "the mock's running builder should offer Stop")
+        stopButton.click()
+        let confirmStop = app.sheets.buttons["Stop"]
+        XCTAssertTrue(confirmStop.waitForExistence(timeout: 5))
+        confirmStop.click()
+
+        let startButton = app.buttons["builderStartButton-default"]
+        XCTAssertTrue(startButton.waitForExistence(timeout: 10),
+                      "builder row should show Start after stopping, without navigating away")
+        XCTAssertTrue(app.buttons["builderDeleteButton-default"].exists, "builder row should also show Delete")
+        XCTAssertFalse(app.buttons["builderStopButton-default"].exists, "Stop should be gone once stopped")
+
+        // Start: reverses the same status flip, proving the fix isn't one-directional.
+        startButton.click()
+        XCTAssertTrue(app.buttons["builderStopButton-default"].waitForExistence(timeout: 10),
+                      "builder row should show Stop again after starting, without navigating away")
+        XCTAssertFalse(app.buttons["builderStartButton-default"].exists, "Start should be gone once running again")
+        XCTAssertFalse(app.buttons["builderDeleteButton-default"].exists, "Delete should be gone once running again")
+
+        // Stop once more, then Delete — proves the row is removed entirely, not just its buttons.
+        app.buttons["builderStopButton-default"].click()
+        app.sheets.buttons["Stop"].click()
+        let deleteButton = app.buttons["builderDeleteButton-default"]
+        XCTAssertTrue(deleteButton.waitForExistence(timeout: 10))
+        deleteButton.click()
+        app.sheets.buttons["Delete"].click()
+
+        // This Text surfaces as accessibility *value*, not label — same gotcha documented
+        // elsewhere in this suite (LogStreamView, ImagesListView rows) — so an exact-label
+        // query silently never matches even though the text is genuinely there.
+        let emptyState = app.staticTexts
+            .matching(NSPredicate(format: "label CONTAINS %@ OR value CONTAINS %@", "No builder found", "No builder found"))
+            .firstMatch
+        XCTAssertTrue(emptyState.waitForExistence(timeout: 10),
+                      "the builder should be gone entirely after deleting the only one")
     }
 }


### PR DESCRIPTION
## Summary
Reported by the user: stopping a builder from the System page correctly stopped it daemon-side (confirmed via `container list -a`), but the row's status stayed "Running" and the Stop/Start/Delete buttons never swapped — until navigating away to another sidebar tab and back, which fixed the display.

That "navigate away fixes it" detail is the key clue: the model data was correct, only the *view* was stale.

## Root cause
`Builder`'s custom `Equatable` compared only `id`:
```swift
static func == (lhs: Self, rhs: Self) -> Bool { lhs.id == rhs.id }
```
`ForEach(service.builders) { builder in BuilderRow(builder: builder) }` uses `Equatable` (when available) to skip re-rendering elements it considers unchanged. Since a running and a stopped `Builder` with the same id compared equal, SwiftUI concluded nothing changed and never passed the fresh value down to the row — even though `service.builders` itself had genuinely mutated.

**This exact bug class had already been fixed twice in this codebase.** `Container` and `Machine` both widen their `==` to include `status` (`Machine` also includes `isDefault`), each with an explicit comment ("Include status so SwiftUI detects section changes... same reason status participates"). `Builder` was simply missed when that convention was established.

`Network` had the identical narrow `id`-only pattern too — not proven broken by any test, but the same latent shape (an endpoint-count change wouldn't redraw the row) — fixed proactively by including `endpoints`. `Volume` and `ContainerImage` were checked and don't override `==` at all (plain synthesized Hashable comparing every field — safe by default).

## Fix
Widen `Builder.==` to include `status` (and give `BuilderStatus` `Equatable` conformance, which it was missing entirely), and `Network.==` to include `endpoints`.

## Test coverage
Added `testBuilderLifecycleUpdatesRowWithoutNavigatingAway` to `SystemViewTests.swift`, exercising the full Stop → Start → Stop → Delete lifecycle **without ever navigating away** — exactly the scenario that reproduced the bug. Covers both directions of the status flip (not just Stop) and confirms Delete removes the row entirely, not just its buttons. Added accessibility identifiers to the builder row's Stop/Start/Delete buttons since the DNS row's own Delete button shares the identical label and is always on screen, so a bare label query would have silently matched the wrong element.

## Test plan
- [x] `testBuilderLifecycleUpdatesRowWithoutNavigatingAway` passes 3/3 in isolation; reliably failed on this exact scenario before the fix
- [x] Full `SystemViewTests` suite (6 tests) passes 2 full runs, 0 flakes
- [x] Full `BerthlyTests` unit suite passes
- [x] Full `BerthlyUITests` regression sweep (33+2 tests) passes, 0 failures
- [x] `swiftlint lint --strict` — 0 violations across all 113 files