### PR TITLE
fix: harden privileged and long-running operations

### DIFF
--- a/Berthly/Core/BuildJobManager.swift
+++ b/Berthly/Core/BuildJobManager.swift
@@ -24,14 +24,15 @@ final class BuildJob: Identifiable {
         case failed(message: String)
     }
 
+    nonisolated static let maxLogLineCount = 5_000
+    private nonisolated static let logTrimCount = 1_000
+
     let id = UUID()
     let reference: String
     let startedAt = Date()
     private(set) var finishedAt: Date?
     private(set) var logLines: [LogLine] = []
     private(set) var status: Status = .building
-    nonisolated static let maxLogLineCount = 5_000
-    private nonisolated static let logTrimCount = 1_000
 
     /// Whether the user has already seen this job's final state (watched it finish in the
     /// sheet, or opened the builds popover). Drives the toolbar badge.

--- a/Berthly/Core/BuildJobManager.swift
+++ b/Berthly/Core/BuildJobManager.swift
@@ -30,6 +30,8 @@ final class BuildJob: Identifiable {
     private(set) var finishedAt: Date?
     private(set) var logLines: [LogLine] = []
     private(set) var status: Status = .building
+    nonisolated static let maxLogLineCount = 5_000
+    private nonisolated static let logTrimCount = 1_000
 
     /// Whether the user has already seen this job's final state (watched it finish in the
     /// sheet, or opened the builds popover). Drives the toolbar badge.
@@ -46,6 +48,10 @@ final class BuildJob: Identifiable {
 
     func appendLog(_ text: String) {
         logLines.append(LogLine(text: text))
+        if logLines.count > Self.maxLogLineCount {
+            // Trim in batches so sustained output doesn't shift a 5,000-element array per line.
+            logLines.removeFirst(Self.logTrimCount)
+        }
     }
 
     fileprivate func finish(_ status: Status) {

--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -12,6 +12,7 @@ import ContainerizationError
 import ContainerizationExtras
 import ContainerizationOCI
 import ContainerizationOS
+import Darwin
 import Foundation
 import Logging
 import MachineAPIClient
@@ -104,8 +105,45 @@ final class LiveContainerService: ContainerServiceBase {
     }
 
     nonisolated static func writePrivateData(_ data: Data, to url: URL) throws {
-        try data.write(to: url, options: .atomic)
-        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        try writeOwnerOnlyData(data, to: url, replaceExisting: true)
+    }
+
+    private nonisolated static func writeOwnerOnlyData(
+        _ data: Data,
+        to destination: URL,
+        replaceExisting: Bool
+    ) throws {
+        let writeURL = replaceExisting
+            ? destination.deletingLastPathComponent().appendingPathComponent(".berthly-\(UUID().uuidString).tmp")
+            : destination
+        let descriptor = open(writeURL.path, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC, S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+        var shouldRemove = true
+        defer {
+            close(descriptor)
+            if shouldRemove { unlink(writeURL.path) }
+        }
+
+        try data.withUnsafeBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else { return }
+            var offset = 0
+            while offset < bytes.count {
+                let written = Darwin.write(descriptor, baseAddress.advanced(by: offset), bytes.count - offset)
+                if written < 0 {
+                    if errno == EINTR { continue }
+                    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+                }
+                guard written > 0 else { throw POSIXError(.EIO) }
+                offset += written
+            }
+        }
+
+        if replaceExisting {
+            guard rename(writeURL.path, destination.path) == 0 else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        }
+        shouldRemove = false
     }
 
     override func togglePinContainer(_ id: String) {
@@ -440,28 +478,38 @@ final class LiveContainerService: ContainerServiceBase {
             && appleExecutableSignatureMarkers.allSatisfy { signatureOutput.contains($0) }
     }
 
-    private nonisolated static func verifyContainerExecutableForPrivilege() async throws {
+    nonisolated static func hierarchyPaths(startingAt path: String) -> [String] {
+        var paths: [String] = []
+        var currentURL = URL(fileURLWithPath: path)
+        while currentURL.path != "/" {
+            paths.append(currentURL.path)
+            currentURL.deleteLastPathComponent()
+        }
+        return paths
+    }
+
+    nonisolated static func isRootOwnedHierarchy(_ entries: [(ownerID: UInt32, permissions: Int)]) -> Bool {
+        !entries.isEmpty && entries.allSatisfy { $0.ownerID == 0 && $0.permissions & 0o022 == 0 }
+    }
+
+    private nonisolated static func verifyContainerExecutableForDNSPrivilege() async throws {
         let path = containerExecutablePath
         let resolvedPath = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
-        func validateRootOwnedHierarchy(_ startingPath: String) throws {
-            var currentURL = URL(fileURLWithPath: startingPath)
-            while currentURL.path != "/" {
-                let currentAttributes = try FileManager.default.attributesOfItem(atPath: currentURL.path)
-                let currentOwnerID = (currentAttributes[.ownerAccountID] as? NSNumber)?.uint32Value ?? UInt32.max
-                let currentPermissions = (currentAttributes[.posixPermissions] as? NSNumber)?.intValue ?? 0o777
-                guard currentOwnerID == 0, currentPermissions & 0o022 == 0 else {
-                    throw ContainerizationError(
-                        .invalidState,
-                        message: "The container executable or one of its parent directories is writable by a non-root user. "
-                            + "Reinstall Apple's container package before changing DNS domains."
-                    )
-                }
-                currentURL.deleteLastPathComponent()
+        for hierarchyStart in Set([path, resolvedPath]) {
+            let entries = try hierarchyPaths(startingAt: hierarchyStart).map { currentPath in
+                let attributes = try FileManager.default.attributesOfItem(atPath: currentPath)
+                return (
+                    ownerID: (attributes[.ownerAccountID] as? NSNumber)?.uint32Value ?? UInt32.max,
+                    permissions: (attributes[.posixPermissions] as? NSNumber)?.intValue ?? 0o777
+                )
             }
-        }
-        try validateRootOwnedHierarchy(path)
-        if resolvedPath != path {
-            try validateRootOwnedHierarchy(resolvedPath)
+            guard isRootOwnedHierarchy(entries) else {
+                throw ContainerizationError(
+                    .invalidState,
+                    message: "The container executable or one of its parent directories is writable by a non-root user. "
+                        + "Reinstall Apple's container package before changing DNS domains."
+                )
+            }
         }
         let attributes = try FileManager.default.attributesOfItem(atPath: resolvedPath)
         let ownerID = (attributes[.ownerAccountID] as? NSNumber)?.uint32Value ?? UInt32.max
@@ -1834,13 +1882,13 @@ final class LiveContainerService: ContainerServiceBase {
         if let problem = Self.validateDNSDomainName(domain) {
             throw ContainerizationError(.invalidArgument, message: problem)
         }
-        try await Self.verifyContainerExecutableForPrivilege()
+        try await Self.verifyContainerExecutableForDNSPrivilege()
         try await runPrivilegedShellCommand(Self.dnsCreateShellCommand(domain: domain)) { _ in }
         await fetchDNSDomains()
     }
 
     override func deleteDNSDomain(_ name: String) async throws {
-        try await Self.verifyContainerExecutableForPrivilege()
+        try await Self.verifyContainerExecutableForDNSPrivilege()
         try await runPrivilegedShellCommand(Self.dnsDeleteShellCommand(domain: name)) { _ in }
         await fetchDNSDomains()
     }
@@ -2585,14 +2633,7 @@ final class LiveContainerService: ContainerServiceBase {
     }
 
     nonisolated static func writeCIDFile(_ id: String, to path: String) throws {
-        let url = URL(fileURLWithPath: path)
-        try Data(id.utf8).write(to: url, options: .withoutOverwriting)
-        do {
-            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
-        } catch {
-            try? FileManager.default.removeItem(at: url)
-            throw error
-        }
+        try writeOwnerOnlyData(Data(id.utf8), to: URL(fileURLWithPath: path), replaceExisting: false)
     }
 
     /// Native (XPC API, no CLI shelling) implementation of `container run`/`container create`.

--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -39,6 +39,7 @@ final class LiveContainerService: ContainerServiceBase {
     private var isBuilding = false
     private var systemConfig: ContainerSystemConfig?
     private static let log = Logger(label: "app.berthly.container")
+    private nonisolated static let pushOperationTracker = PushOperationTracker()
 
     private func resolvedSystemConfig() async -> ContainerSystemConfig {
         if systemConfig == nil {
@@ -86,7 +87,7 @@ final class LiveContainerService: ContainerServiceBase {
     override func saveBuildContext(_ ctx: BuildContext, for reference: String) {
         super.saveBuildContext(ctx, for: reference)
         guard let data = try? JSONEncoder().encode(buildContexts) else { return }
-        try? data.write(to: Self.contextsURL, options: .atomic)
+        try? Self.writePrivateData(data, to: Self.contextsURL)
     }
 
     private func loadPinnedItems() {
@@ -99,7 +100,12 @@ final class LiveContainerService: ContainerServiceBase {
     private func savePinnedItems() {
         let items = PinnedItems(containers: pinnedContainerIDs, machines: pinnedMachineIDs)
         guard let data = try? JSONEncoder().encode(items) else { return }
-        try? data.write(to: Self.pinnedItemsURL, options: .atomic)
+        try? Self.writePrivateData(data, to: Self.pinnedItemsURL)
+    }
+
+    nonisolated static func writePrivateData(_ data: Data, to url: URL) throws {
+        try data.write(to: url, options: .atomic)
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
     }
 
     override func togglePinContainer(_ id: String) {
@@ -171,6 +177,7 @@ final class LiveContainerService: ContainerServiceBase {
     // main actor. Without `nonisolated` they'd be MainActor-isolated (this is a `@MainActor` class)
     // and every off-actor read would warn under Swift 6 concurrency.
     private nonisolated static let apiServerExecutablePath = "/usr/local/bin/container-apiserver"
+    private nonisolated static let containerExecutablePath = "/usr/local/bin/container"
     // `InstallRoot.defaultPath` derives this from `CommandLine.executablePath`, which for a GUI
     // .app resolves to Berthly's own bundle path, not the `container` CLI's install location —
     // hardcode the layout the CLI's own installer uses instead (`container-apiserver` lives next
@@ -310,11 +317,10 @@ final class LiveContainerService: ContainerServiceBase {
         }
     }
 
-    /// Stops the daemon, runs the upstream `update-container.sh` (already handles GitHub release
-    /// lookup, signed-vs-unsigned package selection, and download — reimplementing that natively
-    /// would just duplicate already-correct upstream logic) elevated via `osascript`'s native
-    /// admin-password prompt, then restarts the daemon. Callers must confirm with the user before
-    /// invoking this — `stopDaemon()` stops every running container on the machine.
+    /// Stops the daemon, downloads the pinned signed installer, verifies Apple's identity before
+    /// and after root-owned staging, then restarts. The upstream update script is deliberately not
+    /// used because it selects a release asset by filename without enforcing the signing identity.
+    /// Callers must confirm first because `stopDaemon()` stops every container on the machine.
     override func upgradeContainer(onLog: @MainActor @escaping (String) -> Void) async throws {
         await stopDaemon()
         guard case .installedButStopped = daemonState else {
@@ -322,8 +328,8 @@ final class LiveContainerService: ContainerServiceBase {
         }
 
         do {
-            try await runPrivilegedShellCommand(
-                "/usr/local/bin/update-container.sh -v \(ContainerCompatibility.requiredVersion)",
+            try await installSignedContainerPackage(
+                version: ContainerCompatibility.requiredVersion,
                 onLog: onLog
             )
         } catch {
@@ -337,18 +343,28 @@ final class LiveContainerService: ContainerServiceBase {
         await startDaemon(onLog: onLog)
     }
 
-    /// First-time install: downloads the pinned release's signed installer pkg, verifies its
-    /// signature, and runs `installer` elevated. The upstream `update-container.sh` can't be used
-    /// here — that script is installed *by* the pkg, so on a machine without `container` it
-    /// doesn't exist yet. `startDaemon()` afterwards bootstraps the default kernel, so a fresh
-    /// Mac goes straight to a working setup.
+    /// First-time install uses the same pinned, double-verified package path as an upgrade.
+    /// `startDaemon()` afterwards bootstraps the default kernel, so a fresh Mac goes straight to
+    /// a working setup.
     override func installContainer(onLog: @MainActor @escaping (String) -> Void) async throws {
-        let version = ContainerCompatibility.requiredVersion
+        try await installSignedContainerPackage(
+            version: ContainerCompatibility.requiredVersion,
+            onLog: onLog
+        )
+        onLog("Starting container system…")
+        await startDaemon(onLog: onLog)
+    }
+
+    private func installSignedContainerPackage(
+        version: String,
+        onLog: @MainActor @escaping (String) -> Void
+    ) async throws {
         let pkgName = "container-\(version)-installer-signed.pkg"
         let url = URL(string: "https://github.com/apple/container/releases/download/\(version)/\(pkgName)")!
 
         onLog("Downloading \(pkgName)…")
         let pkgPath = try await Self.downloadFile(from: url, suggestedName: pkgName)
+        defer { try? FileManager.default.removeItem(atPath: pkgPath) }
         onLog("Downloaded to \(pkgPath)")
 
         onLog("Verifying package signature…")
@@ -359,9 +375,6 @@ final class LiveContainerService: ContainerServiceBase {
             Self.stagedInstallCommand(pkgPath: pkgPath),
             onLog: onLog
         )
-
-        onLog("Starting container system…")
-        await startDaemon(onLog: onLog)
     }
 
     private nonisolated static func downloadFile(from url: URL, suggestedName: String) async throws -> String {
@@ -388,6 +401,10 @@ final class LiveContainerService: ContainerServiceBase {
     nonisolated static let appleSignatureMarkers = [
         "Developer ID Installer: Apple Inc. - Containerization (UPBK2H6LZM)"
     ]
+    nonisolated static let appleExecutableSignatureMarkers = [
+        "Authority=Developer ID Application: Apple Inc. - Containerization (UPBK2H6LZM)",
+        "TeamIdentifier=UPBK2H6LZM"
+    ]
 
     /// The acceptance predicate for `pkgutil --check-signature`, extracted pure so the
     /// security-critical decision is testable without spawning a process.
@@ -407,6 +424,71 @@ final class LiveContainerService: ContainerServiceBase {
             throw ContainerizationError(
                 .internalError,
                 message: "The downloaded installer package failed signature verification — refusing to install it.\n\(output)"
+            )
+        }
+    }
+
+    nonisolated static func isTrustedPrivilegedExecutable(
+        ownerID: UInt32,
+        permissions: Int,
+        signatureOutput: String,
+        terminationStatus: Int32
+    ) -> Bool {
+        ownerID == 0
+            && permissions & 0o022 == 0
+            && terminationStatus == 0
+            && appleExecutableSignatureMarkers.allSatisfy { signatureOutput.contains($0) }
+    }
+
+    private nonisolated static func verifyContainerExecutableForPrivilege() async throws {
+        let path = containerExecutablePath
+        let resolvedPath = URL(fileURLWithPath: path).resolvingSymlinksInPath().path
+        func validateRootOwnedHierarchy(_ startingPath: String) throws {
+            var currentURL = URL(fileURLWithPath: startingPath)
+            while currentURL.path != "/" {
+                let currentAttributes = try FileManager.default.attributesOfItem(atPath: currentURL.path)
+                let currentOwnerID = (currentAttributes[.ownerAccountID] as? NSNumber)?.uint32Value ?? UInt32.max
+                let currentPermissions = (currentAttributes[.posixPermissions] as? NSNumber)?.intValue ?? 0o777
+                guard currentOwnerID == 0, currentPermissions & 0o022 == 0 else {
+                    throw ContainerizationError(
+                        .invalidState,
+                        message: "The container executable or one of its parent directories is writable by a non-root user. "
+                            + "Reinstall Apple's container package before changing DNS domains."
+                    )
+                }
+                currentURL.deleteLastPathComponent()
+            }
+        }
+        try validateRootOwnedHierarchy(path)
+        if resolvedPath != path {
+            try validateRootOwnedHierarchy(resolvedPath)
+        }
+        let attributes = try FileManager.default.attributesOfItem(atPath: resolvedPath)
+        let ownerID = (attributes[.ownerAccountID] as? NSNumber)?.uint32Value ?? UInt32.max
+        let permissions = (attributes[.posixPermissions] as? NSNumber)?.intValue ?? 0o777
+        let (verificationStatus, _) = try await runProcessCollectingOutput(
+            executablePath: "/usr/bin/codesign",
+            arguments: ["--verify", "--strict", "--verbose=2", resolvedPath]
+        )
+        guard verificationStatus == 0 else {
+            throw ContainerizationError(
+                .invalidState,
+                message: "The container executable's code signature is invalid. Reinstall Apple's container package before changing DNS domains."
+            )
+        }
+        let (status, output) = try await runProcessCollectingOutput(
+            executablePath: "/usr/bin/codesign",
+            arguments: ["-dv", "--verbose=4", resolvedPath]
+        )
+        guard isTrustedPrivilegedExecutable(
+            ownerID: ownerID,
+            permissions: permissions,
+            signatureOutput: output,
+            terminationStatus: status
+        ) else {
+            throw ContainerizationError(
+                .invalidState,
+                message: "The container executable isn't a trusted, root-owned Apple binary. Reinstall Apple's container package before changing DNS domains."
             )
         }
     }
@@ -467,18 +549,14 @@ final class LiveContainerService: ContainerServiceBase {
     /// Builds the AppleScript source for an elevated shell command. The command is embedded in
     /// an AppleScript string literal, so backslashes and double quotes are escaped — without
     /// that, a command containing a quoted path would terminate the literal early and execute a
-    /// mangled script. `do shell script` runs with a minimal PATH
-    /// (`/usr/bin:/bin:/usr/sbin:/sbin`) that omits `/usr/local/bin` — which made the upstream
-    /// update script's final `container --version` self-check exit 1 *after* the update had
-    /// already succeeded. `/usr/local/bin` is *appended* (not prepended) so container's binaries
-    /// resolve there while the system directories still win any name collision: `/usr/local/bin`
-    /// is world-writable on Intel Homebrew installs, and prepending it would let an attacker who
-    /// planted a binary there shadow a system tool inside this root shell.
+    /// mangled script. The elevated shell gets a fixed system-only PATH. Every non-system
+    /// executable is invoked by an absolute path after its ownership and signature have been
+    /// checked, so a writable package-manager directory can never provide a root command.
     nonisolated static func privilegedAppleScript(for shellCommand: String) -> String {
         let escaped = shellCommand
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
-        return "do shell script \"export PATH=$PATH:/usr/local/bin; \(escaped)\" with administrator privileges"
+        return "do shell script \"export PATH=/usr/bin:/bin:/usr/sbin:/sbin; \(escaped)\" with administrator privileges"
     }
 
     /// `osascript` reports the user dismissing the admin-password dialog as
@@ -1734,11 +1812,11 @@ final class LiveContainerService: ContainerServiceBase {
     }
 
     nonisolated static func dnsCreateShellCommand(domain: String) -> String {
-        "container system dns create \(shellQuoted(domain))"
+        "\(containerExecutablePath) system dns create \(shellQuoted(domain))"
     }
 
     nonisolated static func dnsDeleteShellCommand(domain: String) -> String {
-        "container system dns delete \(shellQuoted(domain))"
+        "\(containerExecutablePath) system dns delete \(shellQuoted(domain))"
     }
 
     override func fetchDNSDomains() async {
@@ -1756,11 +1834,13 @@ final class LiveContainerService: ContainerServiceBase {
         if let problem = Self.validateDNSDomainName(domain) {
             throw ContainerizationError(.invalidArgument, message: problem)
         }
+        try await Self.verifyContainerExecutableForPrivilege()
         try await runPrivilegedShellCommand(Self.dnsCreateShellCommand(domain: domain)) { _ in }
         await fetchDNSDomains()
     }
 
     override func deleteDNSDomain(_ name: String) async throws {
+        try await Self.verifyContainerExecutableForPrivilege()
         try await runPrivilegedShellCommand(Self.dnsDeleteShellCommand(domain: name)) { _ in }
         await fetchDNSDomains()
     }
@@ -2089,7 +2169,7 @@ final class LiveContainerService: ContainerServiceBase {
         cpus: Int64?,
         memory: String?,
         onLog: @MainActor @escaping (String) -> Void
-    ) async throws -> ContainerBuild.Builder {
+    ) async throws -> (builder: ContainerBuild.Builder, group: MultiThreadedEventLoopGroup) {
         let deadline = Date().addingTimeInterval(300)
         // Whether we've had to start the builder this call. Gates the user-facing messages so the
         // common fast path (builder already running → first dial succeeds) stays silent, and the
@@ -2098,11 +2178,16 @@ final class LiveContainerService: ContainerServiceBase {
         while true {
             do {
                 let socket = try await ContainerClient().dial(id: ContainerBuild.Builder.builderContainerId, port: 8088)
-                let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
-                let builder = try ContainerBuild.Builder(socket: socket, group: group, logger: Self.log)
-                _ = try await builder.info()
-                if announcedStart { onLog("Build environment ready.") }
-                return builder
+                let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+                do {
+                    let builder = try ContainerBuild.Builder(socket: socket, group: group, logger: Self.log)
+                    _ = try await builder.info()
+                    if announcedStart { onLog("Build environment ready.") }
+                    return (builder, group)
+                } catch {
+                    try? await group.shutdownGracefully()
+                    throw error
+                }
             } catch {
                 guard Date() < deadline else {
                     throw ContainerizationError(.timeout, message: "Timed out waiting for the builder to start.")
@@ -2281,9 +2366,16 @@ final class LiveContainerService: ContainerServiceBase {
         let platforms = try Self.buildPlatforms(for: options)
 
         let containerSystemConfig = await resolvedSystemConfig()
-        let builder = try await dialOrStartBuilder(containerSystemConfig: containerSystemConfig,
-                                                   cpus: options.cpus.map { Int64($0) },
-                                                   memory: options.memory, onLog: onLog)
+        let builderConnection = try await dialOrStartBuilder(containerSystemConfig: containerSystemConfig,
+                                                             cpus: options.cpus.map { Int64($0) },
+                                                             memory: options.memory, onLog: onLog)
+        let builder = builderConnection.builder
+        let builderGroup = builderConnection.group
+        defer {
+            Task.detached {
+                try? await builderGroup.shutdownGracefully()
+            }
+        }
 
         let systemHealth = try await ClientHealthCheck.ping(timeout: .seconds(10))
         let buildID = UUID().uuidString
@@ -2492,6 +2584,17 @@ final class LiveContainerService: ContainerServiceBase {
         Flags.Registry(scheme: options.insecureRegistry ? "http" : "auto")
     }
 
+    nonisolated static func writeCIDFile(_ id: String, to path: String) throws {
+        let url = URL(fileURLWithPath: path)
+        try Data(id.utf8).write(to: url, options: .withoutOverwriting)
+        do {
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
+        } catch {
+            try? FileManager.default.removeItem(at: url)
+            throw error
+        }
+    }
+
     /// Native (XPC API, no CLI shelling) implementation of `container run`/`container create`.
     /// Reuses the vendored package's own `Utility.containerConfigFromFlags` — the same image
     /// fetch/unpack, kernel resolution, volume/network/DNS resolution the CLI itself runs — so
@@ -2532,11 +2635,12 @@ final class LiveContainerService: ContainerServiceBase {
         }
 
         if let cidFile = options.cidFile, !cidFile.isEmpty {
-            FileManager.default.createFile(
-                atPath: cidFile,
-                contents: id.data(using: .utf8),
-                attributes: [.posixPermissions: 0o644]
-            )
+            do {
+                try Self.writeCIDFile(id, to: cidFile)
+            } catch {
+                try? await client.delete(id: id, force: true)
+                throw error
+            }
         }
 
         guard options.start else {
@@ -3036,13 +3140,23 @@ final class LiveContainerService: ContainerServiceBase {
         // `raceAgainstStall`'s operation runs on a separate, concurrently-executing Task — capture
         // an immutable snapshot of the (possibly just-retagged) image rather than the `var`.
         let imageToPush = image
+        let pushDestination = destination ?? reference
+        guard await Self.pushOperationTracker.begin(pushDestination) else {
+            throw PushAlreadyInProgressError(destination: pushDestination)
+        }
         try await raceAgainstStall(timeout: .seconds(60), monitor: stallMonitor) {
-            try await imageToPush.push(
-                platform: ociPlatform,
-                scheme: insecure ? .http : .auto,
-                containerSystemConfig: config,
-                progressUpdate: watchedProgress
-            )
+            do {
+                try await imageToPush.push(
+                    platform: ociPlatform,
+                    scheme: insecure ? .http : .auto,
+                    containerSystemConfig: config,
+                    progressUpdate: watchedProgress
+                )
+                await Self.pushOperationTracker.finish(pushDestination)
+            } catch {
+                await Self.pushOperationTracker.finish(pushDestination)
+                throw error
+            }
         }
         if insecure, let host = ImageStaleness.registryHost(for: destination ?? reference) {
             Self.rememberInsecureHost(host)

--- a/Berthly/Core/PushStallGuard.swift
+++ b/Berthly/Core/PushStallGuard.swift
@@ -64,7 +64,8 @@ struct PushAlreadyInProgressError: LocalizedError {
     let destination: String
 
     var errorDescription: String? {
-        "A push to \(destination) is already running or still stopping after a timeout."
+        "A push to \(destination) is already running or still stopping after a timeout. "
+            + "If this continues indefinitely, restart Berthly to clear the blocked destination."
     }
 }
 
@@ -77,10 +78,6 @@ actor PushOperationTracker {
 
     func finish(_ destination: String) {
         destinations.remove(destination)
-    }
-
-    func isRunning(_ destination: String) -> Bool {
-        destinations.contains(destination)
     }
 }
 

--- a/Berthly/Core/PushStallGuard.swift
+++ b/Berthly/Core/PushStallGuard.swift
@@ -55,7 +55,32 @@ actor PushStallMonitor {
 
 struct PushStalledError: LocalizedError {
     var errorDescription: String? {
-        "Push made no progress and was cancelled. This registry may require sign-in — add credentials in Registries, then try again."
+        "Push made no progress and timed out. The daemon operation may still be stopping; "
+            + "wait before trying this destination again. This registry may require sign-in."
+    }
+}
+
+struct PushAlreadyInProgressError: LocalizedError {
+    let destination: String
+
+    var errorDescription: String? {
+        "A push to \(destination) is already running or still stopping after a timeout."
+    }
+}
+
+actor PushOperationTracker {
+    private var destinations: Set<String> = []
+
+    func begin(_ destination: String) -> Bool {
+        destinations.insert(destination).inserted
+    }
+
+    func finish(_ destination: String) {
+        destinations.remove(destination)
+    }
+
+    func isRunning(_ destination: String) -> Bool {
+        destinations.contains(destination)
     }
 }
 

--- a/Berthly/Views/BuildImageSheet.swift
+++ b/Berthly/Views/BuildImageSheet.swift
@@ -237,7 +237,12 @@ struct BuildImageSheet: View {
 
         PlatformPicker(title: "Platform", selection: $platformChoice)
 
-        KeyValueEditor(title: "Build arguments", keyPlaceholder: "ARG_NAME", valuePlaceholder: "value", pairs: $buildArgs)
+        VStack(alignment: .leading, spacing: 4) {
+            KeyValueEditor(title: "Build arguments", keyPlaceholder: "ARG_NAME", valuePlaceholder: "value", pairs: $buildArgs)
+            Text("Saved for Rebuild. Use Secrets below for tokens, passwords, and other sensitive values.")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+        }
 
         Toggle("Disable build cache", isOn: $noCache)
             .toggleStyle(.checkbox)

--- a/BerthlyTests/BerthlyTests.swift
+++ b/BerthlyTests/BerthlyTests.swift
@@ -12,6 +12,39 @@ import SwiftTerm
 import Testing
 @testable import Berthly
 
+// MARK: - Local file hardening
+
+struct LocalFileHardeningTests {
+
+    @Test func persistedApplicationDataIsOwnerOnly() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("state.json")
+
+        try LiveContainerService.writePrivateData(Data("{}".utf8), to: url)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
+    }
+
+    @Test func cidFileIsOwnerOnlyAndNeverOverwrites() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("container.cid")
+
+        try LiveContainerService.writeCIDFile("first-id", to: url.path)
+        #expect(try String(contentsOf: url, encoding: .utf8) == "first-id")
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
+        #expect(throws: (any Error).self) {
+            try LiveContainerService.writeCIDFile("second-id", to: url.path)
+        }
+        #expect(try String(contentsOf: url, encoding: .utf8) == "first-id")
+    }
+}
+
 // MARK: - BuildContext Codable
 
 struct BuildContextCodableTests {
@@ -661,14 +694,11 @@ struct ContainerCompatibilityTests {
 
 struct PrivilegedCommandHelperTests {
 
-    /// `do shell script`'s default PATH omits /usr/local/bin, which broke the upstream update
-    /// script's final `container --version` self-check — the AppleScript must add it. It's
-    /// *appended*, not prepended, so a world-writable /usr/local/bin can't shadow a system tool
-    /// inside the root shell.
-    @Test func appleScriptAppendsUsrLocalBinToPath() {
-        let script = LiveContainerService.privilegedAppleScript(for: "/usr/local/bin/update-container.sh -v 1.1.0")
-        #expect(script.hasPrefix("do shell script \"export PATH=$PATH:/usr/local/bin; "))
-        #expect(script.contains("/usr/local/bin/update-container.sh -v 1.1.0"))
+    @Test func appleScriptUsesOnlySystemDirectoriesInPath() {
+        let script = LiveContainerService.privilegedAppleScript(for: "/usr/local/bin/container system dns create 'test'")
+        #expect(script.hasPrefix("do shell script \"export PATH=/usr/bin:/bin:/usr/sbin:/sbin; "))
+        #expect(script.contains("/usr/local/bin/container system dns create 'test'"))
+        #expect(!script.contains("$PATH"))
         #expect(script.hasSuffix("with administrator privileges"))
     }
 
@@ -732,6 +762,25 @@ struct PrivilegedCommandHelperTests {
         let output = "1. Developer ID Installer: Apple Inc. - Containerization (UPBK2H6LZM)"
         #expect(!LiveContainerService.isAcceptableSignature(output: output, terminationStatus: 1))
         #expect(!LiveContainerService.isAcceptableSignature(output: "", terminationStatus: 0))
+    }
+
+    @Test func privilegedExecutableCheckRequiresAppleSignatureAndRootOnlyWrites() {
+        let output = """
+        Authority=Developer ID Application: Apple Inc. - Containerization (UPBK2H6LZM)
+        TeamIdentifier=UPBK2H6LZM
+        """
+        #expect(LiveContainerService.isTrustedPrivilegedExecutable(
+            ownerID: 0, permissions: 0o755, signatureOutput: output, terminationStatus: 0
+        ))
+        #expect(!LiveContainerService.isTrustedPrivilegedExecutable(
+            ownerID: 501, permissions: 0o755, signatureOutput: output, terminationStatus: 0
+        ))
+        #expect(!LiveContainerService.isTrustedPrivilegedExecutable(
+            ownerID: 0, permissions: 0o775, signatureOutput: output, terminationStatus: 0
+        ))
+        #expect(!LiveContainerService.isTrustedPrivilegedExecutable(
+            ownerID: 0, permissions: 0o755, signatureOutput: "TeamIdentifier=EVIL", terminationStatus: 0
+        ))
     }
 
     /// The elevated command must stage the pkg out of the user-writable temp dir, re-verify the

--- a/BerthlyTests/BerthlyTests.swift
+++ b/BerthlyTests/BerthlyTests.swift
@@ -12,39 +12,6 @@ import SwiftTerm
 import Testing
 @testable import Berthly
 
-// MARK: - Local file hardening
-
-struct LocalFileHardeningTests {
-
-    @Test func persistedApplicationDataIsOwnerOnly() throws {
-        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: directory) }
-        let url = directory.appendingPathComponent("state.json")
-
-        try LiveContainerService.writePrivateData(Data("{}".utf8), to: url)
-
-        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
-        #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
-    }
-
-    @Test func cidFileIsOwnerOnlyAndNeverOverwrites() throws {
-        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: directory) }
-        let url = directory.appendingPathComponent("container.cid")
-
-        try LiveContainerService.writeCIDFile("first-id", to: url.path)
-        #expect(try String(contentsOf: url, encoding: .utf8) == "first-id")
-        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
-        #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
-        #expect(throws: (any Error).self) {
-            try LiveContainerService.writeCIDFile("second-id", to: url.path)
-        }
-        #expect(try String(contentsOf: url, encoding: .utf8) == "first-id")
-    }
-}
-
 // MARK: - BuildContext Codable
 
 struct BuildContextCodableTests {

--- a/BerthlyTests/BuildJobManagerTests.swift
+++ b/BerthlyTests/BuildJobManagerTests.swift
@@ -105,6 +105,17 @@ struct BuildJobManagerTests {
         #expect(!job.isFinished)
     }
 
+    @Test func buildLogKeepsOnlyTheNewestLines() async {
+        let job = BuildJob(reference: "local/test:1.0")
+        for index in 0...(BuildJob.maxLogLineCount + 999) {
+            job.appendLog("line \(index)")
+        }
+
+        #expect(job.logLines.count == BuildJob.maxLogLineCount)
+        #expect(job.logLines.first?.text == "line 1000")
+        #expect(job.logLines.last?.text == "line \(BuildJob.maxLogLineCount + 999)")
+    }
+
     @Test func finishNotifiesWithTheFinishedJob() async {
         let service = ScriptedBuildService()
         let manager = makeManager()

--- a/BerthlyTests/DNSDomainTests.swift
+++ b/BerthlyTests/DNSDomainTests.swift
@@ -75,9 +75,9 @@ struct DNSDomainTests {
 
     @Test func buildsQuotedCreateAndDeleteCommands() {
         #expect(LiveContainerService.dnsCreateShellCommand(domain: "test")
-                == "container system dns create 'test'")
+                == "/usr/local/bin/container system dns create 'test'")
         #expect(LiveContainerService.dnsDeleteShellCommand(domain: "dev.internal")
-                == "container system dns delete 'dev.internal'")
+                == "/usr/local/bin/container system dns delete 'dev.internal'")
     }
 
     // MARK: - Mock service behavior (what previews/UI tests run against)

--- a/BerthlyTests/PushStallGuardTests.swift
+++ b/BerthlyTests/PushStallGuardTests.swift
@@ -59,6 +59,21 @@ struct PushStallGuardTests {
     }
 }
 
+struct PushOperationTrackerTests {
+
+    @Test func blocksDuplicateDestinationUntilTheFirstOperationFinishes() async {
+        let tracker = PushOperationTracker()
+
+        #expect(await tracker.begin("registry.example/app:latest"))
+        #expect(!(await tracker.begin("registry.example/app:latest")))
+        #expect(await tracker.isRunning("registry.example/app:latest"))
+
+        await tracker.finish("registry.example/app:latest")
+        #expect(!(await tracker.isRunning("registry.example/app:latest")))
+        #expect(await tracker.begin("registry.example/app:latest"))
+    }
+}
+
 struct RaceAgainstStallTests {
 
     /// The exact bug in the first version of this fix: it used `withThrowingTaskGroup`, which

--- a/BerthlyTests/PushStallGuardTests.swift
+++ b/BerthlyTests/PushStallGuardTests.swift
@@ -66,10 +66,8 @@ struct PushOperationTrackerTests {
 
         #expect(await tracker.begin("registry.example/app:latest"))
         #expect(!(await tracker.begin("registry.example/app:latest")))
-        #expect(await tracker.isRunning("registry.example/app:latest"))
 
         await tracker.finish("registry.example/app:latest")
-        #expect(!(await tracker.isRunning("registry.example/app:latest")))
         #expect(await tracker.begin("registry.example/app:latest"))
     }
 }

--- a/BerthlyTests/SecurityHardeningTests.swift
+++ b/BerthlyTests/SecurityHardeningTests.swift
@@ -1,0 +1,71 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import Foundation
+import Testing
+@testable import Berthly
+
+struct PrivilegedExecutableHierarchyTests {
+
+    @Test func hierarchyPathsWalkFromLeafToButNotIncludingRoot() {
+        #expect(LiveContainerService.hierarchyPaths(startingAt: "/usr/local/bin/container") == [
+            "/usr/local/bin/container", "/usr/local/bin", "/usr/local", "/usr"
+        ])
+        #expect(LiveContainerService.hierarchyPaths(startingAt: "/").isEmpty)
+    }
+
+    @Test func rejectsAnyWritableOrNonRootEntry() {
+        #expect(LiveContainerService.isRootOwnedHierarchy([
+            (ownerID: 0, permissions: 0o755),
+            (ownerID: 0, permissions: 0o755),
+            (ownerID: 0, permissions: 0o700)
+        ]))
+        #expect(!LiveContainerService.isRootOwnedHierarchy([]))
+        #expect(!LiveContainerService.isRootOwnedHierarchy([
+            (ownerID: 0, permissions: 0o755),
+            (ownerID: 501, permissions: 0o755)
+        ]))
+        #expect(!LiveContainerService.isRootOwnedHierarchy([
+            (ownerID: 0, permissions: 0o755),
+            (ownerID: 0, permissions: 0o775)
+        ]))
+        #expect(!LiveContainerService.isRootOwnedHierarchy([
+            (ownerID: 0, permissions: 0o755),
+            (ownerID: 0, permissions: 0o757)
+        ]))
+    }
+}
+
+struct LocalFileHardeningTests {
+
+    @Test func persistedApplicationDataIsOwnerOnly() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("state.json")
+        try Data("old".utf8).write(to: url)
+        try FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: url.path)
+
+        try LiveContainerService.writePrivateData(Data("{}".utf8), to: url)
+
+        #expect(try String(contentsOf: url, encoding: .utf8) == "{}")
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
+    }
+
+    @Test func cidFileIsOwnerOnlyAndNeverOverwrites() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("container.cid")
+
+        try LiveContainerService.writeCIDFile("first-id", to: url.path)
+        #expect(try String(contentsOf: url, encoding: .utf8) == "first-id")
+        let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+        #expect((attributes[.posixPermissions] as? NSNumber)?.intValue == 0o600)
+        #expect(throws: (any Error).self) {
+            try LiveContainerService.writeCIDFile("second-id", to: url.path)
+        }
+        #expect(try String(contentsOf: url, encoding: .utf8) == "first-id")
+    }
+}


### PR DESCRIPTION
## Summary
- verify Apple-signed installer packages for both installs and upgrades
- restrict privileged DNS execution to a trusted root-owned Apple binary and a system-only PATH
- bound build logs, clean up builder event loops, and serialize timed-out pushes
- make CID and persisted app-state files owner-only and non-overwriting
- warn users not to place secrets in persisted build arguments

## Testing
- `swiftlint lint --strict`
- `xcodebuild test -scheme Berthly -destination 'platform=macOS' -only-testing:BerthlyTests CODE_SIGNING_ALLOWED=NO`