### PR TITLE
feat: add Push to image row context menu

### DIFF
--- a/Berthly/Localizable.xcstrings
+++ b/Berthly/Localizable.xcstrings
@@ -1080,6 +1080,9 @@
     "Push this image to a registry" : {
 
     },
+    "Push…" : {
+
+    },
     "Pushing image" : {
 
     },

--- a/Berthly/Views/ImagesListView.swift
+++ b/Berthly/Views/ImagesListView.swift
@@ -224,6 +224,7 @@ private struct ImageRow: View {
     @State private var showRunSheet = false
     @State private var showTagSheet = false
     @State private var showPullSheet = false
+    @State private var showPushSheet = false
     @State private var saveRequest: ImageSaveRequest?
 
     private var image: ContainerImage? {
@@ -312,6 +313,7 @@ private struct ImageRow: View {
                 }
                 Divider()
                 Button("Tag…") { showTagSheet = true }
+                Button("Push…") { showPushSheet = true }
                 Button("Save to Disk…") {
                     if let destination = promptForArchiveDestination(imageName: image.fullName) {
                         saveRequest = ImageSaveRequest(reference: image.fullName, destination: destination)
@@ -345,6 +347,9 @@ private struct ImageRow: View {
             }
             .sheet(isPresented: $showTagSheet) {
                 TagImageSheet(image: image)
+            }
+            .sheet(isPresented: $showPushSheet) {
+                PushImageSheet(image: image)
             }
             .sheet(item: $saveRequest) { request in
                 SaveImageSheet(request: request)

--- a/BerthlyUITests/ContextMenuTests.swift
+++ b/BerthlyUITests/ContextMenuTests.swift
@@ -213,6 +213,7 @@ final class ContextMenuTests: XCTestCase {
 
         XCTAssertTrue(app.menuItems["Run from This Image…"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.menuItems["Tag…"].exists)
+        XCTAssertTrue(app.menuItems["Push…"].exists)
         XCTAssertTrue(app.menuItems["Save to Disk…"].exists)
         XCTAssertTrue(app.menuItems["Copy Reference"].exists)
         XCTAssertTrue(app.menuItems["Copy Digest"].exists)
@@ -240,6 +241,27 @@ final class ContextMenuTests: XCTestCase {
         let imageField = app.windows.textFields["runImageField"]
         XCTAssertTrue(imageField.waitForExistence(timeout: 5), "Run sheet should appear")
         XCTAssertEqual(imageField.value as? String, "local/api:2.1")
+
+        app.typeKey(.escape, modifierFlags: [])
+    }
+
+    /// "Push…" opens PushImageSheet prefilled with the row's own reference — the row-context-menu
+    /// path into the Push sheet, distinct from the toolbar Push button
+    /// (`testPushImageSheetPushesImage`) which is reached via ImageDetailView instead.
+    @MainActor
+    func testImageContextMenuPushOpensPushSheetPrefilled() throws {
+        let app = launchMock()
+        app.staticTexts["Images"].click()
+        let row = app.staticTexts["local/api:2.1"]
+        XCTAssertTrue(row.waitForExistence(timeout: 5))
+        row.rightClick()
+        let pushItem = app.menuItems["Push…"]
+        XCTAssertTrue(pushItem.waitForExistence(timeout: 5))
+        pushItem.click()
+
+        let destinationField = app.textFields["pushDestinationField"]
+        XCTAssertTrue(destinationField.waitForExistence(timeout: 5), "Push sheet should appear")
+        XCTAssertEqual(destinationField.value as? String, "local/api:2.1")
 
         app.typeKey(.escape, modifierFlags: [])
     }


### PR DESCRIPTION
## Summary
- Add a "Push…" item to the image row right-click context menu (between Tag and Save to Disk), opening `PushImageSheet` prefilled with the row's own reference — previously Push was only reachable via `ImageDetailView`'s toolbar.
- Add mock-mode UI test coverage confirming the menu item appears and opens the sheet correctly prefilled.
- Register the new "Push…" string in the localization catalog (Xcode auto-add on build).

## Test plan
- [x] `swiftlint lint --strict` clean
- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test -only-testing:BerthlyUITests/ContextMenuTests/testImageContextMenuShowsActionsAndCopiesReference` passes
- [x] `xcodebuild test -only-testing:BerthlyUITests/ContextMenuTests/testImageContextMenuPushOpensPushSheetPrefilled` passes