### PR TITLE
feat: add drag-and-drop Dockerfile/Containerfile to build

### DIFF
--- a/Berthly/Core/BuildDropResolver.swift
+++ b/Berthly/Core/BuildDropResolver.swift
@@ -1,0 +1,80 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import Foundation
+
+/// A single dropped item, already loaded from its `NSItemProvider` (see
+/// `BuildDropDelegate.performDrop`). `.unreadable` preserves a failed load instead of dropping it
+/// silently, so `resolve(candidates:)` can tell "nothing here was ever readable" apart from "one
+/// file failed, but a later one was a valid Dockerfile" (PLAN/PLAN-drag-drop-build.md §3.3 step 7).
+nonisolated enum BuildDropCandidate: Sendable {
+    case url(URL)
+    case unreadable
+}
+
+/// The build context/Dockerfile path resolved from a successful drop — the resolved target's
+/// parent directory and its own resolved path, not the (possibly symlinked) dropped item's.
+nonisolated struct BuildDropResolution: Sendable, Equatable {
+    let contextPath: String
+    let dockerfilePath: String
+}
+
+/// Why no candidate resolved to a usable Dockerfile. `.unsupportedFile` takes precedence over
+/// `.unreadableFile` when both occurred in the same drop — see `resolve(candidates:)`.
+nonisolated enum BuildDropRejection: Sendable, Error, Equatable {
+    case unsupportedFile
+    case unreadableFile
+}
+
+/// Walks dropped-file candidates and picks the first one that is a real Dockerfile/Containerfile
+/// (PLAN/PLAN-drag-drop-build.md §3.3 steps 2–5). Runs off the main actor — a slow or
+/// network-mounted volume must not freeze the drag — so every member here is `nonisolated` and
+/// touches only local, synchronous filesystem APIs.
+nonisolated enum BuildDropResolver {
+    static func resolve(candidates: [BuildDropCandidate]) -> Result<BuildDropResolution, BuildDropRejection> {
+        var sawUnsupported = false
+
+        for candidate in candidates {
+            guard case .url(let url) = candidate else {
+                continue
+            }
+
+            // Validate the dropped item's own visible name — never the resolved symlink target's
+            // — before touching the filesystem any further (the symlink policy in §3.3).
+            guard BuildDropValidator.isDockerfileLike(url.lastPathComponent) else {
+                sawUnsupported = true
+                continue
+            }
+
+            let resolved = url.resolvingSymlinksInPath()
+
+            // A broken symlink's target doesn't exist, so `resolvingSymlinksInPath()` above leaves
+            // it unresolved (still pointing at the symlink's own path) rather than throwing —
+            // verified empirically, since neither `resourceValues(forKeys:)` nor
+            // `checkResourceIsReachable()` throws for it either. `fileExists` is what actually
+            // tells a missing target apart from a real (if wrong-typed) file.
+            guard FileManager.default.fileExists(atPath: resolved.path) else {
+                continue
+            }
+
+            let resourceValues: URLResourceValues
+            do {
+                resourceValues = try resolved.resourceValues(forKeys: [.isRegularFileKey])
+            } catch {
+                continue
+            }
+
+            guard resourceValues.isRegularFile == true else {
+                sawUnsupported = true
+                continue
+            }
+
+            return .success(BuildDropResolution(
+                contextPath: resolved.deletingLastPathComponent().path(percentEncoded: false),
+                dockerfilePath: resolved.path(percentEncoded: false)
+            ))
+        }
+
+        return .failure(sawUnsupported ? .unsupportedFile : .unreadableFile)
+    }
+}

--- a/Berthly/Core/BuildDropValidator.swift
+++ b/Berthly/Core/BuildDropValidator.swift
@@ -1,0 +1,19 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import Foundation
+
+/// Filename rule for drag-and-drop build (see PLAN/PLAN-drag-drop-build.md §4). Matches on the
+/// candidate's own last path component only — never file content, never a resolved symlink
+/// target's name.
+nonisolated enum BuildDropValidator {
+    static func isDockerfileLike(_ filename: String) -> Bool {
+        let lowered = filename.lowercased()
+        return lowered == "dockerfile"
+            || lowered == "containerfile"
+            || lowered.hasPrefix("dockerfile.")
+            || lowered.hasPrefix("containerfile.")
+            || lowered.hasSuffix(".dockerfile")
+            || lowered.hasSuffix(".containerfile")
+    }
+}

--- a/Berthly/Views/BuildDropDelegate.swift
+++ b/Berthly/Views/BuildDropDelegate.swift
@@ -1,0 +1,94 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// What the hover overlay should say while a drag is over the window. Connectivity-only — there is
+/// no synchronous filename signal available during a drag (PLAN/PLAN-drag-drop-build.md §3.2/§5.0).
+enum BuildDropHoverState {
+    case acceptable
+    case disconnected
+}
+
+/// Presentation-only: no filesystem logic lives here (that's `BuildDropResolver`). Loads dropped
+/// `NSItemProvider`s into plain `BuildDropCandidate` values and hands them to `onDrop` — the caller
+/// decides what a valid drop means.
+struct BuildDropDelegate: DropDelegate {
+    @Binding var hoverState: BuildDropHoverState?
+    /// True from the moment `performDrop` starts until a fresh drag begins. Guards `dropUpdated`:
+    /// empirically, one more `dropUpdated` call can land *after* `performDrop` has already fired
+    /// (right as the drag resolves into a drop), which would otherwise re-set `hoverState` right
+    /// after `performDrop` cleared it — and since the drag session has already ended by then,
+    /// nothing would ever run again to clear it, leaving the overlay stuck until the next drag.
+    @Binding var isDropInFlight: Bool
+    /// Bumped synchronously, here, the instant a drop starts — not after provider loading
+    /// finishes. Loading is async and variable-length, so if generations were assigned on
+    /// completion instead, a slow-loading earlier drop could finish after a fast-loading later
+    /// one and get assigned the *higher* number, letting it incorrectly win. Assigning at the
+    /// start ties generation order to actual drop order, regardless of how long each one takes
+    /// to load or resolve.
+    @Binding var dropGeneration: Int
+    let isConnected: () -> Bool
+    let onDrop: (Int, [BuildDropCandidate]) -> Void
+
+    func dropEntered(info: DropInfo) {
+        isDropInFlight = false
+    }
+
+    func dropExited(info: DropInfo) {
+        hoverState = nil
+    }
+
+    /// Evaluated fresh on every call (not captured once) so a connectivity change mid-drag is
+    /// reflected. Returning `.forbidden` here hard-blocks `performDrop` — confirmed empirically by
+    /// the §5.0 spike, not just a cosmetic cursor hint. Once `isDropInFlight` is set, this stops
+    /// touching `hoverState` at all — see the property's doc comment.
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        guard !isDropInFlight else {
+            return DropProposal(operation: isConnected() ? .copy : .forbidden)
+        }
+        if isConnected() {
+            hoverState = .acceptable
+            return DropProposal(operation: .copy)
+        }
+        hoverState = .disconnected
+        return DropProposal(operation: .forbidden)
+    }
+
+    /// `DropInfo` is only valid for the duration of this synchronous call, so only the
+    /// already-extracted `providers` array is captured into the `Task`, never `info` itself.
+    func performDrop(info: DropInfo) -> Bool {
+        // Order matters: flip `isDropInFlight` first so a trailing `dropUpdated` can't win the
+        // race and re-set `hoverState` right after this clears it.
+        isDropInFlight = true
+        hoverState = nil
+        dropGeneration += 1
+        let generation = dropGeneration
+        let providers = info.itemProviders(for: [.fileURL])
+        guard !providers.isEmpty else { return false }
+        Task { @MainActor in
+            var candidates: [BuildDropCandidate] = []
+            for provider in providers {
+                candidates.append(await Self.loadCandidate(provider))
+            }
+            onDrop(generation, candidates)
+        }
+        return true
+    }
+
+    /// Bridges the one `NSItemProvider` completion callback to `async`/`await`. `NSURL.self`, not
+    /// `URL.self` — confirmed by the §5.0 spike as the form that actually resolves for a real
+    /// Finder file drag.
+    private static func loadCandidate(_ provider: NSItemProvider) async -> BuildDropCandidate {
+        await withCheckedContinuation { continuation in
+            _ = provider.loadObject(ofClass: NSURL.self) { reading, _ in
+                if let url = reading as? URL {
+                    continuation.resume(returning: .url(url))
+                } else {
+                    continuation.resume(returning: .unreadable)
+                }
+            }
+        }
+    }
+}

--- a/Berthly/Views/BuildDropOverlay.swift
+++ b/Berthly/Views/BuildDropOverlay.swift
@@ -1,0 +1,62 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import SwiftUI
+
+/// Full-window overlay shown while dragging a file over the main window. `.allowsHitTesting(false)`
+/// — it sits on top of everything else in `contentPane` and must not intercept the drag events the
+/// underlying `.onDrop` still needs, or ordinary clicks once it's gone.
+struct BuildDropHoverOverlay: View {
+    let state: BuildDropHoverState
+
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.25)
+            VStack(spacing: 12) {
+                Image(systemName: state == .disconnected ? "xmark.circle.fill" : "hammer.fill")
+                    .font(.system(size: 40))
+                    .foregroundStyle(state == .disconnected ? Color.red : Color.berthlyAccent)
+                Text(message)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(24)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 16))
+        }
+        .allowsHitTesting(false)
+    }
+
+    private var message: String {
+        switch state {
+        case .acceptable:   "Drop to build an image"
+        case .disconnected: "Connect to the container service to build."
+        }
+    }
+}
+
+/// Transient rejection message shown after a drop that couldn't be used to build. Auto-dismisses on
+/// a timer (see `MainWindowView.showDropRejection`), so `.allowsHitTesting(false)` keeps it from
+/// blocking clicks on whatever's underneath while it fades out.
+struct BuildDropRejectionBanner: View {
+    let message: String
+
+    var body: some View {
+        VStack {
+            Spacer()
+            HStack(spacing: 10) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.yellow)
+                Text(message)
+                    .font(.callout)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+            .shadow(radius: 8)
+            .padding(.bottom, 24)
+        }
+        .allowsHitTesting(false)
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+    }
+}

--- a/Berthly/Views/BuildImageSheet.swift
+++ b/Berthly/Views/BuildImageSheet.swift
@@ -34,6 +34,7 @@ struct BuildImageSheet: View {
     @State private var pull: Bool = false
 
     @State private var job: BuildJob?
+    @FocusState private var isTagFieldFocused: Bool
 
     init(
         service: ContainerServiceBase,
@@ -134,6 +135,13 @@ struct BuildImageSheet: View {
         }
         .onAppear {
             if existingJob?.isFinished == true { existingJob?.seen = true }
+            // Setting `@FocusState` synchronously in `.onAppear` is unreliable for a freshly
+            // presented sheet on macOS — the request lands before the sheet's window/view is
+            // actually installed, and gets silently dropped. Deferring one runloop tick, after
+            // that installation has finished, is what makes it stick.
+            if job == nil {
+                DispatchQueue.main.async { isTagFieldFocused = true }
+            }
         }
     }
 
@@ -160,6 +168,7 @@ struct BuildImageSheet: View {
                     .textFieldStyle(.plain)
                     .fontDesign(.monospaced)
                     .accessibilityIdentifier("buildTagField")
+                    .focused($isTagFieldFocused)
                 // Existing local tags as one-click suggestions — rebuilding an image you
                 // already have is the common case, so don't make the user retype the tag.
                 if !service.images.isEmpty {

--- a/Berthly/Views/MainWindowView.swift
+++ b/Berthly/Views/MainWindowView.swift
@@ -1,8 +1,20 @@
 // Copyright 2026 Berthly Contributors
 // Licensed under the Apache License, Version 2.0
 
+import AppKit
 import SwiftUI
 import TerminalProgress
+import UniformTypeIdentifiers
+
+/// A request to open the build sheet, however it was triggered — sidebar/palette/toolbar (empty),
+/// builds popover (`existingJob`), or a successful drag-and-drop (`prefillContext`). `Identifiable`
+/// so `.sheet(item:)` re-presents a fresh sheet even if two requests happen to carry the same data.
+private struct BuildSheetRequest: Identifiable {
+    let id = UUID()
+    var prefillTag: String?
+    var prefillContext: BuildContext?
+    var existingJob: BuildJob?
+}
 
 struct MainWindowView: View {
     @Environment(ContainerServiceBase.self) private var service
@@ -16,7 +28,6 @@ struct MainWindowView: View {
     @State private var isRefreshing = false
     @State private var refreshRotation = 0.0
     @State private var showPullSheet = false
-    @State private var showBuildSheet = false
     @State private var showRunMenu = false
     @State private var showRunSheet = false
     @State private var showMachineCreateSheet = false
@@ -25,7 +36,20 @@ struct MainWindowView: View {
     @State private var showAddRegistrySheet = false
     @State private var loadImageRequest: ImageLoadRequest?
     @State private var showBuildsPopover = false
-    @State private var viewedBuildJob: BuildJob?
+    /// One request drives every entry point that opens the build sheet (sidebar, palette,
+    /// toolbar, builds popover, and drag-and-drop) so a stale prefill from one path can't leak
+    /// into an unrelated later Build click.
+    @State private var buildSheetRequest: BuildSheetRequest?
+    @State private var dropHoverState: BuildDropHoverState?
+    @State private var isDropInFlight = false
+    @State private var dropRejectionMessage: String?
+    @State private var dropRejectionDismissTask: Task<Void, Never>?
+    /// Bumped synchronously by `BuildDropDelegate.performDrop` the instant each drop starts (not
+    /// here, and not after loading finishes — see that property's doc comment for why timing
+    /// matters). `handleBuildDrop` compares its captured generation against this after resolving,
+    /// so a resolve that's still running when a newer drop lands can tell it's stale and skip
+    /// presenting.
+    @State private var dropGeneration = 0
     @State private var showCommandPalette = false
     /// Last `commandPaletteToken` this window has acted on, so a ⌘K that predates the window's mount
     /// is presented exactly once via `.onAppear` (see `presentPaletteIfRequested()`).
@@ -138,6 +162,27 @@ struct MainWindowView: View {
             } // end GeometryReader
         }
         .navigationTitle("Berthly")
+        // Drag a Dockerfile/Containerfile from Finder anywhere onto the window — sidebar included —
+        // to jump straight into a pre-filled Build sheet (PLAN/PLAN-drag-drop-build.md §3.1 scopes
+        // this to "the whole main window content area"). Attached at the NavigationSplitView level,
+        // not inside the detail column, so the sidebar is a drop target too.
+        .onDrop(of: [.fileURL], delegate: BuildDropDelegate(
+            hoverState: $dropHoverState,
+            isDropInFlight: $isDropInFlight,
+            dropGeneration: $dropGeneration,
+            isConnected: { service.isConnected },
+            onDrop: handleBuildDrop))
+        .overlay {
+            if let state = dropHoverState {
+                BuildDropHoverOverlay(state: state)
+            }
+        }
+        .overlay {
+            if let message = dropRejectionMessage {
+                BuildDropRejectionBanner(message: message)
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: dropRejectionMessage)
         // ⎋ backs out one level: close the palette if it's up, else collapse the detail pane by
         // clearing the selection. A hidden key-equivalent button, not `.onExitCommand` — key
         // equivalents resolve window-wide regardless of focus, while cancelOperation only reaches
@@ -171,9 +216,6 @@ struct MainWindowView: View {
             }
             .environment(service as ContainerServiceBase)
         }
-        .sheet(isPresented: $showBuildSheet) {
-            BuildImageSheet(service: service)
-        }
         .sheet(isPresented: $showRunSheet) {
             RunContainerSheet(service: service)
         }
@@ -192,8 +234,12 @@ struct MainWindowView: View {
         .sheet(item: $loadImageRequest) { request in
             LoadImageSheet(archiveURL: request.url)
         }
-        .sheet(item: $viewedBuildJob) { job in
-            BuildImageSheet(service: service, existingJob: job)
+        .sheet(item: $buildSheetRequest) { request in
+            BuildImageSheet(
+                service: service,
+                prefillTag: request.prefillTag,
+                prefillContext: request.prefillContext,
+                existingJob: request.existingJob)
         }
         // Lets the menu bar tell whether a main window already exists before deciding whether to
         // call `openWindow(id:)` — that API has no built-in single-instance behavior for a plain
@@ -263,7 +309,7 @@ struct MainWindowView: View {
             sidebarSelection = sidebarSelection(for: section)
         case .runContainer:    showRunSheet = true
         case .createMachine:   showMachineCreateSheet = true
-        case .buildImage:      showBuildSheet = true
+        case .buildImage:      buildSheetRequest = BuildSheetRequest()
         case .pullImage:       showPullSheet = true
         case .loadImage:       promptLoadImage()
         case .createVolume:    showVolumeCreateSheet = true
@@ -293,6 +339,71 @@ struct MainWindowView: View {
     private func promptLoadImage() {
         if let url = promptForArchiveToLoad() {
             loadImageRequest = ImageLoadRequest(url: url)
+        }
+    }
+
+    /// `BuildDropDelegate`'s `onDrop` callback. `BuildDropDelegate` only loads providers into
+    /// candidates (§3.3 step 1); the filename/symlink/regular-file walk (steps 2–5) happens right
+    /// below, in the `BuildDropResolver.resolve` call — this function implements §3.3 steps 2–7
+    /// end to end. `BuildDropResolver` never touches the main actor, so it's dispatched via
+    /// `Task.detached`.
+    private func handleBuildDrop(generation: Int, candidates: [BuildDropCandidate]) {
+        Task {
+            let outcome = await Task.detached {
+                BuildDropResolver.resolve(candidates: candidates)
+            }.value
+            // A newer drop landed while this one was resolving — its outcome is stale, so this
+            // one's is the one that should win instead. Not observable behavior a test can assert
+            // on, but this must run first, before `outcome` is even inspected.
+            guard generation == dropGeneration else { return }
+            present(outcome)
+        }
+    }
+
+    /// Connectivity is checked first, before `outcome` — a disconnect that happens *during*
+    /// resolution (which runs concurrently with anything else that could change
+    /// `service.isConnected`) always produces the disconnected message, regardless of what the
+    /// resolver itself returned.
+    private func present(_ outcome: Result<BuildDropResolution, BuildDropRejection>) {
+        guard service.isConnected else {
+            showDropRejection("Connect to the container service to build.")
+            return
+        }
+        switch outcome {
+        case .success(let resolution):
+            dropRejectionDismissTask?.cancel()
+            dropRejectionMessage = nil
+            // Accepting a drop doesn't activate the app the way a click does — Finder (the drag's
+            // source) can stay frontmost the whole time, and macOS doesn't bring the destination
+            // window forward just because it accepted a drop. Without this, the sheet opens behind
+            // an inactive window: it renders fine, but isn't key, so the Tag field's focus grab
+            // (`BuildImageSheet`'s `.onAppear`) has no key window to actually land in.
+            NSApp.activate(ignoringOtherApps: true)
+            buildSheetRequest = BuildSheetRequest(prefillContext: BuildContext(
+                contextPath: resolution.contextPath,
+                dockerfilePath: resolution.dockerfilePath))
+        case .failure(.unsupportedFile):
+            showDropRejection("Drop a Dockerfile or Containerfile to build.")
+        case .failure(.unreadableFile):
+            showDropRejection("Couldn't read the dropped file.")
+        }
+    }
+
+    /// Shows a transient rejection banner and (re)schedules its dismissal. Cancelling the previous
+    /// dismissal task before setting the new message matters: without it, a second rejected drop
+    /// arriving while the first message is still showing would start a second timer, but the
+    /// first — already in flight — would still fire partway through and clear the second, newer
+    /// message early.
+    private func showDropRejection(_ message: String) {
+        dropRejectionDismissTask?.cancel()
+        dropRejectionMessage = message
+        // The banner is purely visual and gone in ~3s — without an explicit announcement, VoiceOver
+        // has no reason to read it, since nothing moved focus to it.
+        AccessibilityNotification.Announcement(message).post()
+        dropRejectionDismissTask = Task {
+            try? await Task.sleep(for: .seconds(3))
+            guard !Task.isCancelled else { return }
+            dropRejectionMessage = nil
         }
     }
 
@@ -362,7 +473,7 @@ struct MainWindowView: View {
         case .openCreateMachineSheet:
             showMachineCreateSheet = true
         case .openBuildSheet:
-            showBuildSheet = true
+            buildSheetRequest = BuildSheetRequest()
         case .openPullSheet:
             showPullSheet = true
         case .openLoadImageSheet:
@@ -462,7 +573,7 @@ struct MainWindowView: View {
             )
 
             Button {
-                showBuildSheet = true
+                buildSheetRequest = BuildSheetRequest()
             } label: {
                 Label("Build", systemImage: "hammer")
                     .labelStyle(.titleAndIcon)
@@ -508,7 +619,7 @@ struct MainWindowView: View {
                     PopoverAnchor(isPresented: $showBuildsPopover) {
                         BuildsPopover(manager: buildManager) { job in
                             showBuildsPopover = false
-                            viewedBuildJob = job
+                            buildSheetRequest = BuildSheetRequest(existingJob: job)
                         }
                     }
                 )

--- a/BerthlyManualTests/DragDropBuild/01-canonical-dockerfile/Dockerfile
+++ b/BerthlyManualTests/DragDropBuild/01-canonical-dockerfile/Dockerfile
@@ -1,0 +1,1 @@
+FROM scratch

--- a/BerthlyManualTests/DragDropBuild/02-canonical-containerfile/Containerfile
+++ b/BerthlyManualTests/DragDropBuild/02-canonical-containerfile/Containerfile
@@ -1,0 +1,1 @@
+FROM scratch

--- a/BerthlyManualTests/DragDropBuild/03-prefixed-variant/Dockerfile.prod
+++ b/BerthlyManualTests/DragDropBuild/03-prefixed-variant/Dockerfile.prod
@@ -1,0 +1,1 @@
+FROM scratch

--- a/BerthlyManualTests/DragDropBuild/04-suffixed-variant/backend.Dockerfile
+++ b/BerthlyManualTests/DragDropBuild/04-suffixed-variant/backend.Dockerfile
@@ -1,0 +1,1 @@
+FROM scratch

--- a/BerthlyManualTests/DragDropBuild/05-non-matching-name/README.md
+++ b/BerthlyManualTests/DragDropBuild/05-non-matching-name/README.md
@@ -1,0 +1,8 @@
+# Just a README
+
+This file is deliberately *not* named `Dockerfile` or `Containerfile`.
+Dragging it onto Berthly's main window should be rejected with:
+
+> Drop a Dockerfile or Containerfile to build.
+
+Its content is never read to decide that — only the filename is.

--- a/BerthlyManualTests/DragDropBuild/06-symlink-name-matches-target-doesnt/Dockerfile
+++ b/BerthlyManualTests/DragDropBuild/06-symlink-name-matches-target-doesnt/Dockerfile
@@ -1,0 +1,1 @@
+../05-non-matching-name/README.md

--- a/BerthlyManualTests/DragDropBuild/07-symlink-name-mismatch/Dockerfile
+++ b/BerthlyManualTests/DragDropBuild/07-symlink-name-mismatch/Dockerfile
@@ -1,0 +1,1 @@
+FROM scratch

--- a/BerthlyManualTests/DragDropBuild/07-symlink-name-mismatch/build-file
+++ b/BerthlyManualTests/DragDropBuild/07-symlink-name-mismatch/build-file
@@ -1,0 +1,1 @@
+Dockerfile

--- a/BerthlyManualTests/DragDropBuild/08-broken-symlink-named-dockerfile/Dockerfile
+++ b/BerthlyManualTests/DragDropBuild/08-broken-symlink-named-dockerfile/Dockerfile
@@ -1,0 +1,1 @@
+does-not-exist

--- a/BerthlyManualTests/DragDropBuild/09-directory-named-dockerfile/Dockerfile/NOTE.md
+++ b/BerthlyManualTests/DragDropBuild/09-directory-named-dockerfile/Dockerfile/NOTE.md
@@ -1,0 +1,5 @@
+This directory is named `Dockerfile` on purpose — it's not a file.
+
+Dragging the `Dockerfile` entry in the parent folder (`09-directory-named-dockerfile/`)
+onto Berthly should be **rejected**: the name passes the filename check, but
+the resolver's regular-file check then fails, since this is a directory.

--- a/BerthlyManualTests/DragDropBuild/10-path-with-spaces-and-non-ascii/Café Project/Dockerfile
+++ b/BerthlyManualTests/DragDropBuild/10-path-with-spaces-and-non-ascii/Café Project/Dockerfile
@@ -1,0 +1,1 @@
+FROM scratch

--- a/BerthlyManualTests/README.md
+++ b/BerthlyManualTests/README.md
@@ -1,0 +1,57 @@
+# Manual tests
+
+Fixtures for QA scenarios that automation can't reliably cover — currently
+just one: dragging a Dockerfile/Containerfile from Finder onto Berthly's main
+window to open a pre-filled Build sheet. XCUITest has no public API to
+synthesize a real Finder file-promise drag (`NSItemProvider`), so this has to
+be exercised by hand.
+
+This is a companion to `BerthlyTests` (unit), `BerthlyUITests` (mock-mode UI),
+and `BerthlyE2ETests` (real-daemon UI) — same idea, but for the one class of
+interaction none of those three can drive. Nothing here builds or runs as an
+Xcode target; it's just files to drag.
+
+## Drag-and-drop build
+
+Build and run Berthly (⌘R), open this folder in Finder
+(`BerthlyManualTests/DragDropBuild/`), and drag each item below onto the main
+window — the whole window is a drop target, including the sidebar, the
+Images/Compute lists, and any open detail pane. Check the result against the
+"Expected" column.
+
+| # | Drag this | Expected | Why |
+| --- | --- | --- | --- |
+| 01 | `01-canonical-dockerfile/Dockerfile` | Build sheet opens, both fields filled | Canonical name |
+| 02 | `02-canonical-containerfile/Containerfile` | Build sheet opens, both fields filled | Canonical alt name |
+| 03 | `03-prefixed-variant/Dockerfile.prod` | Build sheet opens, both fields filled | `Dockerfile.<suffix>` naming |
+| 04 | `04-suffixed-variant/backend.Dockerfile` | Build sheet opens, both fields filled | `<prefix>.Dockerfile` naming |
+| 05 | `05-non-matching-name/README.md` | Rejection banner: "Drop a Dockerfile or Containerfile to build." | Name doesn't match; content is never read |
+| 06 | `06-symlink-name-matches-target-doesnt/Dockerfile` | **Accepted** — sheet opens pointing at `05-non-matching-name/README.md`'s real location | Symlink's own visible name (`Dockerfile`) is what's validated, not its target |
+| 07 | `07-symlink-name-mismatch/build-file` | **Rejected** — same banner as #05 | Symlink's own name (`build-file`) fails the check; its target (`Dockerfile`) is never even resolved |
+| 08 | `08-broken-symlink-named-dockerfile/Dockerfile` | Rejection banner: "Couldn't read the dropped file." | Name matches, but the symlink's target doesn't exist |
+| 09 | `09-directory-named-dockerfile/Dockerfile` | Rejection banner: "Drop a Dockerfile or Containerfile to build." | Name matches, but it's a directory, not a file |
+| 10 | `10-path-with-spaces-and-non-ascii/Café Project/Dockerfile` | Build sheet opens, both fields filled correctly (no mangled characters) | Round-trips a path with a space and a non-ASCII character |
+
+Also worth checking while you're at it, since these don't need a specific
+fixture:
+
+- **Overlay clears after a drop**, both on acceptance (sheet opens with no
+  stuck overlay behind it) and on rejection (banner shows, overlay itself is
+  gone).
+- **Disconnected daemon**: stop the daemon (or use Settings → Advanced to
+  simulate it) and drag anything — the overlay should read "Connect to the
+  container service to build," and the drop should be refused even if you
+  release over the window.
+- **Rapid re-reject**: drag `05-non-matching-name/README.md` twice in quick
+  succession — the second rejection should reset the banner's ~3s dismiss
+  timer rather than having the first timer cut the second message off early.
+- **Sidebar drop**: drag `01-canonical-dockerfile/Dockerfile` directly onto
+  the sidebar (not the list/detail area) — it should work exactly like
+  dropping anywhere else in the window.
+
+## A note on the symlinks (06–08)
+
+`git` tracks symlinks natively (mode `120000`) and restores them as real
+symbolic links on checkout — no setup needed after `git clone`, on macOS or
+Linux. `08`'s symlink is intentionally broken (points at a target that
+doesn't exist); that's the fixture, not a mistake.

--- a/BerthlyTests/BuildDropResolverTests.swift
+++ b/BerthlyTests/BuildDropResolverTests.swift
@@ -1,0 +1,156 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import Foundation
+import Testing
+@testable import Berthly
+
+struct BuildDropResolverTests {
+
+    /// A fresh temp directory per test, torn down after — real files/symlinks on disk, since this
+    /// layer does actual filesystem work (§3.3 steps 2–5).
+    private func withTempDir(_ body: (URL) throws -> Void) rethrows {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("BuildDropResolverTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try body(dir)
+    }
+
+    @Test func validDropResolvesContextAndDockerfilePath() throws {
+        try withTempDir { dir in
+            let dockerfile = dir.appendingPathComponent("Dockerfile")
+            try "FROM scratch".write(to: dockerfile, atomically: true, encoding: .utf8)
+
+            let result = BuildDropResolver.resolve(candidates: [.url(dockerfile)])
+
+            switch result {
+            case .success(let resolution):
+                #expect(resolution.contextPath == dockerfile.deletingLastPathComponent().path(percentEncoded: false))
+                #expect(resolution.dockerfilePath == dockerfile.path(percentEncoded: false))
+            case .failure(let rejection):
+                Issue.record("expected success, got \(rejection)")
+            }
+        }
+    }
+
+    @Test func directoryNamedDockerfileIsUnsupported() throws {
+        try withTempDir { dir in
+            let fakeDockerfile = dir.appendingPathComponent("Dockerfile")
+            try FileManager.default.createDirectory(at: fakeDockerfile, withIntermediateDirectories: true)
+
+            let result = BuildDropResolver.resolve(candidates: [.url(fakeDockerfile)])
+
+            #expect(result == .failure(.unsupportedFile))
+        }
+    }
+
+    @Test func nonMatchingNameIsUnsupportedRegardlessOfContent() throws {
+        try withTempDir { dir in
+            let readme = dir.appendingPathComponent("README.md")
+            try "FROM scratch".write(to: readme, atomically: true, encoding: .utf8)
+
+            let result = BuildDropResolver.resolve(candidates: [.url(readme)])
+
+            #expect(result == .failure(.unsupportedFile))
+        }
+    }
+
+    @Test func symlinkNamedDockerfilePointingAtOtherFileIsAccepted() throws {
+        try withTempDir { dir in
+            let target = dir.appendingPathComponent("README.md")
+            try "not really a Dockerfile".write(to: target, atomically: true, encoding: .utf8)
+            let link = dir.appendingPathComponent("Dockerfile")
+            try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+            let result = BuildDropResolver.resolve(candidates: [.url(link)])
+
+            switch result {
+            case .success(let resolution):
+                #expect(resolution.dockerfilePath == target.resolvingSymlinksInPath().path(percentEncoded: false))
+                #expect(resolution.contextPath == dir.resolvingSymlinksInPath().path(percentEncoded: false))
+            case .failure(let rejection):
+                Issue.record("expected success, got \(rejection)")
+            }
+        }
+    }
+
+    @Test func symlinkWithNonMatchingNamePointingAtDockerfileIsRejected() throws {
+        try withTempDir { dir in
+            let target = dir.appendingPathComponent("Dockerfile")
+            try "FROM scratch".write(to: target, atomically: true, encoding: .utf8)
+            let link = dir.appendingPathComponent("build-file")
+            try FileManager.default.createSymbolicLink(at: link, withDestinationURL: target)
+
+            let result = BuildDropResolver.resolve(candidates: [.url(link)])
+
+            #expect(result == .failure(.unsupportedFile))
+        }
+    }
+
+    @Test func brokenSymlinkNamedDockerfileIsUnreadable() throws {
+        try withTempDir { dir in
+            let missingTarget = dir.appendingPathComponent("does-not-exist")
+            let link = dir.appendingPathComponent("Dockerfile")
+            try FileManager.default.createSymbolicLink(at: link, withDestinationURL: missingTarget)
+
+            let result = BuildDropResolver.resolve(candidates: [.url(link)])
+
+            #expect(result == .failure(.unreadableFile))
+        }
+    }
+
+    @Test func firstValidCandidateInOrderWins() throws {
+        try withTempDir { dir in
+            let readme = dir.appendingPathComponent("README.md")
+            try "irrelevant".write(to: readme, atomically: true, encoding: .utf8)
+            let first = dir.appendingPathComponent("Dockerfile")
+            try "FROM scratch AS first".write(to: first, atomically: true, encoding: .utf8)
+            let secondDir = dir.appendingPathComponent("second")
+            try FileManager.default.createDirectory(at: secondDir, withIntermediateDirectories: true)
+            let second = secondDir.appendingPathComponent("Containerfile")
+            try "FROM scratch AS second".write(to: second, atomically: true, encoding: .utf8)
+
+            let result = BuildDropResolver.resolve(candidates: [.url(readme), .url(first), .url(second)])
+
+            switch result {
+            case .success(let resolution):
+                #expect(resolution.dockerfilePath == first.path(percentEncoded: false))
+            case .failure(let rejection):
+                Issue.record("expected success, got \(rejection)")
+            }
+        }
+    }
+
+    @Test func unreadableCandidateFollowedByValidOneStillResolves() throws {
+        try withTempDir { dir in
+            let dockerfile = dir.appendingPathComponent("Dockerfile")
+            try "FROM scratch".write(to: dockerfile, atomically: true, encoding: .utf8)
+
+            let result = BuildDropResolver.resolve(candidates: [.unreadable, .url(dockerfile)])
+
+            switch result {
+            case .success(let resolution):
+                #expect(resolution.dockerfilePath == dockerfile.path(percentEncoded: false))
+            case .failure(let rejection):
+                Issue.record("expected success, got \(rejection)")
+            }
+        }
+    }
+
+    @Test func allUnreadableCandidatesYieldsUnreadableFile() {
+        let result = BuildDropResolver.resolve(candidates: [.unreadable, .unreadable])
+        #expect(result == .failure(.unreadableFile))
+    }
+
+    @Test func unreadablePlusUnsupportedYieldsUnsupportedFile() throws {
+        try withTempDir { dir in
+            let readme = dir.appendingPathComponent("README.md")
+            try "irrelevant".write(to: readme, atomically: true, encoding: .utf8)
+
+            let result = BuildDropResolver.resolve(candidates: [.unreadable, .url(readme)])
+
+            #expect(result == .failure(.unsupportedFile))
+        }
+    }
+}

--- a/BerthlyTests/BuildDropValidatorTests.swift
+++ b/BerthlyTests/BuildDropValidatorTests.swift
@@ -1,0 +1,40 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import Testing
+@testable import Berthly
+
+struct BuildDropValidatorTests {
+
+    @Test func canonicalNamesMatch() {
+        #expect(BuildDropValidator.isDockerfileLike("Dockerfile"))
+        #expect(BuildDropValidator.isDockerfileLike("Containerfile"))
+    }
+
+    @Test func caseInsensitive() {
+        #expect(BuildDropValidator.isDockerfileLike("dockerfile"))
+        #expect(BuildDropValidator.isDockerfileLike("DOCKERFILE"))
+        #expect(BuildDropValidator.isDockerfileLike("cOnTaInErFiLe"))
+    }
+
+    @Test func prefixedVariantsMatch() {
+        #expect(BuildDropValidator.isDockerfileLike("Dockerfile.prod"))
+        #expect(BuildDropValidator.isDockerfileLike("containerfile.dev"))
+    }
+
+    @Test func suffixedVariantsMatch() {
+        #expect(BuildDropValidator.isDockerfileLike("backend.Dockerfile"))
+        #expect(BuildDropValidator.isDockerfileLike("worker.containerfile"))
+    }
+
+    @Test func unrelatedNamesAreRejected() {
+        #expect(!BuildDropValidator.isDockerfileLike("README.md"))
+        #expect(!BuildDropValidator.isDockerfileLike("main.swift"))
+        #expect(!BuildDropValidator.isDockerfileLike(""))
+    }
+
+    @Test func nearMissesAreRejected() {
+        #expect(!BuildDropValidator.isDockerfileLike("Dockerfile2"))
+        #expect(!BuildDropValidator.isDockerfileLike(".dockerfileignore"))
+    }
+}


### PR DESCRIPTION
## Summary
- Drag a `Dockerfile`/`Containerfile` from Finder onto Berthly's main window (sidebar included) to open the Build sheet pre-filled with the resolved build context and Dockerfile path.
- Filename-only validation (`Dockerfile`, `Containerfile`, and common prefix/suffix variants), with symlink-safe resolution: the dropped item's own visible name is validated, only the resolved target is used for the actual paths.
- Hover reflects daemon connectivity only — `NSItemProvider.suggestedName` is unavailable synchronously during a real Finder drag, so there's no live filename-aware cursor; the authoritative check happens on drop.
- Unifies every build-sheet entry point (sidebar, palette, toolbar, builds popover, drag-and-drop) behind one `BuildSheetRequest`, replacing the previous `showBuildSheet`/`viewedBuildJob` pair.
- Adds `BerthlyManualTests/DragDropBuild/` — fixtures (including two real symlinks and one intentionally broken one) for the one interaction XCUITest can't synthesize: a real Finder drag.

## Test plan
- [x] `BuildDropValidatorTests` / `BuildDropResolverTests` — 16 new unit tests covering the filename rule and the full symlink/regular-file/precedence matrix against real temp files and symlinks on disk.
- [x] `swiftlint lint --strict` — clean.
- [x] Full build — clean, no warnings.
- [x] Targeted `BerthlyUITests` regressions (main window launch, build sheet open/close, background build survival, palette, run menu, image context menu) — all green, confirming the sheet-presentation refactor didn't break existing entry points.
- [x] Manual QA against `BerthlyManualTests/DragDropBuild/` fixtures on a real daemon: accept/reject paths, both symlink cases, disconnected-daemon overlay, rapid re-reject timer, sidebar drop, and Tag-field focus after a successful drop.