### PR TITLE
docs: note VolumeRow's unexplained immunity to NetworkRow's crash pattern

### DIFF
--- a/Berthly/Views/VolumesListView.swift
+++ b/Berthly/Views/VolumesListView.swift
@@ -168,6 +168,12 @@ private struct VolumeRow: View {
 
                 Spacer()
 
+                // NetworkRow's identical if/else hover-swap reproducibly crashed the app on
+                // context-menu delete (AppKit layout re-entrancy) and was rewritten as a static
+                // ZStack+opacity swap — see its comment for the full story. This row has the same
+                // shape and has never been observed to crash across repeated manual and automated
+                // testing (2026-07-19), but no source-level difference explains why; prefer the
+                // ZStack pattern here too if this row ever needs to change.
                 if isHovered {
                     Button(role: .destructive) { showDeleteConfirm = true } label: {
                         Image(systemName: "trash")


### PR DESCRIPTION
## Summary
- Task #1 from the earlier Equatable-audit follow-up: investigate why `VolumesListView`'s row (`if isHovered { trashButton } else { chips }`) never crashed despite having the identical view-identity-swap pattern that reproducibly crashed `NetworksListView` (fixed in a prior PR via `ZStack`+opacity).
- Full side-by-side comparison found no remaining source-level difference between the two rows — confirmed even the two models' `Equatable` conformance was identically narrow at the time Networks crashed, ruling that out too.
- Evidence is always-vs-never, not "same bug, narrower window": Networks crashed 3/3 and 2/2, always; Volumes was 0-for-~15+ across manual and automated runs this session (including 10 back-to-back `ContextMenuTests` runs with no artificial CPU load — a CPU-pegging stress test was attempted but blocked by tooling policy).
- No failing test justifies rewriting `VolumeRow` to match `NetworkRow`'s `ZStack` fix, so this closes the investigation with a doc comment only, pointing future editors at the preferred pattern if the row ever needs to change.

## Test plan
- [x] `xcodebuild build -scheme Berthly -destination 'platform=macOS'` — clean build
- [x] `swiftlint lint --strict` — 0 violations
- [x] Comment-only change to an existing, already-covered row (`ContextMenuTests.testVolumeContextMenuShowsActionsAndDeletes`); no behavior change