### PR TITLE
feat: add Watchtower-style recreate-with-latest-image

### DIFF
--- a/Berthly/Core/ContainerServiceBase.swift
+++ b/Berthly/Core/ContainerServiceBase.swift
@@ -24,6 +24,14 @@ class ContainerServiceBase {
     var pinnedContainerIDs: Set<String> = []
     var pinnedMachineIDs: Set<String> = []
 
+    /// Remote digest-check results, keyed by `ContainerImage.id`. Lives here (not on the model)
+    /// so badge views observe the dictionary through `@Environment` and re-render on check
+    /// results without widening `ContainerImage.==`.
+    var imageUpdateInfo: [String: ImageUpdateInfo] = [:]
+    var lastImageUpdateCheck: Date?
+    /// Drives the Images toolbar's check-in-progress spinner.
+    var isCheckingImageUpdates = false
+
     /// Set when `startDaemon()` connects fine but a background bootstrap step (installing the
     /// vminit filesystem image or default kernel) failed — the daemon reports `.connected`
     /// regardless (it's the correct state for most purposes), so without this the failure is
@@ -123,6 +131,36 @@ class ContainerServiceBase {
     func deleteBuilder(_ id: String) async throws {}
     func pullImage(reference: String, platform: String? = nil, insecure: Bool = false,
                    progress: ProgressUpdateHandler? = nil, onUnpacking: (() -> Void)? = nil) async throws {}
+
+    func updateAvailability(for image: ContainerImage) -> ImageUpdateAvailability {
+        ImageStaleness.availability(image: image, info: imageUpdateInfo[image.id])
+    }
+    func staleness(of container: Container) -> ContainerImageStaleness {
+        ImageStaleness.staleness(containerImageRef: container.image, containerImageDigest: container.imageDigest,
+                                 images: images, updateInfo: imageUpdateInfo)
+    }
+    /// Whether `reference`'s registry host has been remembered as insecure (Pull/Push/Run/
+    /// Sign-in's "Allow insecure registry" toggle) — used to prefill Pull Latest's own toggle so
+    /// re-pulling a known-insecure host's tag doesn't need re-asking. Base `false`: mock mode has
+    /// no real registries to remember anything about.
+    func isKnownInsecureRegistry(forReference reference: String) -> Bool { false }
+    /// Compare each eligible local image's digest against its registry (HEAD manifest, no pull)
+    /// and record the results in `imageUpdateInfo`. Failures are silent per image — a background
+    /// nicety must never alert; a failed check just means no badge.
+    func checkForImageUpdates(force: Bool = false) async {}
+    /// Watchtower-style update: optionally pull the container's tag, then stop/delete/recreate it
+    /// from the stored configuration with the fresh image digest, restoring the prior run state.
+    /// `onPhase` narrates steps for the sheet; only the pull phase honors cancellation.
+    @discardableResult
+    func recreateContainer(_ id: String, pullFirst: Bool, progress: ProgressUpdateHandler? = nil,
+                           onPhase: @MainActor @escaping (RecreatePhase) -> Void) async throws -> RecreateResult {
+        RecreateResult(wasRunning: false, didPull: false, oldImageDigest: "", newImageDigest: "")
+    }
+    /// Garbage-collect content blobs no longer referenced by any image — what a same-tag re-pull
+    /// leaves behind (apple/container *replaces* the reference, so there's no dangling image row
+    /// to delete, only orphaned bytes). Returns freed bytes.
+    @discardableResult
+    func reclaimOrphanedImageBlobs() async throws -> UInt64 { 0 }
     /// Create an additional local reference for an existing image (like `container image tag`).
     /// Returns the reference actually created: normalization can add a default registry host,
     /// a `library/` namespace, or `:latest` — the UI shows the result so that isn't a surprise.

--- a/Berthly/Core/ImageStaleness.swift
+++ b/Berthly/Core/ImageStaleness.swift
@@ -1,0 +1,129 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import ContainerizationOCI
+import Foundation
+
+/// Pure staleness logic for Watchtower-style image-update detection: which local images are
+/// worth a registry check, how digests compare, and how a container's pinned digest relates to
+/// its tag. All `nonisolated` and free of XPC/network so `BerthlyTests` can cover the matrix
+/// (`LiveContainerService.buildArguments(for:)` is the pattern).
+nonisolated enum ImageStaleness {
+    /// On-connect plus every 6 hours. Registry HEAD manifest requests don't count against
+    /// Docker Hub pull limits (Watchtower relies on this), but there's no reason to ask more
+    /// often than image publishers actually ship.
+    static let checkInterval: TimeInterval = 6 * 3600
+
+    /// Local references worth a remote HEAD: pulled from a real registry (a parseable domain),
+    /// addressed by tag. Built images, domain-less names like `local/web:1.4`, digest-pinned
+    /// pulls (`name@sha256:…` can never have a *newer* digest), and builder infrastructure are
+    /// all skipped. Deduped preserving order.
+    static func eligibleReferences(images: [ContainerImage]) -> [String] {
+        var seen = Set<String>()
+        var result: [String] = []
+        for image in images {
+            guard image.source == .pulled, image.usage != .builderImage else { continue }
+            guard let ref = try? Reference.parse(image.id),
+                  ref.domain != nil, ref.tag != nil, ref.digest == nil else { continue }
+            if seen.insert(image.id).inserted { result.append(image.id) }
+        }
+        return result
+    }
+
+    /// The local digest that is actually comparable to a registry's root digest. When a pulled
+    /// tag's remote root is a single manifest (not an index), the daemon wraps it in a
+    /// synthesized index annotated `containerizationIndexIndirect` — so the image's own digest
+    /// never equals the remote one and naive comparison false-positives forever. This unwraps
+    /// exactly like the package-internal `ClientImage.resolved()` (not `public`, hence the
+    /// reimplementation over the public `index()` data).
+    static func comparableLocalDigest(ownDigest: String, index: Index) -> String {
+        guard let indirect = index.annotations?[AnnotationKeys.containerizationIndexIndirect],
+              ["1", "true"].contains(indirect.lowercased()),
+              let manifest = index.manifests.first else {
+            return ownDigest
+        }
+        return manifest.digest
+    }
+
+    /// A check result is only valid for the image bytes it was computed against: if the image's
+    /// digest has moved since (user pulled or rebuilt), the stored info answers a question about
+    /// an image that no longer exists locally → `.unknown`, not a stale verdict either way.
+    static func availability(image: ContainerImage, info: ImageUpdateInfo?) -> ImageUpdateAvailability {
+        guard let info, info.localImageDigest == image.digest else { return .unknown }
+        return info.isUpdateAvailable ? .updateAvailable : .upToDate
+    }
+
+    /// Ref→image matching mirrors `ContainerImage.resolvingUsage` (id, fullName, or digest) so
+    /// the badge and the "used by" count never disagree about which image a container runs.
+    /// Pinned-digest drift beats a remote update: once the local image is newer than the
+    /// container, "recreate to apply" is the actionable message regardless of the registry.
+    static func staleness(
+        containerImageRef: String, containerImageDigest: String?,
+        images: [ContainerImage], updateInfo: [String: ImageUpdateInfo]
+    ) -> ContainerImageStaleness {
+        guard let image = images.first(where: {
+            containerImageRef == $0.id || containerImageRef == $0.fullName || containerImageRef == $0.digest
+        }) else { return .current }
+        // Without a pinned digest there's no knowing what the container actually runs — it may
+        // already be on the registry's digest — so neither stale verdict can be justified.
+        guard let pinned = containerImageDigest else { return .current }
+        if pinned != image.digest { return .localImageNewer }
+        if availability(image: image, info: updateInfo[image.id]) == .updateAvailable {
+            return .remoteUpdateAvailable
+        }
+        return .current
+    }
+
+    static func isCheckDue(lastCheck: Date?, now: Date, interval: TimeInterval = checkInterval) -> Bool {
+        guard let lastCheck else { return true }
+        return now.timeIntervalSince(lastCheck) >= interval
+    }
+
+    /// Whether `poll()` may run its automatic registry check — the Settings "Check images for
+    /// updates" toggle, defaulting on when unset (a fresh install, or a `UserDefaults` value of
+    /// some other type). Only gates the automatic path: manual checks and recreate always work.
+    static func automaticCheckEnabled(userDefaultValue: Any?) -> Bool {
+        (userDefaultValue as? Bool) ?? true
+    }
+
+    // MARK: - Insecure-registry-host memory
+
+    static let insecureHostsDefaultsKey = "insecureRegistryHosts"
+
+    /// Case/trailing-dot folding shared by both entry points below — every write and every read
+    /// of the insecure-hosts memory must go through one of them, or the same host typed/derived
+    /// differently (case, a trailing FQDN dot) silently fragments into separate trust entries.
+    private static func foldedHost(_ host: String) -> String {
+        var h = host.lowercased()
+        if h.hasSuffix(".") { h.removeLast() }
+        return h
+    }
+
+    /// For a full image reference (pull/push/run, the update checker, recreate) — Docker Hub
+    /// aliasing (`docker.io` → `registry-1.docker.io`) is already handled by `resolvedDomain`.
+    static func registryHost(for reference: String) -> String? {
+        guard let ref = try? Reference.parse(reference), let domain = ref.resolvedDomain else { return nil }
+        return foldedHost(domain)
+    }
+
+    /// For an already-isolated bare host (sign-in's `host` parameter, which the caller resolves
+    /// itself before this is ever relevant) — skips `Reference.parse`, which only detects a
+    /// domain when a `/` separates it from a path; a bare `"host:port"` string with no path
+    /// would otherwise misparse as an image name:tag pair with no domain at all.
+    static func foldedBareHost(_ host: String) -> String {
+        foldedHost(host)
+    }
+
+    /// Merge a newly-trusted host into the persisted array — dedupe via `Set`, sorted for a
+    /// stable, diffable `UserDefaults` value.
+    static func addingInsecureHost(_ host: String, to existing: [String]) -> [String] {
+        var set = Set(existing)
+        set.insert(host)
+        return Array(set).sorted()
+    }
+
+    static func isHostInsecure(reference: String, knownInsecureHosts: [String]) -> Bool {
+        guard let host = registryHost(for: reference) else { return false }
+        return knownInsecureHosts.contains(host)
+    }
+}

--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -148,6 +148,15 @@ final class LiveContainerService: ContainerServiceBase {
             daemonState = ContainerCompatibility.isCompatible(installed: installedVersion)
                 ? .connected
                 : .versionMismatch(installed: installedVersion, required: ContainerCompatibility.requiredVersion)
+            // Piggybacked here (not its own timer) so checks only happen while connected; the
+            // isCheckDue gate keeps the registry traffic at on-connect + every 6h, never per tick.
+            // The Settings toggle only gates this automatic path — manual checks (Images
+            // toolbar) and the recreate action always work regardless.
+            if case .connected = daemonState,
+               ImageStaleness.automaticCheckEnabled(userDefaultValue: UserDefaults.standard.object(forKey: "checkImagesForUpdates")),
+               ImageStaleness.isCheckDue(lastCheck: lastImageUpdateCheck, now: .now) {
+                Task { await checkForImageUpdates() }
+            }
         } catch {
             daemonState = .afterFailedPing(
                 isConnectionFailure: isXPCConnectionError(error),
@@ -826,6 +835,7 @@ final class LiveContainerService: ContainerServiceBase {
             id: snap.id,
             name: snap.id,
             image: image,
+            imageDigest: snap.configuration.image.digest,
             status: mapStatus(snap.status),
             ports: snap.configuration.publishedPorts.map {
                 PortMapping(host: Int($0.hostPort), container: Int($0.containerPort))
@@ -1824,6 +1834,9 @@ final class LiveContainerService: ContainerServiceBase {
         } catch let error as KeychainQuery.Error {
             throw Self.friendlyError(for: error, host: host) ?? error
         }
+        if insecure {
+            Self.rememberInsecureHost(ImageStaleness.foldedBareHost(host))
+        }
         await loadRegistries()
     }
 
@@ -1871,6 +1884,34 @@ final class LiveContainerService: ContainerServiceBase {
         try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 continuation.resume(with: Result { try registryKeychain.delete(hostname: hostname) })
+            }
+        }
+    }
+
+    /// Remembers `host` (already canonicalized by the caller via `ImageStaleness.registryHost`/
+    /// `foldedBareHost`) as one the user has explicitly told Berthly is insecure — so the
+    /// background update checker and recreate's own pull can use HTTP for it later without
+    /// re-asking. Deliberately **not** `nonisolated`: it inherits this class's `@MainActor`
+    /// isolation like every other instance-triggered write here, which statically guarantees no
+    /// two callers' read-merge-write of `UserDefaults` can interleave — MainActor code only
+    /// yields at `await`, and this function has none, so each call runs to completion before
+    /// anything else on MainActor can touch the key. UserDefaults itself needs no background-
+    /// queue offload the way Keychain does (no Security-framework IPC involved).
+    private static func rememberInsecureHost(_ host: String) {
+        let existing = UserDefaults.standard.stringArray(forKey: ImageStaleness.insecureHostsDefaultsKey) ?? []
+        UserDefaults.standard.set(ImageStaleness.addingInsecureHost(host, to: existing),
+                                  forKey: ImageStaleness.insecureHostsDefaultsKey)
+    }
+
+    /// Same offload as `keychainList`/`keychainSave`/`keychainDelete` — used by the background
+    /// image-update check, which runs several of these concurrently in a task group. Without the
+    /// offload, a slow Security-framework IPC or an ACL prompt would block the calling
+    /// cooperative-thread-pool thread, and with only a handful of threads in the pool, a few
+    /// concurrent private-registry checks could stall the whole pool indefinitely.
+    private nonisolated static func keychainLookup(hostname: String) async throws -> Authentication {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                continuation.resume(with: Result { try registryKeychain.lookup(hostname: hostname) })
             }
         }
     }
@@ -2486,6 +2527,10 @@ final class LiveContainerService: ContainerServiceBase {
         let createOptions = ContainerCreateOptions(autoRemove: options.remove)
         try await client.create(configuration: containerConfig, options: createOptions, kernel: kernel, initImage: initImage)
 
+        if options.insecureRegistry, let host = ImageStaleness.registryHost(for: options.reference) {
+            Self.rememberInsecureHost(host)
+        }
+
         if let cidFile = options.cidFile, !cidFile.isEmpty {
             FileManager.default.createFile(
                 atPath: cidFile,
@@ -2645,6 +2690,12 @@ final class LiveContainerService: ContainerServiceBase {
             throw error
         }
 
+        // A host's transport insecurity isn't tied to what you pulled from it — remember it here
+        // too so a later container pull/push against the same registry doesn't need re-asking.
+        if options.insecureRegistry, let host = ImageStaleness.registryHost(for: options.reference) {
+            Self.rememberInsecureHost(host)
+        }
+
         // From here on, a machine exists — checked cancellation points below (rather than just
         // relying on setDefault/bootMachineNatively's own awaits) mean a cancelled create doesn't
         // silently keep going through setDefault/boot; on cancellation the catch below deletes the
@@ -2731,7 +2782,227 @@ final class LiveContainerService: ContainerServiceBase {
         )
         onUnpacking?()
         try await image.unpack(platform: ociPlatform)
+        if insecure, let host = ImageStaleness.registryHost(for: reference) {
+            Self.rememberInsecureHost(host)
+        }
         await refresh()
+    }
+
+    override func isKnownInsecureRegistry(forReference reference: String) -> Bool {
+        let knownInsecureHosts = UserDefaults.standard.stringArray(forKey: ImageStaleness.insecureHostsDefaultsKey) ?? []
+        return ImageStaleness.isHostInsecure(reference: reference, knownInsecureHosts: knownInsecureHosts)
+    }
+
+    override func checkForImageUpdates(force: Bool = false) async {
+        guard isConnected, !isCheckingImageUpdates else { return }
+        if !force, !ImageStaleness.isCheckDue(lastCheck: lastImageUpdateCheck, now: .now) { return }
+        isCheckingImageUpdates = true
+        defer { isCheckingImageUpdates = false }
+        lastImageUpdateCheck = .now
+
+        let config = await resolvedSystemConfig()
+        let dnsDomain = config.dns.domain
+        // Credentials are attempted only for hosts with a stored login: a Keychain lookup for a
+        // never-signed-in host can still hit ACL prompts/errors, and anonymous works for public
+        // registries (RegistryClient runs the token flow itself).
+        let signedInHosts = Set(registries.map(\.host))
+        let knownInsecureHosts = Set(UserDefaults.standard.stringArray(forKey: ImageStaleness.insecureHostsDefaultsKey) ?? [])
+        let eligible = ImageStaleness.eligibleReferences(images: images)
+
+        var results: [String: ImageUpdateInfo] = [:]
+        await withTaskGroup(of: (String, ImageUpdateInfo)?.self) { group in
+            var iterator = eligible.makeIterator()
+            func addNext() {
+                guard let reference = iterator.next() else { return }
+                group.addTask {
+                    await Self.checkOneImageUpdate(reference: reference, signedInHosts: signedInHosts,
+                                                   knownInsecureHosts: knownInsecureHosts,
+                                                   internalDnsDomain: dnsDomain, systemConfig: config)
+                }
+            }
+            // Window of 4: enough parallelism to keep a large image list quick, small enough to
+            // not burst-hammer a single registry host.
+            for _ in 0..<4 { addNext() }
+            for await result in group {
+                if let (id, info) = result { results[id] = info }
+                addNext()
+            }
+        }
+        // A badge must be a *currently confirmable* claim: clear every reference this batch
+        // checked before merging, so a reference whose check failed loses its old verdict
+        // instead of pinning a stale "update available" indefinitely.
+        for reference in eligible { imageUpdateInfo[reference] = nil }
+        imageUpdateInfo.merge(results) { _, new in new }
+    }
+
+    /// One registry HEAD comparison. Returns `nil` on any failure — a background check must
+    /// never surface an error; a missing entry simply means no badge.
+    private nonisolated static func checkOneImageUpdate(
+        reference: String, signedInHosts: Set<String>, knownInsecureHosts: Set<String>,
+        internalDnsDomain: String?, systemConfig: ContainerSystemConfig
+    ) async -> (String, ImageUpdateInfo)? {
+        do {
+            let ref = try Reference.parse(reference)
+            guard let domain = ref.resolvedDomain, let tag = ref.tag else { return nil }
+            // The canonicalized lookup key (case/trailing-dot folded) is used only to consult
+            // the insecure-hosts memory — the raw `domain` still drives the actual connection,
+            // so this can't have any side effect on DNS/URL construction.
+            let isInsecure = knownInsecureHosts.contains(ImageStaleness.registryHost(for: reference) ?? domain)
+            let target = try resolveRegistryConnectionTarget(
+                host: domain, insecure: isInsecure, internalDnsDomain: internalDnsDomain
+            )
+            // try? on the lookup: a CLI-owned Keychain item Berthly can't read (see
+            // errSecInvalidOwnerEdit above) degrades to an anonymous check, not a failure.
+            // Offloaded (keychainLookup, not a direct registryKeychain.lookup call) — several of
+            // these run concurrently in checkForImageUpdates' task group, and the synchronous
+            // Security-framework call would otherwise tie up the cooperative thread pool.
+            let auth: Authentication? = signedInHosts.contains(domain)
+                ? try? await Self.keychainLookup(hostname: domain)
+                : nil
+            let client = RegistryClient(
+                host: target.host,
+                scheme: target.scheme.rawValue,
+                port: target.port,
+                authentication: auth,
+                retryOptions: RetryOptions(maxRetries: 1, retryInterval: 300_000_000, shouldRetry: { $0.status.code >= 500 })
+            )
+            let remote = try await client.resolve(name: ref.path, tag: tag)
+            let local = try await ClientImage.get(reference: reference, containerSystemConfig: systemConfig)
+            let comparable = ImageStaleness.comparableLocalDigest(ownDigest: local.digest, index: try await local.index())
+            return (reference, ImageUpdateInfo(
+                remoteDigest: remote.digest,
+                localImageDigest: local.digest,
+                isUpdateAvailable: remote.digest != comparable,
+                checkedAt: .now
+            ))
+        } catch {
+            return nil
+        }
+    }
+
+    /// The stored configuration pins the digest the container was *created* from — reusing it
+    /// verbatim would recreate the old container byte-for-byte. Everything else (id, mounts,
+    /// networks, DNS, resources, labels, init process) is already resolved and carries over.
+    nonisolated static func recreatedConfiguration(
+        from config: ContainerConfiguration, imageDescriptor: Descriptor
+    ) -> ContainerConfiguration {
+        var newConfig = config
+        newConfig.image = ImageDescription(reference: config.image.reference, descriptor: imageDescriptor)
+        return newConfig
+    }
+
+    override func recreateContainer(_ id: String, pullFirst: Bool, progress: ProgressUpdateHandler? = nil,
+                                    onPhase: @MainActor @escaping (RecreatePhase) -> Void) async throws -> RecreateResult {
+        let client = ContainerClient()
+        let snapshot = try await client.get(id: id)
+        let originalConfig = snapshot.configuration
+        let wasRunning = snapshot.status == .running
+        let reference = originalConfig.image.reference
+        let containerSystemConfig = await resolvedSystemConfig()
+
+        // Pull phase — the only cancellable window: nothing destructive has happened yet, and a
+        // pulled-but-unused image is harmless. Platform nil (all variants) so the stored digest
+        // stays an index digest, comparable to what checkForImageUpdates checks against.
+        // The same insecure-host lookup checkOneImageUpdate uses — without it, this pull has the
+        // identical hardcoded-.auto bug the checker had: a badge could correctly appear for a
+        // private HTTP registry, then this exact call would fail against it.
+        let knownInsecureHosts = UserDefaults.standard.stringArray(forKey: ImageStaleness.insecureHostsDefaultsKey) ?? []
+        let pullScheme: RequestScheme = ImageStaleness.isHostInsecure(reference: reference, knownInsecureHosts: knownInsecureHosts) ? .http : .auto
+        var didPull = false
+        if pullFirst, (try? Reference.parse(reference))?.domain != nil {
+            onPhase(.pullingImage)
+            let pulled = try await ClientImage.pull(reference: reference, platform: nil, scheme: pullScheme,
+                                                    containerSystemConfig: containerSystemConfig,
+                                                    progressUpdate: progress)
+            try await pulled.unpack(platform: nil)
+            didPull = true
+        }
+        try Task.checkCancellation()
+
+        let image = try await ClientImage.fetch(reference: reference, scheme: pullScheme, containerSystemConfig: containerSystemConfig)
+        _ = try await image.getCreateSnapshot(platform: originalConfig.platform)
+        let newConfig = Self.recreatedConfiguration(from: originalConfig, imageDescriptor: image.descriptor)
+        let kernel = try await ClientKernel.getDefaultKernel(for: .current)
+        let initImage = containerSystemConfig.vminit.image
+
+        // Last cancellation point: a cancel racing the fetch/kernel awaits above must land here,
+        // not mid-replacement — the XPC calls below don't reliably honor cancellation, so a
+        // cancel that slipped past would dismiss the sheet while the replacement continues.
+        try Task.checkCancellation()
+
+        // From here to the final start there are deliberately no cancellation checks: the old
+        // container is being replaced, and aborting between delete and create would strand the
+        // user with no container at all. The sheet only enables Cancel during the pull phase.
+        if wasRunning {
+            onPhase(.stoppingContainer)
+            try await client.stop(id: id)
+        }
+        onPhase(.deletingContainer)
+        do {
+            try await client.delete(id: id)
+        } catch let deleteError {
+            // `ContainerClient.delete` wraps every failure as `.internalError` with the real
+            // error buried in `cause`, so a notFound can't be matched directly. An --rm
+            // container deletes itself on stop (autoRemove isn't part of the snapshot, so it
+            // can't be detected up front — or preserved; the recreated container is plain);
+            // post-stop absence is therefore success here.
+            //
+            // The follow-up `get` must distinguish a *confirmed* absence from a failed lookup:
+            // `get` throws `.notFound` directly only when the container list came back empty —
+            // any other outcome (the container still exists, or the lookup itself failed —
+            // e.g. a transient XPC hiccup, which `list` wraps as `.internalError`) means absence
+            // was never established, so proceeding to `create` could collide with a container
+            // that's still there. Only a confirmed `.notFound` excuses the original delete error.
+            var confirmedAbsent = false
+            do {
+                _ = try await client.get(id: id)
+            } catch let lookupError as ContainerizationError where lookupError.isCode(.notFound) {
+                confirmedAbsent = true
+            } catch {
+                // Lookup itself failed (or threw some other error) — absence is unconfirmed.
+            }
+            guard confirmedAbsent else { throw deleteError }
+        }
+        onPhase(.creatingContainer)
+        do {
+            try await client.create(configuration: newConfig, options: .default, kernel: kernel, initImage: initImage)
+        } catch let createError {
+            // Roll back to the original configuration — its image blobs are guaranteed present
+            // (orphaned-blob GC only runs on explicit user request, after success).
+            let restored: Bool
+            do {
+                try await client.create(configuration: originalConfig, options: .default, kernel: kernel, initImage: initImage)
+                if wasRunning {
+                    let process = try await client.bootstrap(id: id, stdio: [nil, nil, nil])
+                    try await process.start()
+                }
+                restored = true
+            } catch {
+                restored = false
+            }
+            await refresh()
+            throw ContainerCLIError(exitCode: 1, message: restored
+                ? "Couldn't create the updated container: \(createError.localizedDescription) The previous container was restored."
+                : "Couldn't create the updated container: \(createError.localizedDescription) Restoring the previous container also failed — run it again manually from its image.")
+        }
+        if wasRunning {
+            onPhase(.startingContainer)
+            let process = try await client.bootstrap(id: id, stdio: [nil, nil, nil])
+            try await process.start()
+        }
+        await refresh()
+        return RecreateResult(wasRunning: wasRunning, didPull: didPull,
+                              oldImageDigest: originalConfig.image.digest, newImageDigest: image.digest)
+    }
+
+    override func reclaimOrphanedImageBlobs() async throws -> UInt64 {
+        // A same-tag re-pull *replaces* the reference in the image store, so there's no dangling
+        // image row to delete — the old version is just unreferenced blobs, and this is blob GC
+        // (the same call pruneImages finishes with), not an image delete.
+        let (_, blobBytes) = try await ClientImage.cleanUpOrphanedBlobs()
+        await refresh()
+        try? await fetchDiskUsage()
+        return blobBytes
     }
 
     override func pushImage(reference: String, destination: String? = nil, platform: String? = nil,
@@ -2772,6 +3043,9 @@ final class LiveContainerService: ContainerServiceBase {
                 containerSystemConfig: config,
                 progressUpdate: watchedProgress
             )
+        }
+        if insecure, let host = ImageStaleness.registryHost(for: destination ?? reference) {
+            Self.rememberInsecureHost(host)
         }
         // A retag created a new local reference — surface it in the list.
         await refresh()

--- a/Berthly/Core/MockContainerService.swift
+++ b/Berthly/Core/MockContainerService.swift
@@ -4,6 +4,20 @@
 import Foundation
 import TerminalProgress
 
+/// Mock-only: the runtime fields a lifecycle flip resets, in one place. Replaces four positional
+/// 15-argument `Container(...)` reconstructions that kept drifting as `Container` gained fields —
+/// three of them silently dropped `imageDigest` the day it was added.
+extension Container {
+    fileprivate func withRuntimeReset(status: ContainerStatus, imageDigest: String? = nil,
+                                      uptime: String = "–", startedDate: Date? = nil) -> Container {
+        Container(id: id, name: name, image: image, imageDigest: imageDigest ?? self.imageDigest,
+                  status: status, ports: ports, cpuPercent: 0, memoryMB: 0,
+                  memoryLimitMB: memoryLimitMB, networkIOString: "–", uptime: uptime,
+                  command: command, mounts: mounts, networks: networks, environment: environment,
+                  startedDate: startedDate)
+    }
+}
+
 @MainActor
 final class MockContainerService: ContainerServiceBase {
 
@@ -15,13 +29,13 @@ final class MockContainerService: ContainerServiceBase {
         // initializers would triple the section's height for no clarity gain.
         // swiftlint:disable line_length
         containers = [
-            Container(id: "3f9a2b7c1d", name: "web-frontend", image: "local/web:1.4", status: .running, ports: [PortMapping(host: 3000, container: 3000)], cpuPercent: 12, memoryMB: 184, memoryLimitMB: 1024, networkIOString: "1.2 MB/s", uptime: "2h 41m", command: #"nginx -g "daemon off;""#, mounts: [ContainerMount(source: "./src", destination: "/app")], networks: ["app-net"], environment: ["NODE_ENV=production", "PORT=3000", "API_URL=http://api-service:8080"], startedDate: Date().addingTimeInterval(-(2*3600 + 41*60))),
-            Container(id: "a17c44e9b2", name: "api-service", image: "local/api:2.1", status: .running, ports: [PortMapping(host: 8080, container: 8080)], cpuPercent: 34, memoryMB: 320, memoryLimitMB: 2048, networkIOString: "3.4 MB/s", uptime: "5h 12m", command: "node server.js", mounts: [], networks: ["app-net", "data-net"], environment: ["NODE_ENV=production"], startedDate: Date().addingTimeInterval(-(5*3600 + 12*60))),
-            Container(id: "c20e81f7a4", name: "datastore", image: "local/datastore:15", status: .running, ports: [PortMapping(host: 5432, container: 5432)], cpuPercent: 8, memoryMB: 512, memoryLimitMB: 1024, networkIOString: "0.8 MB/s", uptime: "1d 3h", command: "postgres", mounts: [], networks: ["data-net"], environment: [], startedDate: Date().addingTimeInterval(-(27*3600))),
-            Container(id: "7b3d09c5e1", name: "cache", image: "local/cache:7", status: .running, ports: [PortMapping(host: 6379, container: 6379)], cpuPercent: 2, memoryMB: 64, memoryLimitMB: 512, networkIOString: "0.2 MB/s", uptime: "1d 3h", command: "redis-server", mounts: [], networks: ["app-net"], environment: [], startedDate: Date().addingTimeInterval(-(27*3600))),
-            Container(id: "d4e5f6a7b8", name: "worker", image: "local/worker:1.0", status: .stopped, ports: [], cpuPercent: 0, memoryMB: 0, memoryLimitMB: 512, networkIOString: "–", uptime: "–", command: "python worker.py", mounts: [], networks: ["data-net"], environment: []),
-            Container(id: "b4c8d2e6f0", name: "edge-proxy", image: "local/proxy:1.25", status: .error, ports: [PortMapping(host: 80, container: 80), PortMapping(host: 443, container: 443)], cpuPercent: 0, memoryMB: 0, memoryLimitMB: 256, networkIOString: "–", uptime: "–", command: "nginx", mounts: [], networks: ["default"], environment: []),
-            Container(id: "1a2b3c4d5e", name: "sandbox", image: "local/base:latest", status: .paused, ports: [], cpuPercent: 0, memoryMB: 0, memoryLimitMB: 512, networkIOString: "–", uptime: "–", command: "/bin/bash", mounts: [], networks: [], environment: [])
+            Container(id: "3f9a2b7c1d", name: "web-frontend", image: "local/web:1.4", imageDigest: "sha256:3f9a2b7c1d", status: .running, ports: [PortMapping(host: 3000, container: 3000)], cpuPercent: 12, memoryMB: 184, memoryLimitMB: 1024, networkIOString: "1.2 MB/s", uptime: "2h 41m", command: #"nginx -g "daemon off;""#, mounts: [ContainerMount(source: "./src", destination: "/app")], networks: ["app-net"], environment: ["NODE_ENV=production", "PORT=3000", "API_URL=http://api-service:8080"], startedDate: Date().addingTimeInterval(-(2*3600 + 41*60))),
+            Container(id: "a17c44e9b2", name: "api-service", image: "local/api:2.1", imageDigest: "sha256:a17c44e9b2", status: .running, ports: [PortMapping(host: 8080, container: 8080)], cpuPercent: 34, memoryMB: 320, memoryLimitMB: 2048, networkIOString: "3.4 MB/s", uptime: "5h 12m", command: "node server.js", mounts: [], networks: ["app-net", "data-net"], environment: ["NODE_ENV=production"], startedDate: Date().addingTimeInterval(-(5*3600 + 12*60))),
+            Container(id: "c20e81f7a4", name: "datastore", image: "local/datastore:15", imageDigest: "sha256:00olddig00", status: .running, ports: [PortMapping(host: 5432, container: 5432)], cpuPercent: 8, memoryMB: 512, memoryLimitMB: 1024, networkIOString: "0.8 MB/s", uptime: "1d 3h", command: "postgres", mounts: [], networks: ["data-net"], environment: [], startedDate: Date().addingTimeInterval(-(27*3600))),
+            Container(id: "7b3d09c5e1", name: "cache", image: "local/cache:7", imageDigest: "sha256:7b3d09c5e1", status: .running, ports: [PortMapping(host: 6379, container: 6379)], cpuPercent: 2, memoryMB: 64, memoryLimitMB: 512, networkIOString: "0.2 MB/s", uptime: "1d 3h", command: "redis-server", mounts: [], networks: ["app-net"], environment: [], startedDate: Date().addingTimeInterval(-(27*3600))),
+            Container(id: "d4e5f6a7b8", name: "worker", image: "local/worker:1.0", imageDigest: "sha256:d4e5f6a7b8", status: .stopped, ports: [], cpuPercent: 0, memoryMB: 0, memoryLimitMB: 512, networkIOString: "–", uptime: "–", command: "python worker.py", mounts: [], networks: ["data-net"], environment: []),
+            Container(id: "b4c8d2e6f0", name: "edge-proxy", image: "local/proxy:1.25", imageDigest: "sha256:b4c8d2e6f0", status: .error, ports: [PortMapping(host: 80, container: 80), PortMapping(host: 443, container: 443)], cpuPercent: 0, memoryMB: 0, memoryLimitMB: 256, networkIOString: "–", uptime: "–", command: "nginx", mounts: [], networks: ["default"], environment: []),
+            Container(id: "1a2b3c4d5e", name: "sandbox", image: "local/base:latest", imageDigest: "sha256:1a2b3c4d5e", status: .paused, ports: [], cpuPercent: 0, memoryMB: 0, memoryLimitMB: 512, networkIOString: "–", uptime: "–", command: "/bin/bash", mounts: [], networks: [], environment: [])
         ]
         images = [
             ContainerImage(id: "local/web:1.4", repository: "local/web", tag: "1.4", digest: "sha256:3f9a2b7c1d", arch: ["arm64", "amd64"], sizeBytes: 182 * 1_048_576, created: "2h ago", source: .built, usage: .usedBy(3)),
@@ -62,6 +76,11 @@ final class MockContainerService: ContainerServiceBase {
             Registry(host: "ghcr.io", username: "apple-bot"),
             Registry(host: "registry-1.docker.io", username: "berthly")
         ]
+        // Two staleness fixtures without adding rows (UI perf tests count rows): `sandbox`'s
+        // image has a seeded remote update (badge on both the image row and the container row),
+        // and `datastore`'s imageDigest above lags its image (recreate-without-pull path).
+        imageUpdateInfo = ["local/base:latest": ImageUpdateInfo(remoteDigest: "sha256:feed5eed01", localImageDigest: "sha256:1a2b3c4d5e", isUpdateAvailable: true, checkedAt: Date())]
+        lastImageUpdateCheck = Date()
         imageInspectData = Self.mockInspectData()
         buildContexts = [
             "local/web:1.4": BuildContext(contextPath: "/Users/dev/projects/web", dockerfilePath: nil),
@@ -104,23 +123,13 @@ final class MockContainerService: ContainerServiceBase {
         // while these are in flight, which an instant flip would make invisible in mock mode.
         try? await Task.sleep(for: .milliseconds(600))
         guard let i = containers.firstIndex(where: { $0.id == id }) else { return }
-        let c = containers[i]
-        containers[i] = Container(id: c.id, name: c.name, image: c.image, status: .running,
-                                  ports: c.ports, cpuPercent: 0, memoryMB: 0,
-                                  memoryLimitMB: c.memoryLimitMB, networkIOString: "–", uptime: "0m",
-                                  command: c.command, mounts: c.mounts, networks: c.networks,
-                                  environment: c.environment)
+        containers[i] = containers[i].withRuntimeReset(status: .running, uptime: "0m")
     }
 
     override func stopContainer(_ id: String) async throws {
         try? await Task.sleep(for: .milliseconds(600))
         guard let i = containers.firstIndex(where: { $0.id == id }) else { return }
-        let c = containers[i]
-        containers[i] = Container(id: c.id, name: c.name, image: c.image, status: .stopped,
-                                  ports: c.ports, cpuPercent: 0, memoryMB: 0,
-                                  memoryLimitMB: c.memoryLimitMB, networkIOString: "–", uptime: "–",
-                                  command: c.command, mounts: c.mounts, networks: c.networks,
-                                  environment: c.environment)
+        containers[i] = containers[i].withRuntimeReset(status: .stopped)
     }
 
     override func restartContainer(_ id: String) async throws {
@@ -131,17 +140,86 @@ final class MockContainerService: ContainerServiceBase {
     override func killContainer(_ id: String) async throws {
         // No simulated latency, unlike stopContainer: SIGKILL is immediate — that's its point.
         guard let i = containers.firstIndex(where: { $0.id == id }) else { return }
-        let c = containers[i]
-        containers[i] = Container(id: c.id, name: c.name, image: c.image, status: .stopped,
-                                  ports: c.ports, cpuPercent: 0, memoryMB: 0,
-                                  memoryLimitMB: c.memoryLimitMB, networkIOString: "–", uptime: "–",
-                                  command: c.command, mounts: c.mounts, networks: c.networks,
-                                  environment: c.environment)
+        containers[i] = containers[i].withRuntimeReset(status: .stopped)
     }
 
     override func deleteContainer(_ id: String) async throws {
         containers.removeAll { $0.id == id }
         pinnedContainerIDs.remove(id)
+    }
+
+    override func checkForImageUpdates(force: Bool = false) async {
+        guard !isCheckingImageUpdates else { return }
+        isCheckingImageUpdates = true
+        // Long enough for the toolbar spinner to be visible (and waitable in UI tests).
+        try? await Task.sleep(for: .milliseconds(300))
+        isCheckingImageUpdates = false
+        lastImageUpdateCheck = Date()
+        // Re-assert the seeded verdict: in mock mode the registry always says what init said.
+        if let base = images.first(where: { $0.id == "local/base:latest" }) {
+            imageUpdateInfo["local/base:latest"] = ImageUpdateInfo(
+                remoteDigest: "sha256:feed5eed01", localImageDigest: base.digest,
+                isUpdateAvailable: base.digest != "sha256:feed5eed01", checkedAt: Date()
+            )
+        }
+    }
+
+    override func recreateContainer(_ id: String, pullFirst: Bool, progress: ProgressUpdateHandler? = nil,
+                                    onPhase: @MainActor @escaping (RecreatePhase) -> Void) async throws -> RecreateResult {
+        guard let index = containers.firstIndex(where: { $0.id == id }) else {
+            throw ContainerCLIError(exitCode: 1, message: "container \(id) not found")
+        }
+        let container = containers[index]
+        let wasRunning = container.status == .running
+        let oldDigest = container.imageDigest ?? ""
+
+        // Pull only when the registry actually has something newer — mirroring the live gate,
+        // and modeling what a same-tag re-pull really does: *replace* the reference's digest
+        // (unlike mock pullImage, which appends a row for a brand-new reference).
+        var didPull = false
+        if pullFirst, staleness(of: container) == .remoteUpdateAvailable,
+           let imageIndex = images.firstIndex(where: { $0.id == container.image || $0.fullName == container.image }) {
+            onPhase(.pullingImage)
+            let old = images[imageIndex]
+            await progress?([.addTotalItems(4), .addTotalSize(old.sizeBytes)])
+            for _ in 0..<4 {
+                try await Task.sleep(for: .milliseconds(200))
+                try Task.checkCancellation()
+                await progress?([.addItems(1), .addSize(old.sizeBytes / 4)])
+            }
+            let remoteDigest = imageUpdateInfo[old.id]?.remoteDigest ?? "sha256:\(UUID().uuidString.prefix(12).lowercased())"
+            images[imageIndex] = ContainerImage(id: old.id, repository: old.repository, tag: old.tag,
+                                                digest: remoteDigest, arch: old.arch, sizeBytes: old.sizeBytes,
+                                                created: "just now", source: old.source, usage: old.usage)
+            imageUpdateInfo[old.id] = ImageUpdateInfo(remoteDigest: remoteDigest, localImageDigest: remoteDigest,
+                                                      isUpdateAvailable: false, checkedAt: Date())
+            didPull = true
+        }
+        try Task.checkCancellation()
+
+        // No cancellation checks past this point — same replace-window semantics as the live
+        // service, so the sheet's cancel-gating is exercised honestly in mock mode.
+        let steps: [RecreatePhase] = wasRunning
+            ? [.stoppingContainer, .deletingContainer, .creatingContainer, .startingContainer]
+            : [.deletingContainer, .creatingContainer]
+        for step in steps {
+            onPhase(step)
+            try? await Task.sleep(for: .milliseconds(150))
+        }
+        let newDigest = images.first { $0.id == container.image || $0.fullName == container.image }?.digest ?? oldDigest
+        // A non-running container lands stopped regardless of what it was (paused/error state
+        // doesn't survive being replaced by a fresh container).
+        containers[index] = container.withRuntimeReset(status: wasRunning ? .running : .stopped,
+                                                       imageDigest: newDigest,
+                                                       uptime: wasRunning ? "0m" : "–",
+                                                       startedDate: wasRunning ? Date() : nil)
+        return RecreateResult(wasRunning: wasRunning, didPull: didPull,
+                              oldImageDigest: oldDigest, newImageDigest: newDigest)
+    }
+
+    override func reclaimOrphanedImageBlobs() async throws -> UInt64 {
+        try? await Task.sleep(for: .milliseconds(200))
+        return 96 * 1_048_576
     }
 
     // Records the arguments of the last copy so tests and previews can assert what the UI asked
@@ -498,6 +576,7 @@ final class MockContainerService: ContainerServiceBase {
             id: id,
             name: id,
             image: options.reference,
+            imageDigest: images.first { $0.id == options.reference || $0.fullName == options.reference }?.digest,
             status: isRunning ? .running : .stopped,
             ports: ports,
             cpuPercent: 0,

--- a/Berthly/Core/MockContainerService.swift
+++ b/Berthly/Core/MockContainerService.swift
@@ -198,13 +198,17 @@ final class MockContainerService: ContainerServiceBase {
         try Task.checkCancellation()
 
         // No cancellation checks past this point — same replace-window semantics as the live
-        // service, so the sheet's cancel-gating is exercised honestly in mock mode.
+        // service, so the sheet's cancel-gating is exercised honestly in mock mode. 1200ms/step
+        // (not the original 150ms): a CI run of testRecreatePullPhaseDisablesCancelInReplaceWindow
+        // showed ~1s+ per accessibility-tree query round-trip on the runner, longer than the old
+        // 600ms total replace window — the whole flow could finish before a single poll caught it
+        // still in progress, so `cancel.exists` (checked with no retry) saw the sheet already done.
         let steps: [RecreatePhase] = wasRunning
             ? [.stoppingContainer, .deletingContainer, .creatingContainer, .startingContainer]
             : [.deletingContainer, .creatingContainer]
         for step in steps {
             onPhase(step)
-            try? await Task.sleep(for: .milliseconds(150))
+            try? await Task.sleep(for: .milliseconds(1200))
         }
         let newDigest = images.first { $0.id == container.image || $0.fullName == container.image }?.digest ?? oldDigest
         // A non-running container lands stopped regardless of what it was (paused/error state

--- a/Berthly/Core/Models.swift
+++ b/Berthly/Core/Models.swift
@@ -66,6 +66,10 @@ struct Container: Identifiable, Hashable {
     let id: String
     let name: String
     let image: String
+    /// The content digest the container was created from (`configuration.image.descriptor`) —
+    /// what staleness compares against the tag's current local image. Defaulted so the many
+    /// fixture call sites don't all name it.
+    var imageDigest: String?
     let status: ContainerStatus
     let ports: [PortMapping]
     let cpuPercent: Double
@@ -79,9 +83,13 @@ struct Container: Identifiable, Hashable {
     let environment: [String]
     var startedDate: Date?
 
-    // Include status and image so SwiftUI detects section changes and late-arriving image data.
+    // Include status and image so SwiftUI detects section changes and late-arriving image data,
+    // and imageDigest because a recreate changes the digest while status and image stay equal —
+    // rows take Container by value from ForEach, so a narrower == freezes their staleness badge.
     // Hash by id only for stable Set membership across status/image transitions.
-    static func == (lhs: Self, rhs: Self) -> Bool { lhs.id == rhs.id && lhs.status == rhs.status && lhs.image == rhs.image }
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.id == rhs.id && lhs.status == rhs.status && lhs.image == rhs.image && lhs.imageDigest == rhs.imageDigest
+    }
     func hash(into hasher: inout Hasher) { hasher.combine(id) }
 
     var portsDisplayString: String {
@@ -93,9 +101,12 @@ struct Container: Identifiable, Hashable {
 
 // MARK: - Image
 
-enum ImageSource { case built, pulled }
+// `nonisolated`: read by `ImageStaleness.eligibleReferences`, a nonisolated pure function —
+// without it, their derived `Equatable` is MainActor-isolated under this module's default
+// isolation and a nonisolated caller warns (error under Swift 6 mode).
+nonisolated enum ImageSource { case built, pulled }
 
-enum ImageUsage: Equatable {
+nonisolated enum ImageUsage: Equatable {
     case usedBy(Int)
     case unused
     case builderImage
@@ -148,7 +159,13 @@ struct ContainerImage: Identifiable, Hashable {
 
     // Include usage so SwiftUI detects the row's UsageBadge needing to redraw when a container
     // starts/stops using this image — same class of fix as Container/Machine/Builder/Network.
-    static func == (lhs: Self, rhs: Self) -> Bool { lhs.id == rhs.id && lhs.usage == rhs.usage }
+    // Also include digest: a real-daemon E2E investigation (2026-07-20) found that after a
+    // same-reference re-pull (Pull Latest) changes `digest` alone, ForEach — which diffs
+    // ContainerImage by value even though ImageRow re-resolves the model live by id — considered
+    // the row unchanged and never re-invoked its body, so imageUpdateBadge silently never
+    // cleared. A prior investigation had called Image immune to this bug class, but that
+    // predates the update-badge feature: nothing rendered depended on digest alone until now.
+    static func == (lhs: Self, rhs: Self) -> Bool { lhs.id == rhs.id && lhs.usage == rhs.usage && lhs.digest == rhs.digest }
     func hash(into hasher: inout Hasher) { hasher.combine(id) }
 }
 
@@ -193,6 +210,62 @@ extension ContainerImage {
             )
         }
     }
+}
+
+// MARK: - Image updates (Watchtower-style)
+
+/// Result of one remote registry digest check, keyed in the service by `ContainerImage.id`.
+nonisolated struct ImageUpdateInfo: Equatable {
+    let remoteDigest: String
+    /// The local digest the check was computed against — the invalidation key: once the image's
+    /// digest moves (pull/rebuild), this info describes bytes that no longer exist locally and
+    /// `ImageStaleness.availability` reports `.unknown` instead of a stale verdict.
+    let localImageDigest: String
+    let isUpdateAvailable: Bool
+    let checkedAt: Date
+}
+
+nonisolated enum ImageUpdateAvailability: Equatable { case unknown, upToDate, updateAvailable }
+
+/// Why a container lags its image tag — drives the badge's help text and the recreate sheet's
+/// context line.
+nonisolated enum ContainerImageStaleness: Equatable {
+    case current
+    /// The tag's local image is newer than the container's pinned digest (pulled, not recreated).
+    case localImageNewer
+    /// The registry has a newer digest for the tag than the local image.
+    case remoteUpdateAvailable
+}
+
+/// Recreate progress steps, reported to the sheet via `onPhase`. Everything from
+/// `.stoppingContainer` on is the non-cancellable window (the old container is being replaced),
+/// which the sheet uses to disable its Cancel button.
+nonisolated enum RecreatePhase: Equatable {
+    case pullingImage, stoppingContainer, deletingContainer, creatingContainer, startingContainer
+
+    /// `LocalizedStringResource`, not `String` (matching `ContainerImage.deleteWarning`'s
+    /// precedent) — this feeds `Text(phase.logLine)` directly as the visible phase caption, and
+    /// `Text(String)` never consults the string catalog at runtime even if the literal is
+    /// extracted into it, so a plain `String` here would silently never localize.
+    var logLine: LocalizedStringResource {
+        switch self {
+        case .pullingImage:      return "Pulling latest image…"
+        case .stoppingContainer: return "Stopping container…"
+        case .deletingContainer: return "Removing old container…"
+        case .creatingContainer: return "Creating container from new image…"
+        case .startingContainer: return "Starting container…"
+        }
+    }
+}
+
+nonisolated struct RecreateResult: Equatable {
+    let wasRunning: Bool
+    let didPull: Bool
+    let oldImageDigest: String
+    let newImageDigest: String
+    /// Whether the recreate actually moved to different bytes — only then does the success UI
+    /// offer to reclaim the old digest's now-orphaned blobs.
+    var oldImageReclaimable: Bool { oldImageDigest != newImageDigest }
 }
 
 /// Outcome of loading an OCI tar archive: one archive can carry several images, and the client

--- a/Berthly/Localizable.xcstrings
+++ b/Berthly/Localizable.xcstrings
@@ -22,6 +22,9 @@
     "/app" : {
 
     },
+    "%@" : {
+
+    },
     "%@ · %@" : {
       "localizations" : {
         "en" : {
@@ -53,6 +56,9 @@
       }
     },
     "%@ is running — changes take effect after you stop and start it." : {
+
+    },
+    "%@ will be stopped, recreated, and started again." : {
 
     },
     "%@, %@" : {
@@ -133,6 +139,18 @@
 
     },
     "A NAT or host-only network for containers" : {
+
+    },
+    "A newer image is available for this tag — it will be pulled first." : {
+
+    },
+    "A newer image is published for %@" : {
+
+    },
+    "A newer image was already pulled — the container will be recreated from it." : {
+
+    },
+    "A newer image was pulled — recreate the container to apply it" : {
 
     },
     "A vmlinux binary already on disk." : {
@@ -288,7 +306,13 @@
     "Changes take effect the next time the machine boots." : {
 
     },
+    "Check for Updates" : {
+
+    },
     "Check for Updates…" : {
+
+    },
+    "Check images for updates" : {
 
     },
     "Choose a folder…" : {
@@ -361,6 +385,9 @@
 
     },
     "Container Not Installed" : {
+
+    },
+    "Container recreated" : {
 
     },
     "Container System Stopped" : {
@@ -451,6 +478,9 @@
 
     },
     "Creates an additional name for this image" : {
+
+    },
+    "Creating container from new image…" : {
 
     },
     "Creating…" : {
@@ -669,6 +699,9 @@
     "Forward SSH agent" : {
 
     },
+    "Freed %@" : {
+
+    },
     "General" : {
 
     },
@@ -715,6 +748,9 @@
 
     },
     "Image tagged" : {
+
+    },
+    "Image Updates" : {
 
     },
     "Images" : {
@@ -970,6 +1006,9 @@
     "Path" : {
 
     },
+    "Periodically compares your pulled images against their registries and badges the ones with a newer version. You can always check manually from the Images page." : {
+
+    },
     "Pin" : {
 
     },
@@ -1015,6 +1054,9 @@
     "Pull Image…" : {
 
     },
+    "Pull Latest" : {
+
+    },
     "Pull latest base images" : {
 
     },
@@ -1022,6 +1064,12 @@
 
     },
     "Pulling image" : {
+
+    },
+    "Pulling latest image" : {
+
+    },
+    "Pulling latest image…" : {
 
     },
     "Pulls from Docker Hub or any public registry — no sign-in" : {
@@ -1049,6 +1097,24 @@
 
     },
     "Rebuild" : {
+
+    },
+    "Reclaim Old Image Space" : {
+
+    },
+    "Reclaiming…" : {
+
+    },
+    "Recreate" : {
+
+    },
+    "Recreate %@" : {
+
+    },
+    "Recreate with Latest Image…" : {
+
+    },
+    "Recreating…" : {
 
     },
     "Refresh" : {
@@ -1088,6 +1154,12 @@
 
     },
     "Removes unused images and stopped containers in one step. Volumes are never touched here — use the Volumes row's own Prune if you're sure you don't need their data." : {
+
+    },
+    "Removing old container…" : {
+
+    },
+    "Replacing the container — this step can't be cancelled." : {
 
     },
     "Required" : {
@@ -1286,6 +1358,9 @@
     "Start the container to copy files" : {
 
     },
+    "Starting container…" : {
+
+    },
     "Start the container to open a shell." : {
 
     },
@@ -1317,6 +1392,9 @@
 
     },
     "Stop the container daemon?" : {
+
+    },
+    "Stopping container…" : {
 
     },
     "Stop the container first" : {
@@ -1391,10 +1469,16 @@
     "The container daemon is installed but not running." : {
 
     },
+    "The container is deleted and recreated from its image. Changes inside the container's own filesystem are discarded. Data on volumes is kept." : {
+
+    },
     "The default network can't be deleted" : {
 
     },
     "The exact vminit and builder image versions this install of Berthly is built against — these must match what the installed container CLI expects." : {
+
+    },
+    "The image is up to date — this recreates the container in a fresh state." : {
 
     },
     "The installed container (v%@) is newer than this version of Berthly supports (v%@).\nUpdate Berthly to keep using it — your container installation won't be touched." : {
@@ -1408,6 +1492,9 @@
       }
     },
     "The log stream ended unexpectedly — the daemon connection may have been lost." : {
+
+    },
+    "The previous image version is no longer used." : {
 
     },
     "This can't be undone." : {
@@ -1489,7 +1576,13 @@
     "Unused" : {
 
     },
+    "update" : {
+
+    },
     "Update" : {
+
+    },
+    "Update available — pull and recreate to apply it" : {
 
     },
     "Update Berthly" : {

--- a/Berthly/Views/ComputeListView.swift
+++ b/Berthly/Views/ComputeListView.swift
@@ -182,6 +182,7 @@ private struct ContainerComputeRow: View {
     @State private var isDeleting = false
     @State private var isWorking = false
     @State private var errorMessage: String?
+    @State private var showRecreateSheet = false
 
     private var isRunning: Bool { container.status == .running }
 
@@ -199,11 +200,15 @@ private struct ContainerComputeRow: View {
                     // Unambiguous handle for the sidebar row (E2E lifecycle journey): the
                     // detail view shows the same name, so tests can't query by text alone.
                     .accessibilityIdentifier("computeRow-\(container.name)")
-                Text(container.image)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fontDesign(.monospaced)
-                    .lineLimit(1)
+                HStack(spacing: 4) {
+                    Text(container.image)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fontDesign(.monospaced)
+                        .lineLimit(1)
+                    ContainerStalenessGlyph(staleness: service.staleness(of: container),
+                                            containerName: container.name)
+                }
             }
 
             Spacer()
@@ -274,6 +279,9 @@ private struct ContainerComputeRow: View {
             // otherwise, so the capability stays discoverable with the gate implied.
             Button("Export Filesystem…") { exportFilesystem() }
                 .disabled(container.status != .stopped)
+            // Always enabled, not just when the badge shows: with no update it's the
+            // "reset to a fresh container" action, which is just as legitimate.
+            Button("Recreate with Latest Image…") { showRecreateSheet = true }
             Divider()
             // No accessibilityIdentifier: it doesn't survive the SwiftUI→NSMenu bridge for
             // context-menu items — tests query menuItems["Delete…"] by label instead.
@@ -295,6 +303,9 @@ private struct ContainerComputeRow: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This can't be undone.")
+        }
+        .sheet(isPresented: $showRecreateSheet) {
+            RecreateContainerSheet(container: container)
         }
         .errorAlert($errorMessage)
     }

--- a/Berthly/Views/ContainerDetailView.swift
+++ b/Berthly/Views/ContainerDetailView.swift
@@ -32,6 +32,7 @@ private struct ContainerDetailContent: View {
     @State private var isWorking    = false
     @State private var errorMessage: String?
     @State private var showCopySheet     = false
+    @State private var showRecreateSheet = false
 
     // Reads directly from service so every `container.xxx` access in body/computed-props
     // is tracked by @Observable — re-renders immediately when status/stats change.
@@ -88,6 +89,9 @@ private struct ContainerDetailContent: View {
         .sheet(isPresented: $showCopySheet) {
             CopyFilesSheet(service: service, containerID: container.id, targetName: container.name)
         }
+        .sheet(isPresented: $showRecreateSheet) {
+            RecreateContainerSheet(container: container)
+        }
         // Palette "Open Shell" routing. `.onChange` covers the already-selected container;
         // `.onAppear` covers the usual case where selecting this container mounts the view fresh
         // (with the request already set), which `.onChange` would miss.
@@ -120,11 +124,15 @@ private struct ContainerDetailContent: View {
                         .lineLimit(1)
                     StatusBadge(status: container.status)
                 }
-                Text(container.image)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fontDesign(.monospaced)
-                    .lineLimit(1)
+                HStack(spacing: 4) {
+                    Text(container.image)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fontDesign(.monospaced)
+                        .lineLimit(1)
+                    ContainerStalenessGlyph(staleness: service.staleness(of: container),
+                                            containerName: container.name)
+                }
             }
             .layoutPriority(1)
             Spacer(minLength: 8)
@@ -135,6 +143,14 @@ private struct ContainerDetailContent: View {
             }
             .buttonStyle(.bordered)
             .help(service.isContainerPinned(container.id) ? "Unpin" : "Pin")
+            .hoverScale()
+
+            Button { showRecreateSheet = true } label: {
+                Image(systemName: "arrow.triangle.2.circlepath")
+            }
+            .buttonStyle(.bordered)
+            .accessibilityIdentifier("containerRecreateButton")
+            .help("Recreate with Latest Image…")
             .hoverScale()
 
             Button { showCopySheet = true } label: {
@@ -298,6 +314,9 @@ private struct InspectSection: View {
         return [
             ("Status", "\(container.status.label)\(container.status == .running ? " · up \(container.uptime)" : "")"),
             ("Image", container.image),
+            // Makes staleness legible: this is the digest the container was created from, which
+            // the badge compares against the tag's current local image.
+            ("Image digest", container.imageDigest ?? "–"),
             ("Container ID", container.id),
             ("Command", container.command),
             ("Ports", container.ports.isEmpty ? "–" : container.ports.map(\.displayString).joined(separator: ", ")),
@@ -322,7 +341,7 @@ private struct InspectSection: View {
                             .foregroundStyle(.secondary)
                             .frame(width: 120, alignment: .leading)
                         Text(val)
-                            .fontDesign(["Container ID", "Command", "Ports", "Mounts"].contains(key) ? .monospaced : .default)
+                            .fontDesign(["Image digest", "Container ID", "Command", "Ports", "Mounts"].contains(key) ? .monospaced : .default)
                             .textSelection(.enabled)
                         Spacer()
                     }

--- a/Berthly/Views/ImagesListView.swift
+++ b/Berthly/Views/ImagesListView.swift
@@ -115,6 +115,17 @@ struct ImagesListView: View {
         // that frees it belongs here too, not only in System > Disk Usage.
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
+                if service.isCheckingImageUpdates {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Button("Check for Updates") {
+                        Task { await service.checkForImageUpdates(force: true) }
+                    }
+                    .help(checkForUpdatesHelp)
+                    .accessibilityIdentifier("checkImageUpdatesButton")
+                }
+            }
+            ToolbarItem(placement: .primaryAction) {
                 if isPruning {
                     ProgressView().controlSize(.small)
                 } else {
@@ -154,6 +165,13 @@ struct ImagesListView: View {
 
     private var deleteTarget: ContainerImage? {
         service.images.first(where: { $0.id == deleteTargetID })
+    }
+
+    private var checkForUpdatesHelp: String {
+        guard let last = service.lastImageUpdateCheck else {
+            return "Compare local images against their registries"
+        }
+        return "Compare local images against their registries (last checked \(last.formatted(.relative(presentation: .named))))"
     }
 
     private var deleteConfirmTitle: String {
@@ -205,10 +223,15 @@ private struct ImageRow: View {
     @State private var errorMessage: String?
     @State private var showRunSheet = false
     @State private var showTagSheet = false
+    @State private var showPullSheet = false
     @State private var saveRequest: ImageSaveRequest?
 
     private var image: ContainerImage? {
         service.images.first(where: { $0.id == imageID })
+    }
+
+    private var hasUpdate: Bool {
+        image.map { service.updateAvailability(for: $0) == .updateAvailable } ?? false
     }
 
     var body: some View {
@@ -238,12 +261,23 @@ private struct ImageRow: View {
                                 .foregroundStyle(.tertiary)
                         }
                         UsageBadge(usage: image.usage)
+                        if hasUpdate {
+                            UpdateAvailableBadge(image: image)
+                        }
                     }
                 }
 
                 Spacer()
 
                 if isHovered {
+                    if hasUpdate {
+                        Button { showPullSheet = true } label: {
+                            Image(systemName: "arrow.down.circle")
+                        }
+                        .buttonStyle(.hoverIcon)
+                        .help("Pull Latest")
+                        .accessibilityLabel("Pull Latest")
+                    }
                     Button { showRunSheet = true } label: {
                         Image(systemName: "play.fill")
                     }
@@ -273,6 +307,9 @@ private struct ImageRow: View {
             .onHover { isHovered = $0 }
             .contextMenu {
                 Button("Run from This Image…") { showRunSheet = true }
+                if hasUpdate {
+                    Button("Pull Latest") { showPullSheet = true }
+                }
                 Divider()
                 Button("Tag…") { showTagSheet = true }
                 Button("Save to Disk…") {
@@ -301,6 +338,10 @@ private struct ImageRow: View {
             }
             .sheet(isPresented: $showRunSheet) {
                 RunContainerSheet(service: service, initialReference: image.fullName)
+            }
+            .sheet(isPresented: $showPullSheet) {
+                PullImageSheet(initialReference: image.fullName,
+                              initiallyInsecure: service.isKnownInsecureRegistry(forReference: image.fullName))
             }
             .sheet(isPresented: $showTagSheet) {
                 TagImageSheet(image: image)

--- a/Berthly/Views/PullImageSheet.swift
+++ b/Berthly/Views/PullImageSheet.swift
@@ -22,6 +22,12 @@ struct PullImageSheet: View {
     @State private var pullProgress = TransferProgressState.pull()
     @State private var pullTask: Task<Void, Never>?
 
+    init(initialReference: String = "", initiallyInsecure: Bool = false, onOpenRegistries: @escaping () -> Void = {}) {
+        self.onOpenRegistries = onOpenRegistries
+        _reference = State(initialValue: initialReference)
+        _allowInsecure = State(initialValue: initiallyInsecure)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             SheetHeader(

--- a/Berthly/Views/RecreateContainerSheet.swift
+++ b/Berthly/Views/RecreateContainerSheet.swift
@@ -1,0 +1,252 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import SwiftUI
+
+// MARK: - Recreate Container Sheet
+
+/// Watchtower-style update flow: pull the container's tag (when the registry has something
+/// newer), then stop/delete/recreate it from its stored configuration and restore the prior run
+/// state. Modeled on `PullImageSheet` (idle → working → done in one frame) because the pull is
+/// the dominant-duration phase; the recreate steps append to the same log as `STEP` lines.
+struct RecreateContainerSheet: View {
+    let container: Container
+
+    @Environment(ContainerServiceBase.self) private var service
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var phase: RecreatePhase?
+    @State private var isWorking = false
+    @State private var isDone = false
+    @State private var result: RecreateResult?
+    @State private var errorMessage: String?
+    @State private var progress = TransferProgressState.pull()
+    @State private var recreateTask: Task<Void, Never>?
+    @State private var reclaim: ReclaimPhase = .idle
+
+    private enum ReclaimPhase: Equatable { case idle, working, freed(UInt64) }
+
+    /// Only the pull phase is cancellable. `phase == nil` while working must NOT qualify: in the
+    /// no-pull path the service runs several awaits before its first phase report, and a cancel
+    /// landing there would dismiss the sheet while XPC calls that ignore cancellation continue
+    /// replacing the container behind it (the service double-checks cancellation right before
+    /// its replace window, but the button shouldn't invite the race at all).
+    private var canCancel: Bool { phase == .pullingImage }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            SheetHeader(
+                systemImage: "arrow.triangle.2.circlepath",
+                title: "Recreate \(container.name)",
+                subtitle: "\(container.image)"
+            )
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 14) {
+                if isWorking || isDone {
+                    activeContent
+                } else {
+                    idleContent
+                }
+                if let error = errorMessage {
+                    Text(error).font(.caption).foregroundStyle(.red).lineLimit(3)
+                }
+            }
+            .padding(20)
+
+            Divider()
+
+            SheetSubmitFooter(
+                phase: isDone ? .done : (isWorking ? .working : .idle),
+                submitLabel: "Recreate",
+                busyLabel: "Recreating…",
+                submitIdentifier: "recreateSubmitButton",
+                onCancel: cancelRecreate,
+                workingCancelDisabledHelp: canCancel ? nil : "Replacing the container — this step can't be cancelled.",
+                onSubmit: startRecreate
+            )
+        }
+        .frame(width: 480)
+        // The replace window must finish even if the sheet goes away mid-flight — only an
+        // explicit Cancel during the pull phase stops the task.
+        .interactiveDismissDisabled(isWorking)
+    }
+
+    // MARK: - Idle (confirm)
+
+    @ViewBuilder
+    private var idleContent: some View {
+        SheetCallout(tint: .statusPaused) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(Color.statusPaused)
+                    .imageScale(.small)
+                    .padding(.top, 1)
+                Text("""
+                The container is deleted and recreated from its image. Changes inside the \
+                container's own filesystem are discarded. Data on volumes is kept. If \
+                "Remove when stopped" was enabled, that setting cannot be preserved by recreation.
+                """)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+
+        VStack(alignment: .leading, spacing: 4) {
+            Text(stalenessContext)
+                .fixedSize(horizontal: false, vertical: true)
+            if container.status == .running {
+                Text("\(container.name) will be stopped, recreated, and started again.")
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+
+    private var stalenessContext: LocalizedStringKey {
+        switch service.staleness(of: container) {
+        case .remoteUpdateAvailable:
+            return "A newer image is available for this tag — it will be pulled first."
+        case .localImageNewer:
+            return "A newer image was already pulled — the container will be recreated from it."
+        case .current:
+            return "The image is up to date — this recreates the container in a fresh state."
+        }
+    }
+
+    // MARK: - Working / done
+
+    @ViewBuilder
+    private var activeContent: some View {
+        if isWorking, phase == .pullingImage {
+            TransferProgressHeader(title: "Pulling latest image", progress: progress)
+        }
+        if isWorking, let phase {
+            Text(phase.logLine)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .accessibilityIdentifier("recreatePhaseLabel")
+        }
+
+        TransferLogView(lines: progress.logLines)
+
+        if isDone, let result {
+            SheetStatusCallout(symbol: "checkmark.circle.fill", tint: .green, title: "Container recreated", alignment: .center) {
+                SheetCalloutDetail(
+                    text: result.wasRunning
+                        ? "\(container.name) is running on the updated image."
+                        : "\(container.name) was recreated and left stopped.",
+                    monospaced: false
+                )
+            }
+            if result.oldImageReclaimable {
+                reclaimRow
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var reclaimRow: some View {
+        switch reclaim {
+        case .idle:
+            HStack(spacing: 8) {
+                Button("Reclaim Old Image Space") { performReclaim() }
+                    .accessibilityIdentifier("reclaimOldImageButton")
+                Text("The previous image version is no longer used.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        case .working:
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text("Reclaiming…").font(.caption).foregroundStyle(.secondary)
+            }
+        case .freed(let bytes):
+            Label("Freed \(formatDiskBytes(bytes))", systemImage: "checkmark.circle")
+                .font(.caption)
+                .foregroundStyle(.green)
+                .accessibilityIdentifier("reclaimFreedLabel")
+        }
+    }
+
+    // MARK: - Actions
+
+    private func startRecreate() {
+        guard !isWorking else { return }
+        isWorking = true
+        isDone = false
+        errorMessage = nil
+        phase = nil
+        // Skip the pull when the user already pulled (that *is* the localImageNewer state);
+        // otherwise let the service decide — a cached-tag pull is a cheap no-op.
+        let willPull = service.staleness(of: container) != .localImageNewer
+        progress = TransferProgressState.pull()
+        if willPull {
+            progress.start(reference: container.image)
+        } else {
+            progress.appendLog(tag: "STEP", text: "using the already-pulled local image")
+        }
+
+        recreateTask = Task {
+            do {
+                let outcome = try await service.recreateContainer(
+                    container.id, pullFirst: willPull,
+                    progress: progress.handler,
+                    onPhase: { newPhase in
+                        phase = newPhase
+                        if newPhase != .pullingImage {
+                            // The log box is a terminal-style trace (same convention as the
+                            // unlocalized "unpacking image"/"resolving manifest" lines elsewhere),
+                            // so a resolved plain String is fine here — only the on-screen
+                            // caption above needs the LocalizedStringResource itself.
+                            progress.appendLog(tag: "STEP", text: String(localized: newPhase.logLine))
+                        }
+                    }
+                )
+                progress.appendLog(tag: "DONE", text: outcome.wasRunning
+                    ? "\(container.name) recreated and started"
+                    : "\(container.name) recreated")
+                result = outcome
+                isWorking = false
+                isDone = true
+            } catch is CancellationError {
+                isWorking = false
+                phase = nil
+            } catch {
+                errorMessage = error.localizedDescription
+                isWorking = false
+                phase = nil
+            }
+            recreateTask = nil
+        }
+    }
+
+    private func cancelRecreate() {
+        guard canCancel else { return }
+        recreateTask?.cancel()
+        recreateTask = nil
+        isWorking = false
+        phase = nil
+        errorMessage = nil
+    }
+
+    private func performReclaim() {
+        reclaim = .working
+        Task {
+            do {
+                reclaim = .freed(try await service.reclaimOrphanedImageBlobs())
+            } catch {
+                errorMessage = error.localizedDescription
+                reclaim = .idle
+            }
+        }
+    }
+}
+
+#Preview {
+    RecreateContainerSheet(container: MockContainerService().containers[2])
+        .environment(MockContainerService() as ContainerServiceBase)
+}

--- a/Berthly/Views/SettingsView.swift
+++ b/Berthly/Views/SettingsView.swift
@@ -29,6 +29,15 @@ private struct GeneralSettingsTab: View {
     @State private var launchAtLogin = SMAppService.mainApp.status == .enabled
     @State private var errorMessage: String?
     @Environment(UpdaterService.self) private var updater
+    /// Read by `LiveContainerService.poll()` to gate the automatic registry-digest check —
+    /// manual checks (Images toolbar) and the recreate action itself are never gated by this.
+    @AppStorage("checkImagesForUpdates") private var checkImagesForUpdates = true
+    /// Hosts remembered as insecure by the "Allow insecure registry" toggle on Pull/Push/Run/
+    /// Sign-in/Machine Create (`ImageStaleness.registryHost`/`rememberInsecureHost`). A one-time
+    /// snapshot, not `@AppStorage` (no native `[String]` support) — doesn't live-update if
+    /// another window adds one while Settings is open, same limitation `launchAtLogin`'s
+    /// snapshot already accepts.
+    @State private var insecureHosts = UserDefaults.standard.stringArray(forKey: ImageStaleness.insecureHostsDefaultsKey) ?? []
 
     var body: some View {
         @Bindable var updater = updater
@@ -56,6 +65,43 @@ private struct GeneralSettingsTab: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+
+            Section {
+                Toggle("Check images for updates", isOn: $checkImagesForUpdates)
+            } header: {
+                Text("Image Updates")
+            } footer: {
+                Text("""
+                Periodically compares your pulled images against their registries and badges \
+                the ones with a newer version. You can always check manually from the Images page.
+                """)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            if !insecureHosts.isEmpty {
+                Section {
+                    ForEach(insecureHosts, id: \.self) { host in
+                        HStack {
+                            Text(host)
+                                .font(.callout.monospaced())
+                            Spacer()
+                            Button("Remove") { removeInsecureHost(host) }
+                                .buttonStyle(.borderless)
+                                .foregroundStyle(.red)
+                        }
+                    }
+                } header: {
+                    Text("Insecure Registries")
+                } footer: {
+                    Text("""
+                    Hosts you've told Berthly to trust over HTTP instead of HTTPS. Remove one to \
+                    require HTTPS again — you'll be asked to allow it again the next time it's needed.
+                    """)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
         }
         .formStyle(.grouped)
         .alert("Couldn't Change Login Item", isPresented: Binding(
@@ -66,6 +112,11 @@ private struct GeneralSettingsTab: View {
         } message: {
             Text(errorMessage ?? "")
         }
+    }
+
+    private func removeInsecureHost(_ host: String) {
+        insecureHosts.removeAll { $0 == host }
+        UserDefaults.standard.set(insecureHosts, forKey: ImageStaleness.insecureHostsDefaultsKey)
     }
 
     private func setLaunchAtLogin(_ enabled: Bool) {

--- a/Berthly/Views/SheetChrome.swift
+++ b/Berthly/Views/SheetChrome.swift
@@ -206,6 +206,10 @@ struct SheetSubmitFooter: View {
     var showsBusyButton: Bool = true
     /// Working-phase Cancel action; `nil` keeps the idle behavior of dismissing the sheet.
     var onCancel: (() -> Void)?
+    /// Set to disable the working-phase Cancel with this tooltip — for flows whose work enters a
+    /// non-cancellable window (recreate's stop→delete→create) rather than being cancelable end
+    /// to end. Disabled, not hidden: the button vanishing mid-operation reads as a glitch.
+    var workingCancelDisabledHelp: LocalizedStringKey?
     var onSubmit: () -> Void = {}
 
     @Environment(\.dismiss) private var dismiss
@@ -225,6 +229,8 @@ struct SheetSubmitFooter: View {
             case .working:
                 Button("Cancel") { (onCancel ?? { dismiss() })() }
                     .keyboardShortcut(.cancelAction)
+                    .disabled(workingCancelDisabledHelp != nil)
+                    .help(workingCancelDisabledHelp ?? "")
                 if showsBusyButton {
                     Button {} label: {
                         HStack(spacing: 6) {
@@ -253,7 +259,13 @@ struct SheetSubmitFooter: View {
 // MARK: - Shared option controls
 
 /// The "Allow insecure registry" checkbox with its warning subtext — identical wherever a
-/// sheet talks to a registry (pull, push, machine create, run).
+/// sheet talks to a registry (pull, push, machine create, run, sign-in).
+///
+/// Checking this once remembers the host as insecure (Settings > Image Updates lists and can
+/// forget it) — not just for this one operation. The copy says so explicitly: silently turning
+/// a per-operation choice into a standing HTTP downgrade for that host would mean a later
+/// operation (including one carrying credentials, e.g. sign-in) could go out over plaintext
+/// without the user ever seeing this checkbox again.
 struct InsecureRegistryToggle: View {
     @Binding var isOn: Bool
 
@@ -262,7 +274,7 @@ struct InsecureRegistryToggle: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text("Allow insecure registry")
                     .font(.caption.weight(.medium))
-                Text("Forces HTTP instead of HTTPS. Only use for private registries without TLS.")
+                Text("Forces HTTP instead of HTTPS and remembers this host as insecure for future update checks. Only use for private registries without TLS.")
                     .font(.caption)
                     .foregroundStyle(.tertiary)
             }

--- a/Berthly/Views/UpdateBadges.swift
+++ b/Berthly/Views/UpdateBadges.swift
@@ -1,0 +1,50 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import SwiftUI
+
+// MARK: - Image update badge
+
+/// Marks an image whose registry has a newer digest for its tag — shown next to `UsageBadge` on
+/// the image row. Accent (not the amber caution tint): unlike "used by", this badge is an
+/// invitation to act (Pull Latest), and accent is this codebase's interactive color.
+struct UpdateAvailableBadge: View {
+    let image: ContainerImage
+
+    var body: some View {
+        HStack(spacing: 3) {
+            Image(systemName: "arrow.up.circle.fill")
+                .imageScale(.small)
+            Text("update")
+        }
+        .font(.system(size: 9, weight: .semibold, design: .monospaced))
+        .foregroundStyle(Color.berthlyAccent)
+        .padding(.horizontal, 5)
+        .padding(.vertical, 2)
+        .background(Color.berthlyAccent.opacity(0.12), in: RoundedRectangle(cornerRadius: 3))
+        .help("A newer image is published for \(image.fullName)")
+        .accessibilityIdentifier("imageUpdateBadge-\(image.id)")
+    }
+}
+
+// MARK: - Container staleness glyph
+
+/// Marks a container lagging its image tag, next to the image reference on the compute row and
+/// the detail header. A bare glyph, not a text pill: the row's trailing area is already
+/// contended (ports/hover actions), and the `.help` text carries the which-kind distinction.
+struct ContainerStalenessGlyph: View {
+    let staleness: ContainerImageStaleness
+    let containerName: String
+
+    var body: some View {
+        if staleness != .current {
+            Image(systemName: "arrow.up.circle.fill")
+                .imageScale(.small)
+                .foregroundStyle(Color.berthlyAccent)
+                .help(staleness == .remoteUpdateAvailable
+                      ? "Update available — pull and recreate to apply it"
+                      : "A newer image was pulled — recreate the container to apply it")
+                .accessibilityIdentifier("containerUpdateBadge-\(containerName)")
+        }
+    }
+}

--- a/BerthlyE2ETests/BerthlyE2ETests.swift
+++ b/BerthlyE2ETests/BerthlyE2ETests.swift
@@ -856,8 +856,10 @@ final class ResourceJourneyTests: BerthlyE2ETestCase {
 /// the anonymous push/pull case (credentialed sign-in stays descoped for the same reason: it
 /// would need real secrets in a local test suite).
 final class RegistryJourneyTests: BerthlyE2ETestCase {
-    private static let fixtureImage = "alpine:latest"
-    private static let registryImage = "registry:latest"
+    // Not `private`: RecreateWatchtowerJourneyTests.swift extends this class from a separate
+    // file, and Swift's `private` is file-scoped, not type-scoped.
+    static let fixtureImage = "alpine:latest"
+    static let registryImage = "registry:latest"
     /// Arbitrary, uncommon high port — avoids macOS's own AirPlay Receiver (5000/7000) and
     /// anything else plausibly already listening on a dev machine.
     private static let registryPort = 18581
@@ -993,9 +995,10 @@ final class RegistryJourneyTests: BerthlyE2ETestCase {
     /// Polls the freshly-started registry until it accepts pushes. `container run -d` returning
     /// doesn't mean the distribution server inside has bound its port yet; retries a real (cheap,
     /// already-local) push rather than an HTTP probe, since that's the exact path the journey
-    /// itself exercises.
-    private func waitForRegistryReady(timeout: TimeInterval = 30) throws {
-        let probeRef = "localhost:\(Self.registryPort)/berthly-e2e/ready-probe:1"
+    /// itself exercises. Not `private`: `RecreateWatchtowerJourneyTests.swift` extends this class
+    /// from a separate file, and Swift's `private` is file-scoped, not type-scoped.
+    func waitForRegistryReady(port: Int = RegistryJourneyTests.registryPort, timeout: TimeInterval = 30) throws {
+        let probeRef = "localhost:\(port)/berthly-e2e/ready-probe:1"
         _ = try ContainerCLI.run(["image", "tag", Self.fixtureImage, probeRef])
         let deadline = Date(timeIntervalSinceNow: timeout)
         repeat {
@@ -1004,7 +1007,7 @@ final class RegistryJourneyTests: BerthlyE2ETestCase {
             }
             Thread.sleep(forTimeInterval: 1)
         } while Date() < deadline
-        throw XCTSkip("local registry on port \(Self.registryPort) never became ready")
+        throw XCTSkip("local registry on port \(port) never became ready")
     }
 
     /// Credentialed counterpart to `testBuildPushPullRoundTripThroughLocalInsecureRegistry`: a

--- a/BerthlyE2ETests/E2ESupport.swift
+++ b/BerthlyE2ETests/E2ESupport.swift
@@ -245,6 +245,19 @@ class BerthlyE2ETestCase: XCTestCase {
     private(set) var volumeName = ""
     private(set) var networkName = ""
 
+    /// The real app's UserDefaults suite — E2E drives the actual `LiveContainerService`, not a
+    /// mock, so any test that checks "Allow insecure registry" (Pull/Push/Run/Sign-in/Machine
+    /// Create) writes to the developer's REAL, persistent preferences. Snapshotted in setUp and
+    /// restored verbatim in tearDown so a local E2E run never permanently pollutes it — this must
+    /// live in the shared base class, not just one test, since every registry-touching E2E test
+    /// now has this side effect.
+    private static let berthlyDefaults = UserDefaults(suiteName: "app.berthly.Berthly")!
+    /// Must match `ImageStaleness.insecureHostsDefaultsKey` — this target only `import XCTest`,
+    /// no `@testable import Berthly`, so the Swift constant isn't reachable here.
+    private static let insecureHostsKey = "insecureRegistryHosts"
+    private var didSnapshotInsecureHosts = false
+    private var savedInsecureHosts: [String]?
+
     override func setUpWithError() throws {
         continueAfterFailure = false
 
@@ -282,6 +295,11 @@ class BerthlyE2ETestCase: XCTestCase {
             """)
         }
 
+        // Snapshot before anything in this run could possibly write to it (see the property's
+        // doc comment) — restored verbatim in tearDown regardless of what this test does.
+        savedInsecureHosts = Self.berthlyDefaults.stringArray(forKey: Self.insecureHostsKey)
+        didSnapshotInsecureHosts = true
+
         // Same rationale as BerthlyUITests.setUpWithError: a stray instance from a manual
         // launch or crashed run makes launch() adopt nothing and every wait time out.
         let killer = Process()
@@ -311,6 +329,16 @@ class BerthlyE2ETestCase: XCTestCase {
             ContainerCLI.sweepNetworks(prefix: Self.resourcePrefix)
             ContainerCLI.sweepImages(prefix: Self.resourcePrefix)
             ContainerCLI.sweepMachines(prefix: Self.resourcePrefix)
+        }
+        // Restore exactly what was there before this run — preserves any real entries the
+        // developer already had, only reverts what this test itself added (or unsets the key
+        // again if it was never set to begin with).
+        if didSnapshotInsecureHosts {
+            if let savedInsecureHosts {
+                Self.berthlyDefaults.set(savedInsecureHosts, forKey: Self.insecureHostsKey)
+            } else {
+                Self.berthlyDefaults.removeObject(forKey: Self.insecureHostsKey)
+            }
         }
     }
 

--- a/BerthlyE2ETests/RecreateWatchtowerJourneyTests.swift
+++ b/BerthlyE2ETests/RecreateWatchtowerJourneyTests.swift
@@ -1,0 +1,269 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import XCTest
+
+/// Split into its own file to keep `BerthlyE2ETests.swift` under the `file_length` ratchet —
+/// this is still logically part of `RegistryJourneyTests` (an `extension`, not a new class), so
+/// it shares that class's registry fixtures/helpers directly. `fixtureImage`/`registryImage`/
+/// `waitForRegistryReady` are `internal` there rather than `private` specifically so this
+/// extension can reach them from a separate file — Swift's `private` is file-scoped, not
+/// type-scoped.
+extension RegistryJourneyTests {
+    /// The recreate feature's one real-daemon journey. Unit/mock tests can't prove: a real
+    /// registry HEAD comparison, real indirect-index digest unwrapping, a real pull replacing
+    /// the local tag, recreate preserving configuration/run state and volume data while
+    /// discarding the writable layer, the `.localImageNewer` vs `.remoteUpdateAvailable`
+    /// distinction via "Pull Latest", a recreate that provably needs zero network, and an
+    /// `--rm`/autoRemove container surviving the post-stop `notFound`-confirmed-absence fallback.
+    ///
+    /// Build/push/retag for v1/v2/v3 are CLI-driven fixture setup — Build/Push/generic-Pull are
+    /// already proven end to end by the two tests above, so re-driving those sheets three times
+    /// each here would be pure duplication. The UI is exercised only for what's new: one initial
+    /// Pull (insecure toggle ON, to exercise the insecure-host memory's write path for real),
+    /// Check for Updates, Recreate, and Pull Latest (which should need NO manual toggle click —
+    /// the host is already remembered as insecure from the first pull, so this doubles as a
+    /// behavioral proof that the prefill wiring actually works).
+    ///
+    /// The core trick (verified empirically against this exact daemon before writing this test):
+    /// any push through this ONE daemon updates the local store's entry for that reference too,
+    /// so local and remote can never naturally disagree. Publish vN to the registry, then
+    /// **locally** retag a preserved alias back onto the canonical name (confirmed: retagging
+    /// overwrites an existing local name rather than erroring) — a real, no-network operation —
+    /// so the registry keeps vN while the local store (and anything already pinned to the old
+    /// digest) stays at vN-1.
+    @MainActor
+    func testRecreateWithLatestImageThroughLocalRegistry() throws {
+        try ContainerCLI.ensureImage(Self.fixtureImage)
+        try ContainerCLI.ensureImage(Self.registryImage)
+
+        let port = 18583
+        let watchtowerRegistryName = "\(Self.resourcePrefix)-watchtower-registry"
+        let canonical = "localhost:\(port)/berthly-e2e/watchtower:latest"
+
+        // ── 1. Local registry — fixture infra via CLI, its own port to avoid any collision with
+        // the two tests above. ──
+        let registryRun = try ContainerCLI.run(
+            ["run", "-d", "--name", watchtowerRegistryName, "-p", "\(port):5000", Self.registryImage],
+            timeout: 60
+        )
+        XCTAssertEqual(registryRun.status, 0, "starting the local registry failed:\n\(registryRun.output)")
+        try waitForRegistryReady(port: port)
+
+        let workDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(Self.resourcePrefix)-watchtower-\(UUID().uuidString.prefix(8))")
+        try FileManager.default.createDirectory(at: workDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: workDir) }
+
+        // ── 2. Publish v1 (CLI fixture setup). ──
+        try buildTagPush(marker: "v1", workDir: workDir, as: canonical)
+
+        // ── 3. The one UI touch that isn't pure setup: pull v1 through Berthly with the
+        // insecure toggle on, for real. ──
+        let app = XCUIApplication.berthlyE2E()
+        app.launch()
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 15))
+        // Daemon-ready gate: unlike the round-trip tests above (which do a slow Build first,
+        // incidentally giving the app time to connect), this is the very first UI action here —
+        // the palette's "Pull Image" entry can silently no-op if invoked before the daemon
+        // connection settles. Same enabled-state wait openRunSheet uses.
+        let runButton = app.buttons["runToolbarButton"]
+        XCTAssertTrue(runButton.waitForExistence(timeout: 15))
+        expectation(for: NSPredicate(format: "isEnabled == true"), evaluatedWith: runButton)
+        waitForExpectations(timeout: 30)
+
+        XCTAssertTrue(app.openViaPalette("Pull Image"))
+        let pullField = app.windows.textFields["pullImageField"]
+        XCTAssertTrue(pullField.waitForExistence(timeout: 5), "Pull sheet should appear")
+        pullField.click(); pullField.typeText(canonical)
+        expandAdvancedSection(app, revealing: "allowInsecureRegistryToggle")
+        app.checkBoxes["allowInsecureRegistryToggle"].click()
+        app.buttons["pullSubmitButton"].click()
+        XCTAssertTrue(app.buttons["Done"].waitForExistence(timeout: 60), "the initial pull should succeed")
+        dismissDoneSheet(app)
+
+        // ── 4. Run two containers from the pulled reference: "main" (named volume + a marker
+        // written straight into its writable layer) and "-ar" (Remove when stopped). ──
+        let mainName = containerName
+        let autoRemoveName = "\(containerName)-ar"
+
+        openRunSheet(app)
+        typeField(app, canonical, into: "runImageField")
+        typeField(app, mainName, into: "runNameField")
+        typeField(app, "sleep 600", into: "runCommandField")
+        app.buttons["runCategory-Storage"].click()
+        app.buttons["runVolumeAddButton"].click()
+        typeField(app, "\(volumeName):/data", into: "runVolumeField")
+        app.buttons["runSubmitButton"].click()
+        XCTAssertTrue(app.buttons["Show Container"].waitForExistence(timeout: 60), "main container should boot")
+        app.buttons["Show Container"].click()
+
+        openRunSheet(app)
+        typeField(app, canonical, into: "runImageField")
+        typeField(app, autoRemoveName, into: "runNameField")
+        typeField(app, "sleep 600", into: "runCommandField")
+        app.checkBoxes["runRemoveWhenStoppedToggle"].click()
+        app.buttons["runSubmitButton"].click()
+        XCTAssertTrue(app.buttons["Show Container"].waitForExistence(timeout: 60), "auto-remove container should boot")
+        app.buttons["Show Container"].click()
+
+        // Two markers: one inside the volume mount (must survive recreate), one in the
+        // container's own writable layer outside any mount (must NOT survive recreate) —
+        // the exact distinction the confirm sheet's own warning text makes.
+        XCTAssertEqual(try ContainerCLI.exec(mainName, ["sh", "-c", "echo volume-data > /data/marker"]).status, 0)
+        XCTAssertEqual(try ContainerCLI.exec(mainName, ["sh", "-c", "echo layer-data > /root/marker"]).status, 0)
+
+        // ── 5. Publish v2 to the registry while the local store (and both containers, still
+        // pinned at run time) stays at v1. ──
+        try republishKeepingLocalPinned(marker: "v2", workDir: workDir, canonical: canonical)
+
+        // ── 6. Detect + recreate the remote-update path. ──
+        app.staticTexts["Images"].click()
+        let checkButton = app.buttons["checkImageUpdatesButton"]
+        XCTAssertTrue(checkButton.waitForExistence(timeout: 10))
+        checkButton.click()
+        XCTAssertTrue(checkButton.waitForNonExistence(timeout: 5), "check should show a spinner while running")
+        XCTAssertTrue(checkButton.waitForExistence(timeout: 30), "check should complete")
+
+        let imageBadge = app.descendants(matching: .any)["imageUpdateBadge-\(canonical)"]
+        XCTAssertTrue(imageBadge.waitForExistence(timeout: 5), "image row should show an update badge for v2")
+
+        app.staticTexts["Compute"].click()
+        let mainRow = app.staticTexts["computeRow-\(mainName)"]
+        XCTAssertTrue(mainRow.waitForExistence(timeout: 10))
+        let mainBadge = app.descendants(matching: .any)["containerUpdateBadge-\(mainName)"]
+        XCTAssertTrue(mainBadge.waitForExistence(timeout: 5), "main container row should show an update badge")
+
+        openRecreateSheet(app, on: mainRow)
+        XCTAssertTrue(app.buttons["Done"].waitForExistence(timeout: 240),
+                      "recreate should succeed with a real HTTP pull; sheet:\n\(app.windows.firstMatch.debugDescription)")
+        dismissDoneSheet(app)
+
+        let mainJSON = try ContainerCLI.inspectJSON(mainName)
+        XCTAssertEqual(ContainerCLI.value(at: "status.state", in: mainJSON) as? String, "running")
+        let imageMarker = try ContainerCLI.exec(mainName, ["cat", "/berthly-e2e-marker"])
+        XCTAssertTrue(imageMarker.output.contains("v2"), "image marker should read v2 after recreate")
+        let volumeMarker = try ContainerCLI.exec(mainName, ["cat", "/data/marker"])
+        XCTAssertTrue(volumeMarker.output.contains("volume-data"), "the volume marker should survive recreate")
+        let layerMarker = try ContainerCLI.exec(mainName, ["cat", "/root/marker"])
+        XCTAssertNotEqual(layerMarker.status, 0, "the writable-layer marker should be discarded by recreate")
+
+        XCTAssertTrue(mainBadge.waitForNonExistence(timeout: 5), "container badge should clear")
+        XCTAssertTrue(imageBadge.waitForNonExistence(timeout: 5), "image badge should clear")
+
+        // ── 7. Recreate the auto-remove container too — it's now .localImageNewer (local moved
+        // to v2 via the pull above; it's still pinned to v1) — exercises BOTH the no-pull path
+        // and the post-stop notFound-confirmed-absence fallback in one action. ──
+        let autoRemoveRow = app.staticTexts["computeRow-\(autoRemoveName)"]
+        XCTAssertTrue(autoRemoveRow.waitForExistence(timeout: 10))
+        openRecreateSheet(app, on: autoRemoveRow)
+        XCTAssertTrue(app.buttons["Done"].waitForExistence(timeout: 60),
+                      "the auto-remove container should survive recreate despite self-deleting on stop")
+        dismissDoneSheet(app)
+        let autoRemoveJSON = try ContainerCLI.inspectJSON(autoRemoveName)
+        XCTAssertEqual(ContainerCLI.value(at: "status.state", in: autoRemoveJSON) as? String, "running")
+        // Not asserting autoRemove is still enabled: the product explicitly can't preserve it
+        // (ContainerSnapshot never carries it) — the confirm sheet's copy says so.
+
+        // ── 8. v3 + Pull Latest — the .localImageNewer path reached via the Images page's own
+        // button instead of an implicit side effect. ──
+        try republishKeepingLocalPinned(marker: "v3", workDir: workDir, canonical: canonical)
+
+        app.staticTexts["Images"].click()
+        checkButton.click()
+        XCTAssertTrue(checkButton.waitForNonExistence(timeout: 5))
+        XCTAssertTrue(checkButton.waitForExistence(timeout: 30))
+        XCTAssertTrue(imageBadge.waitForExistence(timeout: 5), "image badge should reappear for v3")
+
+        app.staticTexts[canonical].rightClick()
+        let pullLatest = app.menuItems["Pull Latest"]
+        XCTAssertTrue(pullLatest.waitForExistence(timeout: 5))
+        pullLatest.click()
+        // No manual toggle click here: the host was already remembered as insecure from step 3,
+        // so PullImageSheet's initiallyInsecure prefill should have it checked already — this is
+        // as much a functional proof of that prefill as it is journey setup.
+        app.buttons["pullSubmitButton"].click()
+        XCTAssertTrue(app.buttons["Done"].waitForExistence(timeout: 60), "Pull Latest should succeed")
+        dismissDoneSheet(app)
+
+        XCTAssertTrue(imageBadge.waitForNonExistence(timeout: 5), "image badge should clear after Pull Latest")
+        app.staticTexts["Compute"].click()
+        XCTAssertTrue(mainBadge.waitForExistence(timeout: 5),
+                      "container badge should REMAIN — still pinned to v2 while local is now v3")
+
+        // ── 9. Stop the registry entirely, then recreate again — a definitive, non-racy proof
+        // that .localImageNewer needs zero network (a "no PULL log line ever appeared" string
+        // match would be flaky by comparison — this can't pass by accident). ──
+        _ = try ContainerCLI.run(["stop", watchtowerRegistryName], timeout: 30)
+        openRecreateSheet(app, on: mainRow)
+        XCTAssertTrue(app.buttons["Done"].waitForExistence(timeout: 30),
+                      "recreate must succeed with the registry unreachable — proves .localImageNewer needs no network")
+        dismissDoneSheet(app)
+
+        XCTAssertTrue(mainBadge.waitForNonExistence(timeout: 5))
+        let finalMarker = try ContainerCLI.exec(mainName, ["cat", "/berthly-e2e-marker"])
+        XCTAssertTrue(finalMarker.output.contains("v3"), "final recreate should be pinned to v3")
+
+        // watchtower registry (already stopped above), both compute containers, and every
+        // berthly-e2e/… image swept by prefix in tearDown.
+    }
+
+    /// Right-clicks `row`, opens "Recreate with Latest Image…" (label query — no identifier
+    /// survives the SwiftUI→NSMenu bridge), and submits. Leaves the caller to wait for whatever
+    /// this particular recreate should produce (a real pull can take much longer than a no-pull
+    /// no-network one).
+    @MainActor
+    private func openRecreateSheet(_ app: XCUIApplication, on row: XCUIElement) {
+        row.rightClick()
+        let item = app.menuItems["Recreate with Latest Image…"]
+        XCTAssertTrue(item.waitForExistence(timeout: 5))
+        item.click()
+        app.buttons["recreateSubmitButton"].click()
+    }
+
+    /// Dismisses a sheet's "Done" button by clicking it — matching the round-trip tests above
+    /// (`buildDone.click()`, the push/pull "Done" clicks), not the mock-mode UI test convention
+    /// of a Return keypress: a real-daemon E2E launch has no `UITEST_DISABLE_ANIMATIONS` and (for
+    /// the pull sheets specifically) a just-typed text field can still hold first responder, so
+    /// Return isn't guaranteed to route to the button here the way it does in mock mode — verified
+    /// empirically (Return alone left the sheet up past a 10s wait; a direct click doesn't).
+    /// Waits for the sheet to be fully gone before returning, since the next action in this
+    /// journey is often another coordinate-sensitive gesture (a right-click).
+    @MainActor
+    private func dismissDoneSheet(_ app: XCUIApplication) {
+        let done = app.buttons["Done"]
+        done.click()
+        XCTAssertTrue(done.waitForNonExistence(timeout: 10), "sheet should fully dismiss")
+    }
+
+    /// Builds a tiny marker image and pushes it to `destination` — CLI fixture setup, not the
+    /// feature under test (Build/Push are already proven end to end by the two tests above).
+    @discardableResult
+    private func buildTagPush(marker: String, workDir: URL, as destination: String) throws -> ContainerCLI.Result {
+        let dockerfile = """
+        FROM alpine:latest
+        RUN echo \(marker) > /berthly-e2e-marker
+        """
+        try dockerfile.write(to: workDir.appendingPathComponent("Dockerfile"), atomically: true, encoding: .utf8)
+        let localTag = "\(Self.resourcePrefix)/watchtower-src-\(UUID().uuidString.prefix(8).lowercased()):1"
+        let build = try ContainerCLI.run(["build", "-t", localTag, workDir.path], timeout: 120)
+        XCTAssertEqual(build.status, 0, "build (\(marker)) failed:\n\(build.output)")
+        let tag = try ContainerCLI.run(["image", "tag", localTag, destination], timeout: 30)
+        XCTAssertEqual(tag.status, 0, "tag (\(marker)) failed:\n\(tag.output)")
+        let push = try ContainerCLI.run(["image", "push", "--scheme", "http", destination], timeout: 60)
+        XCTAssertEqual(push.status, 0, "push (\(marker)) failed:\n\(push.output)")
+        return push
+    }
+
+    /// Publishes a new version to the registry while leaving the local store (and anything
+    /// already pinned to the old digest, e.g. a running container) exactly where it was — see
+    /// the journey's own doc comment for why a plain push can't do this on a single daemon.
+    private func republishKeepingLocalPinned(marker: String, workDir: URL, canonical: String) throws {
+        let alias = "\(Self.resourcePrefix)/watchtower-preserved-\(UUID().uuidString.prefix(8).lowercased()):1"
+        let preserve = try ContainerCLI.run(["image", "tag", canonical, alias], timeout: 30)
+        XCTAssertEqual(preserve.status, 0, "preserving the local alias failed:\n\(preserve.output)")
+        try buildTagPush(marker: marker, workDir: workDir, as: canonical)
+        let restore = try ContainerCLI.run(["image", "tag", alias, canonical], timeout: 30)
+        XCTAssertEqual(restore.status, 0, "restoring the local canonical tag failed:\n\(restore.output)")
+    }
+}

--- a/BerthlyTests/ImageStalenessTests.swift
+++ b/BerthlyTests/ImageStalenessTests.swift
@@ -1,0 +1,299 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import ContainerizationOCI
+import ContainerResource
+import Foundation
+import Testing
+@testable import Berthly
+
+struct ImageStalenessTests {
+
+    private func image(
+        id: String, digest: String = "sha256:aaa", source: ImageSource = .pulled,
+        usage: ImageUsage = .unused
+    ) -> ContainerImage {
+        let base = id.firstIndex(of: "@").map { String(id[id.startIndex ..< $0]) } ?? id
+        let colon = base.lastIndex(of: ":")
+        let repo = colon.map { String(base[base.startIndex ..< $0]) } ?? base
+        let tag = colon.map { String(base[base.index(after: $0)...]) } ?? "latest"
+        return ContainerImage(id: id, repository: repo, tag: tag, digest: digest,
+                              arch: ["arm64"], sizeBytes: 0, created: "-", source: source, usage: usage)
+    }
+
+    // MARK: - eligibleReferences
+
+    @Test func eligibilityRequiresRegistryDomainTagAndPulledSource() {
+        let images = [
+            image(id: "docker.io/library/nginx:latest"),
+            image(id: "ghcr.io/acme/api:2.1"),
+            image(id: "local/web:1.4"),                                // no registry domain
+            image(id: "docker.io/library/redis@sha256:\(String(repeating: "b", count: 64))"), // digest-pinned
+            image(id: "docker.io/acme/tool:1.0", source: .built),      // built locally
+            image(id: "ghcr.io/acme/buildkit:0.13", usage: .builderImage) // infra
+        ]
+        #expect(ImageStaleness.eligibleReferences(images: images)
+                == ["docker.io/library/nginx:latest", "ghcr.io/acme/api:2.1"])
+    }
+
+    @Test func eligibilityDedupesPreservingOrder() {
+        let images = [
+            image(id: "ghcr.io/acme/api:2.1"),
+            image(id: "docker.io/library/nginx:latest"),
+            image(id: "ghcr.io/acme/api:2.1")
+        ]
+        #expect(ImageStaleness.eligibleReferences(images: images)
+                == ["ghcr.io/acme/api:2.1", "docker.io/library/nginx:latest"])
+    }
+
+    // MARK: - comparableLocalDigest (indirect-index unwrap)
+
+    private func descriptor(_ digest: String) -> Descriptor {
+        Descriptor(mediaType: MediaTypes.imageManifest, digest: digest, size: 1)
+    }
+
+    @Test func directIndexComparesByOwnDigest() {
+        let index = Index(manifests: [descriptor("sha256:inner")])
+        #expect(ImageStaleness.comparableLocalDigest(ownDigest: "sha256:own", index: index) == "sha256:own")
+    }
+
+    @Test func indirectIndexUnwrapsToWrappedManifestDigest() {
+        for flag in ["true", "1", "True"] {
+            let index = Index(manifests: [descriptor("sha256:inner")],
+                              annotations: [AnnotationKeys.containerizationIndexIndirect: flag])
+            #expect(ImageStaleness.comparableLocalDigest(ownDigest: "sha256:own", index: index) == "sha256:inner")
+        }
+    }
+
+    @Test func indirectIndexWithoutManifestsFallsBackToOwnDigest() {
+        let index = Index(manifests: [],
+                          annotations: [AnnotationKeys.containerizationIndexIndirect: "true"])
+        #expect(ImageStaleness.comparableLocalDigest(ownDigest: "sha256:own", index: index) == "sha256:own")
+    }
+
+    // MARK: - availability
+
+    @Test func availabilityUnknownWithoutCheckInfo() {
+        #expect(ImageStaleness.availability(image: image(id: "a:1"), info: nil) == .unknown)
+    }
+
+    @Test func availabilityReflectsCheckResult() {
+        let img = image(id: "a:1", digest: "sha256:aaa")
+        let stale = ImageUpdateInfo(remoteDigest: "sha256:new", localImageDigest: "sha256:aaa",
+                                    isUpdateAvailable: true, checkedAt: .now)
+        let fresh = ImageUpdateInfo(remoteDigest: "sha256:aaa", localImageDigest: "sha256:aaa",
+                                    isUpdateAvailable: false, checkedAt: .now)
+        #expect(ImageStaleness.availability(image: img, info: stale) == .updateAvailable)
+        #expect(ImageStaleness.availability(image: img, info: fresh) == .upToDate)
+    }
+
+    @Test func availabilityInvalidatedWhenImagePulledSinceCheck() {
+        // The check ran against sha256:aaa; the user has since pulled and the image is now
+        // sha256:new — the stored verdict describes bytes that no longer exist locally.
+        let img = image(id: "a:1", digest: "sha256:new")
+        let info = ImageUpdateInfo(remoteDigest: "sha256:new", localImageDigest: "sha256:aaa",
+                                   isUpdateAvailable: true, checkedAt: .now)
+        #expect(ImageStaleness.availability(image: img, info: info) == .unknown)
+    }
+
+    // MARK: - container staleness
+
+    @Test func stalenessCurrentWhenDigestsMatchAndNoUpdate() {
+        let img = image(id: "ghcr.io/acme/api:2.1", digest: "sha256:aaa")
+        #expect(ImageStaleness.staleness(containerImageRef: "ghcr.io/acme/api:2.1",
+                                         containerImageDigest: "sha256:aaa",
+                                         images: [img], updateInfo: [:]) == .current)
+    }
+
+    @Test func stalenessLocalImageNewerWhenPinnedDigestLags() {
+        let img = image(id: "ghcr.io/acme/api:2.1", digest: "sha256:new")
+        #expect(ImageStaleness.staleness(containerImageRef: "ghcr.io/acme/api:2.1",
+                                         containerImageDigest: "sha256:old",
+                                         images: [img], updateInfo: [:]) == .localImageNewer)
+    }
+
+    @Test func stalenessDriftBeatsRemoteUpdate() {
+        let img = image(id: "ghcr.io/acme/api:2.1", digest: "sha256:new")
+        let info = ImageUpdateInfo(remoteDigest: "sha256:newest", localImageDigest: "sha256:new",
+                                   isUpdateAvailable: true, checkedAt: .now)
+        #expect(ImageStaleness.staleness(containerImageRef: "ghcr.io/acme/api:2.1",
+                                         containerImageDigest: "sha256:old",
+                                         images: [img], updateInfo: [img.id: info]) == .localImageNewer)
+    }
+
+    @Test func stalenessRemoteUpdateWhenPinnedMatchesLocal() {
+        let img = image(id: "ghcr.io/acme/api:2.1", digest: "sha256:aaa")
+        let info = ImageUpdateInfo(remoteDigest: "sha256:new", localImageDigest: "sha256:aaa",
+                                   isUpdateAvailable: true, checkedAt: .now)
+        #expect(ImageStaleness.staleness(containerImageRef: "ghcr.io/acme/api:2.1",
+                                         containerImageDigest: "sha256:aaa",
+                                         images: [img], updateInfo: [img.id: info]) == .remoteUpdateAvailable)
+    }
+
+    @Test func stalenessMatchesByFullNameLikeUsageResolver() {
+        // Container refs match id, fullName, or digest — same rule as ContainerImage.resolvingUsage.
+        let img = image(id: "ghcr.io/acme/api:2.1", digest: "sha256:new")
+        #expect(ImageStaleness.staleness(containerImageRef: img.fullName,
+                                         containerImageDigest: "sha256:old",
+                                         images: [img], updateInfo: [:]) == .localImageNewer)
+    }
+
+    @Test func stalenessCurrentForUnknownImageOrNilDigest() {
+        let img = image(id: "ghcr.io/acme/api:2.1", digest: "sha256:aaa")
+        #expect(ImageStaleness.staleness(containerImageRef: "gone:1",
+                                         containerImageDigest: "sha256:old",
+                                         images: [img], updateInfo: [:]) == .current)
+        #expect(ImageStaleness.staleness(containerImageRef: "ghcr.io/acme/api:2.1",
+                                         containerImageDigest: nil,
+                                         images: [img], updateInfo: [:]) == .current)
+        // Even with a known remote update: an unpinned container may already run the remote
+        // digest, so no stale verdict of either kind is justified.
+        let info = ImageUpdateInfo(remoteDigest: "sha256:new", localImageDigest: "sha256:aaa",
+                                   isUpdateAvailable: true, checkedAt: .now)
+        #expect(ImageStaleness.staleness(containerImageRef: "ghcr.io/acme/api:2.1",
+                                         containerImageDigest: nil,
+                                         images: [img], updateInfo: [img.id: info]) == .current)
+    }
+
+    // MARK: - insecure-host memory
+
+    @Test func registryHostCanonicalizesCase() {
+        #expect(ImageStaleness.registryHost(for: "GHCR.io/acme/api:2.1") == "ghcr.io")
+        #expect(ImageStaleness.registryHost(for: "LOCALHOST:18583/berthly-e2e/watchtower:latest") == "localhost:18583")
+    }
+
+    @Test func registryHostNilForATrailingDotDomain() {
+        // Reference.parse itself rejects a domain with a trailing dot (the domain regex
+        // requires a non-empty final label after each "."), so this never reaches
+        // registryHost's own folding logic — trailing-dot trimming only matters for
+        // foldedBareHost, which skips Reference.parse entirely. Documented here, not just
+        // assumed, so a future change to either function doesn't silently break this.
+        #expect(ImageStaleness.registryHost(for: "ghcr.io./acme/api:2.1") == nil)
+    }
+
+    @Test func registryHostNilForDomainlessOrDockerHubAlias() {
+        #expect(ImageStaleness.registryHost(for: "local/web:1.4") == nil)
+        #expect(ImageStaleness.registryHost(for: "docker.io/library/nginx:latest") == "registry-1.docker.io")
+    }
+
+    @Test func foldedBareHostDoesNotRequireAPath() {
+        // signInRegistry's `host` is already an isolated bare host, never a full reference —
+        // Reference.parse would misread "localhost:18581" (no slash) as an image:tag pair with
+        // no domain at all, so this must NOT go through registryHost(for:).
+        #expect(ImageStaleness.foldedBareHost("LOCALHOST:18581") == "localhost:18581")
+        #expect(ImageStaleness.foldedBareHost("ghcr.io.") == "ghcr.io")
+    }
+
+    @Test func addingInsecureHostDedupesAndSorts() {
+        #expect(ImageStaleness.addingInsecureHost("localhost:18581", to: []) == ["localhost:18581"])
+        #expect(ImageStaleness.addingInsecureHost("localhost:18581", to: ["localhost:18581"]) == ["localhost:18581"])
+        #expect(ImageStaleness.addingInsecureHost("a.example.com", to: ["z.example.com"])
+                == ["a.example.com", "z.example.com"])
+    }
+
+    @Test func isHostInsecureMatchesCanonicalizedMembership() {
+        let known = ["localhost:18581"]
+        #expect(ImageStaleness.isHostInsecure(reference: "LOCALHOST:18581/berthly-e2e/x:1", knownInsecureHosts: known))
+        #expect(!ImageStaleness.isHostInsecure(reference: "ghcr.io/acme/api:2.1", knownInsecureHosts: known))
+        #expect(!ImageStaleness.isHostInsecure(reference: "local/web:1.4", knownInsecureHosts: known))
+    }
+
+    // MARK: - check cadence
+
+    @Test func automaticCheckEnabledDefaultsOnWhenUnsetOrWrongType() {
+        #expect(ImageStaleness.automaticCheckEnabled(userDefaultValue: nil))
+        #expect(ImageStaleness.automaticCheckEnabled(userDefaultValue: "not a bool"))
+        #expect(ImageStaleness.automaticCheckEnabled(userDefaultValue: true))
+        #expect(!ImageStaleness.automaticCheckEnabled(userDefaultValue: false))
+    }
+
+    @Test func checkDueOnFirstRunAndAfterInterval() {
+        let now = Date()
+        #expect(ImageStaleness.isCheckDue(lastCheck: nil, now: now))
+        #expect(ImageStaleness.isCheckDue(lastCheck: now.addingTimeInterval(-7 * 3600), now: now))
+        #expect(!ImageStaleness.isCheckDue(lastCheck: now.addingTimeInterval(-3600), now: now))
+    }
+
+    // MARK: - mock fixtures
+
+    @MainActor @Test func mockFixturesSeedBothStalenessCases() {
+        let mock = MockContainerService()
+        let sandbox = mock.containers.first { $0.name == "sandbox" }
+        let datastore = mock.containers.first { $0.name == "datastore" }
+        let web = mock.containers.first { $0.name == "web-frontend" }
+        #expect(sandbox.map(mock.staleness(of:)) == .remoteUpdateAvailable)
+        #expect(datastore.map(mock.staleness(of:)) == .localImageNewer)
+        #expect(web.map(mock.staleness(of:)) == .current, "unseeded fixtures must stay badge-free")
+    }
+
+    // MARK: - recreated configuration
+
+    @Test func recreatedConfigurationSwapsOnlyTheImageDescriptor() {
+        let process = ProcessConfiguration(executable: "/bin/server", arguments: ["--port", "8080"],
+                                           environment: ["MODE=prod"], workingDirectory: "/srv",
+                                           terminal: false, user: .id(uid: 0, gid: 0))
+        var config = ContainerConfiguration(
+            id: "api",
+            image: ImageDescription(reference: "ghcr.io/acme/api:2.1", descriptor: descriptor("sha256:old")),
+            process: process
+        )
+        config.labels = ["app": "api"]
+        config.mounts = [Filesystem(type: .tmpfs, source: "", destination: "/run", options: [])]
+
+        let recreated = LiveContainerService.recreatedConfiguration(from: config,
+                                                                    imageDescriptor: descriptor("sha256:new"))
+
+        #expect(recreated.image.digest == "sha256:new")
+        #expect(recreated.image.reference == "ghcr.io/acme/api:2.1", "tag reference must survive the swap")
+        #expect(recreated.id == config.id)
+        #expect(recreated.labels == config.labels)
+        #expect(recreated.mounts.map(\.destination) == ["/run"])
+        #expect(recreated.initProcess.executable == "/bin/server")
+    }
+
+    // MARK: - mock recreate
+
+    @MainActor @Test func mockRecreatePreservesRunStateAndClearsStaleness() async throws {
+        let mock = MockContainerService()
+        let datastore = try #require(mock.containers.first { $0.name == "datastore" })
+        #expect(mock.staleness(of: datastore) == .localImageNewer)
+
+        var phases: [RecreatePhase] = []
+        let result = try await mock.recreateContainer(datastore.id, pullFirst: false) { phases.append($0) }
+
+        let recreated = try #require(mock.containers.first { $0.name == "datastore" })
+        #expect(recreated.status == .running, "a running container must come back running")
+        #expect(mock.staleness(of: recreated) == .current)
+        #expect(result.wasRunning && !result.didPull)
+        #expect(result.oldImageReclaimable, "digest moved, so the old bytes are reclaimable")
+        #expect(phases == [.stoppingContainer, .deletingContainer, .creatingContainer, .startingContainer])
+    }
+
+    @MainActor @Test func mockRecreatePullsWhenRemoteUpdateSeeded() async throws {
+        let mock = MockContainerService()
+        let sandbox = try #require(mock.containers.first { $0.name == "sandbox" })
+        #expect(mock.staleness(of: sandbox) == .remoteUpdateAvailable)
+
+        var phases: [RecreatePhase] = []
+        let result = try await mock.recreateContainer(sandbox.id, pullFirst: true) { phases.append($0) }
+
+        let recreated = try #require(mock.containers.first { $0.name == "sandbox" })
+        #expect(result.didPull && !result.wasRunning)
+        #expect(recreated.status == .stopped, "a non-running container must not be started by recreate")
+        #expect(recreated.imageDigest == "sha256:feed5eed01", "container must pin the freshly pulled digest")
+        #expect(mock.staleness(of: recreated) == .current)
+        #expect(phases.first == .pullingImage)
+        #expect(!phases.contains(.startingContainer))
+    }
+
+    // MARK: - recreate result
+
+    @Test func recreateResultReclaimableOnlyWhenDigestMoved() {
+        let moved = RecreateResult(wasRunning: true, didPull: true,
+                                   oldImageDigest: "sha256:old", newImageDigest: "sha256:new")
+        let same = RecreateResult(wasRunning: true, didPull: true,
+                                  oldImageDigest: "sha256:same", newImageDigest: "sha256:same")
+        #expect(moved.oldImageReclaimable)
+        #expect(!same.oldImageReclaimable)
+    }
+}

--- a/BerthlyTests/ModelEquatableTests.swift
+++ b/BerthlyTests/ModelEquatableTests.swift
@@ -43,6 +43,20 @@ struct ModelEquatableTests {
         #expect(a != b, "same id, different image must compare unequal (late-arriving image data)")
     }
 
+    @Test func containerInequalityOnImageDigestChange() {
+        let old = Container(
+            id: "c1", name: "web", image: "local/web:1.0", imageDigest: "sha256:old", status: .running,
+            ports: [], cpuPercent: 0, memoryMB: 0, memoryLimitMB: 0, networkIOString: "-", uptime: "-",
+            command: "", mounts: [], networks: [], environment: []
+        )
+        let recreated = Container(
+            id: "c1", name: "web", image: "local/web:1.0", imageDigest: "sha256:new", status: .running,
+            ports: [], cpuPercent: 0, memoryMB: 0, memoryLimitMB: 0, networkIOString: "-", uptime: "-",
+            command: "", mounts: [], networks: [], environment: []
+        )
+        #expect(old != recreated, "same id, different imageDigest must compare unequal (staleness badge redraw)")
+    }
+
     @Test func machineInequalityOnStatusChange() {
         let running = Machine(
             id: "m1", name: "dev", image: "debian:12", status: .running, isUtility: false,
@@ -119,5 +133,20 @@ struct ModelEquatableTests {
             arch: ["arm64"], sizeBytes: 0, created: "-", source: .pulled, usage: .usedBy(1)
         )
         #expect(unused != used, "same id, different usage must compare unequal (UsageBadge redraw)")
+    }
+
+    @Test func containerImageInequalityOnDigestChange() {
+        // Regression test for a real-daemon E2E finding (2026-07-20): after Pull Latest re-pulls
+        // the same reference, only `digest` changes — ForEach considered the row unchanged and
+        // never re-invoked ImageRow's body, so imageUpdateBadge silently never cleared.
+        let before = ContainerImage(
+            id: "localhost:1/repo:latest", repository: "localhost:1/repo", tag: "latest", digest: "sha256:old",
+            arch: ["arm64"], sizeBytes: 0, created: "-", source: .pulled, usage: .unused
+        )
+        let after = ContainerImage(
+            id: "localhost:1/repo:latest", repository: "localhost:1/repo", tag: "latest", digest: "sha256:new",
+            arch: ["arm64"], sizeBytes: 0, created: "-", source: .pulled, usage: .unused
+        )
+        #expect(before != after, "same id, different digest must compare unequal (imageUpdateBadge redraw)")
     }
 }

--- a/BerthlyUITests/RecreateImageUpdateTests.swift
+++ b/BerthlyUITests/RecreateImageUpdateTests.swift
@@ -111,7 +111,7 @@ final class RecreateImageUpdateTests: XCTestCase {
 
         XCTAssertTrue(app.staticTexts["recreatePhaseLabel"].waitForExistence(timeout: 5))
         let cancel = app.sheets.buttons["Cancel"].firstMatch
-        XCTAssertTrue(cancel.exists)
+        XCTAssertTrue(cancel.waitForExistence(timeout: 2))
         expectation(for: NSPredicate(format: "isEnabled == false"), evaluatedWith: cancel)
         waitForExpectations(timeout: 10)
 

--- a/BerthlyUITests/RecreateImageUpdateTests.swift
+++ b/BerthlyUITests/RecreateImageUpdateTests.swift
@@ -1,0 +1,153 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import XCTest
+
+/// Mock-mode coverage for the Watchtower-style image-update surface: the staleness badges on
+/// image/container rows, the Pull Latest shortcut, and the full recreate flow through
+/// `RecreateContainerSheet`. The mock seeds two stale fixtures at launch (`sandbox` = remote
+/// update available, `datastore` = newer image pulled but not applied), so every badge assertion
+/// is deterministic with no network or clock involved.
+///
+/// Badges are HStacks/Images whose `.accessibilityIdentifier` is set on the styled container, so
+/// they're queried via `descendants(matching: .any)` rather than a concrete element type (SwiftUI
+/// reports them as different types on different rows). Context-menu items are label-queried —
+/// identifiers don't survive the SwiftUI→NSMenu bridge (ContextMenuTests precedent).
+final class RecreateImageUpdateTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        let killer = Process()
+        killer.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
+        killer.arguments = ["-9", "Berthly"]
+        killer.standardOutput = FileHandle.nullDevice
+        killer.standardError = FileHandle.nullDevice
+        if (try? killer.run()) != nil { killer.waitUntilExit() }
+    }
+
+    private func launchMock() -> XCUIApplication {
+        let app = XCUIApplication.berthly()
+        app.launchEnvironment["UITEST_USE_MOCK_SERVICE"] = "1"
+        app.launch()
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+        return app
+    }
+
+    private func badge(_ app: XCUIApplication, _ identifier: String) -> XCUIElement {
+        app.descendants(matching: .any)[identifier].firstMatch
+    }
+
+    // MARK: - Badges
+
+    /// Both staleness kinds show on their seeded containers, an up-to-date container stays
+    /// badge-free, and the Images page shows the update pill plus the Check for Updates control.
+    @MainActor
+    func testUpdateBadgesShowOnSeededStaleFixtures() throws {
+        let app = launchMock()
+
+        XCTAssertTrue(app.staticTexts["computeRow-sandbox"].waitForExistence(timeout: 5))
+        XCTAssertTrue(badge(app, "containerUpdateBadge-sandbox").exists, "seeded remote update must badge the row")
+        XCTAssertTrue(badge(app, "containerUpdateBadge-datastore").exists, "pulled-but-not-recreated must badge the row")
+        XCTAssertFalse(badge(app, "containerUpdateBadge-web-frontend").exists, "an up-to-date container must not")
+
+        app.staticTexts["Images"].click()
+        XCTAssertTrue(app.staticTexts["local/base:latest"].waitForExistence(timeout: 5))
+        XCTAssertTrue(badge(app, "imageUpdateBadge-local/base:latest").exists)
+        XCTAssertFalse(badge(app, "imageUpdateBadge-local/web:1.4").exists)
+        XCTAssertTrue(app.buttons["checkImageUpdatesButton"].exists)
+    }
+
+    // MARK: - Recreate flow
+
+    /// End-to-end on `datastore` (running, localImageNewer): context menu → confirm sheet →
+    /// working phases → done callout → opt-in reclaim → freed size — then the badge is gone and
+    /// the container is running again.
+    @MainActor
+    func testRecreateFlowClearsBadgeAndOffersReclaim() throws {
+        let app = launchMock()
+        let row = app.staticTexts["computeRow-datastore"]
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
+        row.rightClick()
+
+        let item = app.menuItems["Recreate with Latest Image…"]
+        XCTAssertTrue(item.waitForExistence(timeout: 5))
+        item.click()
+
+        let submit = app.buttons["recreateSubmitButton"]
+        XCTAssertTrue(submit.waitForExistence(timeout: 5))
+        submit.click()
+
+        let reclaimButton = app.buttons["reclaimOldImageButton"]
+        XCTAssertTrue(reclaimButton.waitForExistence(timeout: 10), "recreate should finish and offer reclaim (digest moved)")
+        reclaimButton.click()
+        XCTAssertTrue(badge(app, "reclaimFreedLabel").waitForExistence(timeout: 5))
+
+        // Done button binds ⏎; a key event can't race sheet animation coordinates.
+        app.typeKey(.return, modifierFlags: [])
+        XCTAssertTrue(app.buttons["recreateSubmitButton"].waitForNonExistence(timeout: 5))
+
+        XCTAssertTrue(badge(app, "containerUpdateBadge-datastore").waitForNonExistence(timeout: 5),
+                      "recreate pins the new digest, so the staleness badge must clear")
+        XCTAssertTrue(row.exists, "the recreated container keeps its row")
+    }
+
+    /// The pull-then-recreate path on `sandbox` (remote update seeded): the phase label shows
+    /// while working, and Cancel disables once the flow crosses into the non-cancellable
+    /// replace window (an eventually-true condition — phases always progress in mock mode).
+    @MainActor
+    func testRecreatePullPhaseDisablesCancelInReplaceWindow() throws {
+        let app = launchMock()
+        let row = app.staticTexts["computeRow-sandbox"]
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
+        row.rightClick()
+
+        let item = app.menuItems["Recreate with Latest Image…"]
+        XCTAssertTrue(item.waitForExistence(timeout: 5))
+        item.click()
+
+        let submit = app.buttons["recreateSubmitButton"]
+        XCTAssertTrue(submit.waitForExistence(timeout: 5))
+        submit.click()
+
+        XCTAssertTrue(app.staticTexts["recreatePhaseLabel"].waitForExistence(timeout: 5))
+        let cancel = app.sheets.buttons["Cancel"].firstMatch
+        XCTAssertTrue(cancel.exists)
+        expectation(for: NSPredicate(format: "isEnabled == false"), evaluatedWith: cancel)
+        waitForExpectations(timeout: 10)
+
+        XCTAssertTrue(app.buttons["Done"].waitForExistence(timeout: 10))
+        app.typeKey(.return, modifierFlags: [])
+        XCTAssertTrue(badge(app, "containerUpdateBadge-sandbox").waitForNonExistence(timeout: 5))
+    }
+
+    // MARK: - Pull Latest shortcut
+
+    /// "Pull Latest" appears only on an image with a seeded update, and opens the pull sheet
+    /// with the reference prefilled.
+    @MainActor
+    func testPullLatestPrefillsPullSheet() throws {
+        let app = launchMock()
+        app.staticTexts["Images"].click()
+
+        let current = app.staticTexts["local/web:1.4"]
+        XCTAssertTrue(current.waitForExistence(timeout: 5))
+        current.rightClick()
+        XCTAssertTrue(app.menuItems["Run from This Image…"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.menuItems["Pull Latest"].exists, "no update seeded for this image")
+        app.typeKey(.escape, modifierFlags: [])
+        XCTAssertTrue(app.menuItems["Run from This Image…"].waitForNonExistence(timeout: 5))
+
+        let stale = app.staticTexts["local/base:latest"]
+        XCTAssertTrue(stale.waitForExistence(timeout: 5))
+        stale.rightClick()
+        let pullLatest = app.menuItems["Pull Latest"]
+        XCTAssertTrue(pullLatest.waitForExistence(timeout: 5))
+        pullLatest.click()
+
+        let field = app.textFields["pullImageField"]
+        XCTAssertTrue(field.waitForExistence(timeout: 5))
+        XCTAssertEqual(field.value as? String, "local/base:latest")
+        app.typeKey(.escape, modifierFlags: [])
+        XCTAssertTrue(field.waitForNonExistence(timeout: 5))
+    }
+}

--- a/PARITY.md
+++ b/PARITY.md
@@ -43,6 +43,12 @@ interactive/tty, ssh, shm-size, Rosetta, virtualization.
 Berthly additionally persists each image's build context and settings, so
 **Rebuild** re-runs a build without re-entering anything — no CLI equivalent.
 
+Also CLI-less: **update detection** (a background registry HEAD comparison
+badges images whose tag has a newer digest, plus the containers running them)
+and **Recreate with Latest Image** on a container (pull, then delete/recreate
+from its stored configuration, restoring the prior run state) — the CLI would
+need a manual `pull` + `delete` + a re-typed `run` for the same result.
+
 ## Registries
 
 `login`, `logout`, `list` — the Registries page, using the same Keychain

--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ around the *workflow*, with a tier of features the CLI doesn't have:
   toolchain, then start and monitor the daemon for you.
 - **Disk hygiene at a glance** — reclaimable-space badges on Images and
   Volumes, with confirmed one-click pruning.
+- **Image updates, Watchtower-style** — Berthly periodically compares your
+  pulled tags against their registries and badges stale images and the
+  containers running them; "Recreate with Latest Image" pulls and rebuilds the
+  container with its exact configuration, volumes intact.
 
 And yes — Berthly also covers the `container` CLI's full feature surface — see
 [PARITY.md](PARITY.md) for the subcommand-by-subcommand mapping and the few


### PR DESCRIPTION
## Summary

- Berthly can now detect when a pulled image's registry has published a newer digest than the local copy (or than a running container's pinned digest), badge the affected Images/Compute rows, and recreate a container from the updated image while preserving its configuration and volumes — the container's writable layer is discarded (disclosed in the confirm sheet).
- Adds a per-host "insecure registry" memory (`ImageStaleness`/`LiveContainerService`) so the background update checker and recreate's own pull can use HTTP for registries the user has already told Berthly to trust via Pull/Push/Run/Sign-in/Machine Create, with a Settings section to review/forget remembered hosts.
- Fixes a real bug surfaced by the new E2E coverage: `ContainerImage`'s custom `Equatable` never included `digest`, so SwiftUI's `ForEach` silently skipped re-rendering a row after a same-reference re-pull — the update badge could never clear no matter how long you waited.

## Test plan

- [x] `swiftlint lint --strict` clean
- [x] Full build, zero warnings
- [x] `BerthlyTests` (unit) green, including new `ImageStalenessTests` and the `ContainerImage` Equatable regression test
- [x] `BerthlyUITests` (mock mode) green, including new `RecreateImageUpdateTests`
- [x] `scripts/e2e.sh RegistryJourneyTests/testRecreateWithLatestImageThroughLocalRegistry` (real daemon) — two consecutive clean passes after the Equatable fix, exercising: real registry HEAD comparison, a real HTTP pull replacing the local tag, recreate preserving volumes while discarding the writable layer, the `.localImageNewer` vs `.remoteUpdateAvailable` distinction via Pull Latest, a recreate proven to need zero network, and an `--rm`/autoRemove container surviving the post-stop confirmed-absence fallback