### PR TITLE
Trim redundant Registries strip, palette Refresh, and toolbar scope

### DIFF
--- a/Berthly/Core/CommandPalette.swift
+++ b/Berthly/Core/CommandPalette.swift
@@ -30,7 +30,6 @@ nonisolated enum PaletteAction: Equatable {
     case createVolume
     case createNetwork
     case addRegistry
-    case refresh
 
     case selectContainer(String)
     case selectMachine(String)
@@ -175,9 +174,7 @@ func buildPaletteCommands(isConnected: Bool, containers: [Container], machines: 
         PaletteCommand(id: "action.createNetwork", title: "Create Network…", systemImage: "arrow.triangle.branch",
                        keywords: ["new"], action: .createNetwork),
         PaletteCommand(id: "action.addRegistry", title: "Add Registry…", systemImage: "plus.circle",
-                       keywords: ["login", "sign in"], action: .addRegistry),
-        PaletteCommand(id: "action.refresh", title: "Refresh", systemImage: "arrow.clockwise",
-                       keywords: ["reload"], action: .refresh)
+                       keywords: ["login", "sign in"], action: .addRegistry)
     ]
 
     for container in containers {

--- a/Berthly/Localizable.xcstrings
+++ b/Berthly/Localizable.xcstrings
@@ -470,9 +470,6 @@
     "Credentials are stored in the **macOS Keychain**, never written to `config.toml` in plaintext. Signing in or out maps to `container registry login` / `logout` — no daemon restart. While signed in, macOS may confirm Keychain access on pulls from that host too, even for public images — sign out below to stop it." : {
 
     },
-    "Credentials for pushing & pulling images" : {
-
-    },
     "Currently %@" : {
 
     },

--- a/Berthly/Views/MainWindowView.swift
+++ b/Berthly/Views/MainWindowView.swift
@@ -312,7 +312,6 @@ struct MainWindowView: View {
         case .createVolume:    showVolumeCreateSheet = true
         case .createNetwork:   showNetworkCreateSheet = true
         case .addRegistry:     showAddRegistrySheet = true
-        case .refresh:         Task { await service.refresh() }
         case .selectContainer(let id): selectCompute(.container(id))
         case .selectMachine(let id):   selectCompute(.machine(id))
         case .openContainerShell(let id): openShell(.container(id))
@@ -504,6 +503,16 @@ struct MainWindowView: View {
         }
     }
 
+    /// Build/Pull only make sense while looking at images or the containers they build/pull
+    /// into — Volumes/Networks/Registries/System keep the toolbar to Run + their own add action.
+    /// Still reachable from anywhere via the ⌘K palette.
+    private var showsBuildAndPullActions: Bool {
+        switch sidebarSelection {
+        case .compute, .images: true
+        default:                false
+        }
+    }
+
     // MARK: - Content pane (list)
 
     @ViewBuilder
@@ -567,23 +576,25 @@ struct MainWindowView: View {
                 }
             )
 
-            Button {
-                buildSheetRequest = BuildSheetRequest()
-            } label: {
-                Label("Build", systemImage: "hammer")
-                    .labelStyle(.titleAndIcon)
-            }
-            .disabled(!service.isConnected)
-            .help("Build an image from a Dockerfile")
+            if showsBuildAndPullActions {
+                Button {
+                    buildSheetRequest = BuildSheetRequest()
+                } label: {
+                    Label("Build", systemImage: "hammer")
+                        .labelStyle(.titleAndIcon)
+                }
+                .disabled(!service.isConnected)
+                .help("Build an image from a Dockerfile")
 
-            Button {
-                showPullSheet = true
-            } label: {
-                Label("Pull", systemImage: "arrow.down.circle")
-                    .labelStyle(.titleAndIcon)
+                Button {
+                    showPullSheet = true
+                } label: {
+                    Label("Pull", systemImage: "arrow.down.circle")
+                        .labelStyle(.titleAndIcon)
+                }
+                .disabled(!service.isConnected)
+                .help("Pull an image from a registry")
             }
-            .disabled(!service.isConnected)
-            .help("Pull an image from a registry")
 
             // One home for section-scoped create actions (Finder/Notes keep primary actions in
             // the toolbar), instead of each list view growing its own in-content button bar.

--- a/Berthly/Views/RegistriesListView.swift
+++ b/Berthly/Views/RegistriesListView.swift
@@ -23,8 +23,6 @@ struct RegistriesListView: View {
         Group {
             if service.registries.isEmpty {
                 VStack(alignment: .leading, spacing: 0) {
-                    scopeBar
-                        .padding(.top, 8)
                     infoBanner
                         .padding(.horizontal, 20)
                         .padding(.top, 8)
@@ -42,8 +40,6 @@ struct RegistriesListView: View {
                 }
             } else if filtered.isEmpty {
                 VStack(alignment: .leading, spacing: 0) {
-                    scopeBar
-                        .padding(.top, 8)
                     infoBanner
                         .padding(.horizontal, 20)
                         .padding(.top, 8)
@@ -62,8 +58,6 @@ struct RegistriesListView: View {
                 // divider under the toolbar that Compute/Networks (List with no header) don't have.
                 .safeAreaInset(edge: .top) {
                     VStack(alignment: .leading, spacing: 0) {
-                        scopeBar
-                            .padding(.top, 8)
                         infoBanner
                             .padding(.horizontal, 20)
                             .padding(.top, 8)
@@ -83,21 +77,6 @@ struct RegistriesListView: View {
     }
 
     // MARK: - Header
-
-    // A quiet, icon-anchored context strip under the toolbar title — same tier as Volumes'
-    // usage strip. Not an in-content large title (the toolbar already says "Registries"); the
-    // SF Symbol + caption/secondary styling makes it read as pane identity, not a stray subtitle.
-    private var scopeBar: some View {
-        HStack(spacing: 8) {
-            Label("Credentials for pushing & pulling images",
-                  systemImage: "building.columns")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-            Spacer()
-        }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 8)
-    }
 
     private var infoBanner: some View {
         HStack(alignment: .top, spacing: 10) {

--- a/BerthlyTests/CommandPaletteTests.swift
+++ b/BerthlyTests/CommandPaletteTests.swift
@@ -10,7 +10,7 @@ import Testing
 
     /// A minimal command whose only interesting fields are what the matcher reads.
     private func cmd(_ id: String, _ title: String, subtitle: String? = nil, keywords: [String] = []) -> PaletteCommand {
-        PaletteCommand(id: id, title: title, subtitle: subtitle, systemImage: "circle", keywords: keywords, action: .refresh)
+        PaletteCommand(id: id, title: title, subtitle: subtitle, systemImage: "circle", keywords: keywords, action: .addRegistry)
     }
 
     @Test func emptyQueryReturnsAllInOriginalOrder() {
@@ -105,7 +105,6 @@ import Testing
         #expect(actions.contains(.runContainer))
         #expect(actions.contains(.buildImage))
         #expect(actions.contains(.pullImage))
-        #expect(actions.contains(.refresh))
     }
 
     @Test func runningContainerGetsStopAndRestartNotStart() {


### PR DESCRIPTION
## Summary
- Remove the Registries "Credentials for pushing & pulling images" scope strip — it repeated the toolbar title and the Keychain info banner already covers the same ground.
- Remove the ⌘K command palette's "Refresh" entry — it duplicated the always-visible Compute ▸ Refresh menu item (⌘R) without surfacing anything otherwise buried.
- Make the toolbar's Build/Pull buttons contextual to Compute/Images (where they're actionable) instead of showing everywhere; Volumes/Networks/Registries/System keep Run plus their own contextual add action. Both actions remain reachable from any section via ⌘K.
- Prune the now-stale string-catalog entry left behind by the strip removal.

## Test plan
- [x] `xcodebuild build` — clean build
- [x] `swiftlint lint --strict` — 0 violations
- [x] `xcodebuild test -only-testing:BerthlyTests` — full suite passes (updated `CommandPaletteTests` for the removed `.refresh` action)
- [x] Manual mock-mode run: confirmed Registries shows no scope strip, Build/Pull hidden on Volumes/Networks/Registries/System and visible on Compute/Images, and Refresh absent from the ⌘K palette