### PR TITLE
perf: cache decoded image metadata by digest instead of every poll

### DIFF
--- a/.claude/skills/performance-profiling/SKILL.md
+++ b/.claude/skills/performance-profiling/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: performance-profiling
+description: Measure and diagnose Berthly launch time, CPU usage, memory growth, and leaks using XCTest performance metrics, leaks, and xctrace/Instruments. Load BEFORE running performance or profiling work, investigating high CPU or memory, adding performance tests, setting baselines, or claiming that Berthly is leak-free.
+user-invocable: true
+---
+
+# Performance profiling
+
+Use complementary measurements rather than treating one green test as proof:
+
+1. Unit lifetime tests catch known retain cycles deterministically.
+2. Mock-mode UI churn measures repeatable interaction cost.
+3. A live-service idle run exposes the five-second daemon polling path.
+4. `leaks` finds currently reachable leak roots in one process snapshot.
+5. Time Profiler identifies where sampled CPU time is spent.
+
+Load the `ui-testing` skill before changing or debugging any XCTest UI
+performance test. Load `e2e-testing` before profiling workflows that mutate or
+exercise the real daemon through BerthlyE2ETests. Idle live-service profiling is
+read-only and must not start, stop, or modify daemon resources.
+
+## Environment record
+
+Record this with every result so numbers are not compared across unlike hosts:
+
+```sh
+xcodebuild -version
+system_profiler SPHardwareDataType \
+  | grep -E 'Model Name|Model Identifier|Chip|Total Number of Cores|Memory'
+git rev-parse --short HEAD
+git status --short
+```
+
+State the build configuration and whether the app used mock mode or the live
+service. Never compare absolute XCTest or Instruments numbers from different
+machines, Xcode versions, build configurations, thermal states, or daemon data
+sets as if they were regressions.
+
+## Existing automated measurements
+
+Run the existing performance tests with an explicit result bundle:
+
+```sh
+rm -rf /tmp/BerthlyPerformance.xcresult
+xcodebuild test \
+  -project Berthly.xcodeproj \
+  -scheme Berthly \
+  -destination 'platform=macOS' \
+  -resultBundlePath /tmp/BerthlyPerformance.xcresult \
+  -only-testing:BerthlyUITests/BerthlyUITests/testMemoryAndCPUUsageDuringSheetChurn \
+  -only-testing:BerthlyUITests/BerthlyUITests/testMemoryAndCPUUsageDuringTerminalTabChurn \
+  -only-testing:BerthlyUITests/BerthlyUITests/testLaunchPerformance \
+  | tee /tmp/berthly-performance.log
+```
+
+Extract the measurements without summarizing thousands of UI event lines:
+
+```sh
+grep -E 'Test Case .*measured|Test Case .*passed|Executed [0-9]+ tests|TEST (SUCCEEDED|FAILED)' \
+  /tmp/berthly-performance.log
+```
+
+Run all unit tests so the explicit weak-reference lifetime checks execute along
+with the rest of the service/task lifecycle coverage:
+
+```sh
+rm -rf /tmp/BerthlyUnitTests.xcresult
+xcodebuild test -quiet \
+  -project Berthly.xcodeproj \
+  -scheme Berthly \
+  -destination 'platform=macOS' \
+  -resultBundlePath /tmp/BerthlyUnitTests.xcresult \
+  -only-testing:BerthlyTests \
+  | tee /tmp/berthly-unit-tests.log
+```
+
+Confirm that `MockContainerServiceTests/doesNotLeakAfterGoingOutOfScope()` and
+`BuildJobManagerTests/doesNotLeakAfterGoingOutOfScope()` appear as passed. A
+mistyped `-only-testing` filter can select zero Swift Testing tests while
+`xcodebuild` still exits successfully, so never infer execution from exit status
+alone.
+
+## Interpreting XCTest metrics
+
+XCTest performance metrics do not fail on an absolute limit by default. A
+passing test means the interaction completed, not that CPU, memory, or launch
+time are acceptable. Report the raw values, relative standard deviation (RSD),
+iteration count, and whether an Xcode baseline exists.
+
+- CPU Time/Cycles with RSD below 10% are generally stable enough to consider for
+  a baseline.
+- A near-zero `Memory Physical` delta often has very high RSD. Do not baseline
+  noise or call it a leak.
+- `Memory Peak Physical` from a measured interval is not the app's total resident
+  footprint. Preserve XCTest's metric name and units instead of relabeling it.
+- `XCTApplicationLaunchMetric` reports launch duration in seconds. Report its
+  individual iterations and RSD; an RSD below 10% is generally stable enough to
+  consider for a baseline. It measures process/UI launch, not steady-state
+  polling or time until daemon data finishes loading. Keep window-restoration
+  state and build configuration identical between comparisons, and rerun rather
+  than discarding an inconvenient outlier when thermal or machine load intrudes.
+- Set or update baselines in Xcode's Report Navigator only after checking RSD and
+  only when the user asks. Do not silently bless a regression.
+
+A leak requires sustained growth or retained objects across repeated lifecycles;
+one positive memory delta does not establish one.
+
+## Idle CPU and resident-memory sampling
+
+Build the configuration being assessed first. Prefer Release for product-level
+numbers and Debug when diagnosing source-level behavior:
+
+```sh
+xcodebuild build -quiet \
+  -project Berthly.xcodeproj \
+  -scheme Berthly \
+  -configuration Release \
+  -destination 'platform=macOS'
+```
+
+Resolve the product from build settings; do not hardcode a DerivedData hash:
+
+```sh
+build_settings=$(xcodebuild -project Berthly.xcodeproj -scheme Berthly \
+  -configuration Release -destination 'platform=macOS' -showBuildSettings)
+target_build_dir=$(printf '%s\n' "$build_settings" \
+  | awk -F ' = ' '/ TARGET_BUILD_DIR = / { print $2; exit }')
+full_product_name=$(printf '%s\n' "$build_settings" \
+  | awk -F ' = ' '/ FULL_PRODUCT_NAME = / { print $2; exit }')
+executable_name=$(printf '%s\n' "$build_settings" \
+  | awk -F ' = ' '/ EXECUTABLE_NAME = / { print $2; exit }')
+app="$target_build_dir/$full_product_name"
+executable="$app/Contents/MacOS/$executable_name"
+test -x "$executable"
+```
+
+Tell the user that the currently running app will be closed, then terminate it
+before launching the measured copy. Prefer stopping an Xcode-run process with
+Xcode's Stop button (⌘.) first. A process whose `ps` state contains `X` is being
+traced/debugged; this project has produced `SX` Berthly processes that survive
+even `kill -9` until Xcode releases them. Inspect before escalating:
+
+```sh
+pgrep -x Berthly | while IFS= read -r existing_pid; do
+  ps -p "$existing_pid" -o pid=,stat=,command=
+done
+```
+
+If a remaining process is Xcode-debugged, stop the active run in Xcode. When GUI
+control is unavailable, the observed fallback is:
+
+```sh
+osascript -e 'tell application "Xcode" to stop workspace document 1'
+```
+
+That command stops the active run for workspace document 1 and must not be run
+blindly when Xcode has multiple workspaces or unrelated jobs open. After Xcode
+releases a debugged process, use normal `kill`/`pkill` if it remains and verify
+`pgrep -x Berthly` is empty.
+
+Launch the executable directly so the shell captures Berthly's PID; `$!` from
+`open` would be the short-lived `open` helper instead. Use one of these forms:
+
+```sh
+# Deterministic mock baseline
+UITEST_USE_MOCK_SERVICE=1 "$executable" >/tmp/berthly-profile-app.log 2>&1 &
+pid=$!
+
+# Live-service polling profile
+# "$executable" >/tmp/berthly-profile-app.log 2>&1 &
+# pid=$!
+
+kill -0 "$pid"
+ps -p "$pid" -o pid=,stat=,command=
+```
+
+Keep this shell alive for the remaining commands; `pid` is consumed by the RSS,
+`leaks`, and Time Profiler sections. Add a cleanup trap when running the steps in
+one script:
+
+```sh
+trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' EXIT
+```
+
+Allow at least 15 seconds of warm-up, then sample for at least 45 seconds so
+multiple five-second polls occur. Capture `%CPU` and RSS once per second,
+reporting average, maximum, minimum, and first-to-last RSS. Treat one-time
+framework/cache allocation as warm-up; look for a repeated upward staircase that
+does not settle.
+
+`ps` sampling is coarse and can miss short spikes. Use it to establish shape and
+resident-memory stability, not as a substitute for Time Profiler.
+
+## Leak snapshot
+
+Against the warmed process:
+
+```sh
+leaks "$pid" | tee /tmp/berthly-leaks.log
+```
+
+Report the process's allocated nodes/bytes and the exact leak count. `0 leaks`
+means the tool found no leak roots in that snapshot. It does not prove that every
+UI lifecycle, asynchronous task, terminal session, or real-daemon operation is
+leak-free. Pair it with churn and weak-reference tests.
+
+## Time Profiler
+
+Prefer attaching to the already launched, warmed PID. This avoids measuring only
+startup and avoids LaunchServices selecting another installed app with the same
+bundle identifier:
+
+```sh
+rm -rf /tmp/BerthlyTimeProfile.trace
+xcrun xctrace record \
+  --template 'Time Profiler' \
+  --time-limit 30s \
+  --output /tmp/BerthlyTimeProfile.trace \
+  --attach "$pid"
+```
+
+Export and inspect the table of contents before interpreting samples:
+
+```sh
+xcrun xctrace export \
+  --input /tmp/BerthlyTimeProfile.trace \
+  --toc \
+  --output /tmp/berthly-time-toc.xml
+```
+
+Verify all of the following:
+
+- The trace exists and its duration is close to the requested limit.
+- The target PID and binary are the process launched for this checkout.
+- The end reason is the time limit, not a crash.
+- Samples cover warmed steady state rather than only startup.
+
+`xctrace` may return a nonzero status when it terminates a launched target at the
+time limit. Never ignore a nonzero status blindly: accept the trace only after
+the TOC proves it completed for the intended process. Attaching to a warmed PID
+is preferred.
+
+Export the `time-profile` table for scripted inspection when needed:
+
+```sh
+xcrun xctrace export \
+  --input /tmp/BerthlyTimeProfile.trace \
+  --xpath '/trace-toc/run[@number="1"]/data/table[@schema="time-profile"]' \
+  --output /tmp/berthly-time-profile.xml
+```
+
+Resolve XML `id`/`ref` entries before aggregating stacks; counting only inline
+`frame` elements undercounts deduplicated frames. Report the dominant Berthly
+call path and its sample count, not just leaf system calls. For idle CPU, compare
+polling stacks such as `startPolling → poll → refreshAll` against UI/AppKit and
+startup work. A sampled stack identifies an optimization target, not elapsed time
+by itself.
+
+Use Instruments Allocations/Leaks interactively when the snapshot or RSS trend
+is suspicious. Use Metal System Trace/Core Animation for GPU concerns; XCTest
+has no public GPU metric.
+
+## Reporting
+
+Every report must include:
+
+- Commit, hardware, macOS/Xcode, and build configuration.
+- Exact commands or result-bundle/trace paths.
+- Tests executed and failures, including proof that lifetime tests ran.
+- Launch, CPU, and memory metric values with RSD and baseline status.
+- Idle average/peak CPU and RSS min/max/first-to-last after warm-up.
+- `leaks` count with the snapshot limitation stated.
+- Dominant Time Profiler call paths and whether the target binary was verified.
+- A clear separation between observed facts, suspected causes, and recommended
+  changes.
+
+Do not claim “no memory leak” from a single green XCTest metric. Say “no leak was
+detected in these exercised paths” unless repeated lifecycle tests, stable RSS,
+and leak inspection all support the stronger conclusion.

--- a/Berthly/Core/ImageMetadataCacheReconciler.swift
+++ b/Berthly/Core/ImageMetadataCacheReconciler.swift
@@ -1,0 +1,45 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+/// Reconciles a per-digest metadata cache against the current poll's set of digests.
+///
+/// Pulled out of `LiveContainerService.fetchImages` so the dedup/eviction rules are unit-testable
+/// without a real daemon: `decode` is the only daemon-dependent piece, injected by the caller.
+///
+/// Rules:
+/// - A digest already in `cache` is reused, never re-decoded.
+/// - Multiple images can share a digest (retags); an uncached digest is decoded at most once per
+///   call, and every image with that digest gets the same result — decoding per-reference instead
+///   let an earlier row see a transient failure while a later row (same digest, retried within the
+///   same poll) saw a success, splitting one digest across two different displayed states.
+/// - A decode failure is left out of both `cache` and `results`, so the next poll retries it
+///   instead of freezing a blank/failed state permanently.
+/// - Cache entries for digests no longer present are dropped (image removed).
+enum ImageMetadataCacheReconciler {
+    static func reconcile<Digest: Hashable, Metadata>(
+        digests: [Digest],
+        cache: [Digest: Metadata],
+        decode: (Digest) async -> Metadata?
+    ) async -> (results: [Digest: Metadata], cache: [Digest: Metadata]) {
+        var cache = cache
+        var results: [Digest: Metadata] = [:]
+        var attempted: Set<Digest> = []
+
+        for digest in digests {
+            if let cached = cache[digest] {
+                results[digest] = cached
+                continue
+            }
+            guard !attempted.contains(digest) else { continue }
+            attempted.insert(digest)
+            if let decoded = await decode(digest) {
+                cache[digest] = decoded
+                results[digest] = decoded
+            }
+        }
+
+        let currentDigests = Set(digests)
+        cache = cache.filter { currentDigests.contains($0.key) }
+        return (results, cache)
+    }
+}

--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -27,6 +27,14 @@ internal import ContainerPlugin
 // plumbing has a single seam. Splitting it is a known future refactor, not a lint fix.
 // swiftlint:disable file_length type_body_length
 
+/// Fields `mapImage`/inspect views need out of an `ImageResource`, decoded once per digest.
+private struct CachedImageMetadata {
+    let arch: [String]
+    let sizeBytes: Int64
+    let created: String
+    let inspectData: ImageInspectData
+}
+
 @MainActor
 final class LiveContainerService: ContainerServiceBase {
 
@@ -39,6 +47,12 @@ final class LiveContainerService: ContainerServiceBase {
     private var privilegedProcess: Foundation.Process?
     private var isBuilding = false
     private var systemConfig: ContainerSystemConfig?
+    /// Decoded per-digest image metadata, keyed by `ClientImage.digest` (content-addressed,
+    /// immutable). `toImageResource` walks the content store for the manifest index + OCI config
+    /// of every platform variant — expensive enough that redoing it for every image on every 5s
+    /// poll tick dominates steady-state CPU. Since a digest's content never changes, once decoded
+    /// it's cached here and reused until the image is removed (evicted in `fetchImages`).
+    private var imageMetadataCache: [String: CachedImageMetadata] = [:]
     private static let log = Logger(label: "app.berthly.container")
     private nonisolated static let pushOperationTracker = PushOperationTracker()
 
@@ -919,15 +933,28 @@ final class LiveContainerService: ContainerServiceBase {
         let initImage    = config.vminit.image
         let clientImages = try await ClientImage.list()
             .filter { !Utility.isInfraImage(name: $0.reference, builderImage: builderImage, initImage: initImage) }
-        var result: [ContainerImage] = []
-        var inspectData: [String: ImageInspectData] = [:]
-        for img in clientImages {
-            let resource = try? await img.toImageResource(containerSystemConfig: config)
-            if let resource { inspectData[img.digest] = makeInspectData(resource) }
-            result.append(mapImage(img, resource: resource))
+
+        // Multiple references (retags) can share a digest — keep the first image seen per
+        // digest to decode from, so a digest is fetched/decoded at most once this poll.
+        var imageByDigest: [String: ClientImage] = [:]
+        for img in clientImages where imageByDigest[img.digest] == nil {
+            imageByDigest[img.digest] = img
         }
-        imageInspectData = inspectData
-        return result
+
+        let (results, newCache) = await ImageMetadataCacheReconciler.reconcile(
+            digests: clientImages.map(\.digest),
+            cache: imageMetadataCache
+        ) { digest in
+            guard let img = imageByDigest[digest],
+                  let resource = try? await img.toImageResource(containerSystemConfig: config) else {
+                return nil
+            }
+            return self.makeCachedMetadata(resource)
+        }
+
+        imageMetadataCache = newCache
+        imageInspectData = newCache.mapValues(\.inspectData)
+        return clientImages.map { mapImage($0, metadata: results[$0.digest]) }
     }
 
     private func fetchVolumes() async throws -> [Volume] {
@@ -987,11 +1014,24 @@ final class LiveContainerService: ContainerServiceBase {
         )
     }
 
-    private func makeInspectData(_ resource: ImageResource) -> ImageInspectData {
+    /// Decodes everything `mapImage`/inspect views need from a fetched `ImageResource` once,
+    /// so the result can be cached per digest instead of re-decoded on every poll tick.
+    private func makeCachedMetadata(_ resource: ImageResource) -> CachedImageMetadata {
         let supportedArch = Set(["arm64", "amd64"])
         let displayVariants = resource.variants.filter {
             supportedArch.contains($0.platform.architecture)
         }
+        let sizedVariants = resource.variants.filter {
+            !($0.platform.os == "unknown" && $0.platform.architecture == "unknown")
+        }
+        let sizeBytes = sizedVariants.reduce(0) { $0 + $1.size }
+        let arch = Array(Set(sizedVariants.map { $0.platform.architecture }).intersection(supportedArch)).sorted()
+        let created: String = {
+            let date = resource.configuration.creationDate
+            guard date.timeIntervalSince1970 > 0 else { return "–" }
+            return date.formatted(Date.FormatStyle().day(.defaultDigits).month(.abbreviated).year(.defaultDigits))
+        }()
+
         let variants = (displayVariants.isEmpty ? resource.variants : displayVariants).map {
             ImageVariantInfo(arch: $0.platform.architecture, archVariant: $0.platform.variant,
                              sizeBytes: $0.size, digest: $0.digest)
@@ -1010,7 +1050,7 @@ final class LiveContainerService: ContainerServiceBase {
             if s.hasPrefix("#(nop) ") { s = String(s.dropFirst("#(nop) ".count)) }
             return s.trimmingCharacters(in: .whitespaces)
         }
-        return ImageInspectData(
+        let inspectData = ImageInspectData(
             variants: variants,
             command: (ep + cmd).joined(separator: " "),
             workDir: cfg?.workingDir ?? "",
@@ -1020,27 +1060,16 @@ final class LiveContainerService: ContainerServiceBase {
             labels: cfg?.labels ?? [:],
             history: history
         )
+        return CachedImageMetadata(arch: arch, sizeBytes: sizeBytes, created: created, inspectData: inspectData)
     }
 
-    private func mapImage(_ img: ClientImage, resource: ImageResource?) -> ContainerImage {
+    private func mapImage(_ img: ClientImage, metadata: CachedImageMetadata?) -> ContainerImage {
         let ref = img.reference
         let atIdx = ref.firstIndex(of: "@")
         let base = atIdx.map { String(ref[ref.startIndex ..< $0]) } ?? ref
         let colonIdx = base.lastIndex(of: ":")
         let repository = colonIdx.map { String(base[base.startIndex ..< $0]) } ?? base
         let tag = colonIdx.map { idx -> String in String(base[base.index(after: idx)...]) } ?? "latest"
-
-        let variants = resource?.variants.filter {
-            !($0.platform.os == "unknown" && $0.platform.architecture == "unknown")
-        } ?? []
-        let sizeBytes = variants.reduce(0) { $0 + $1.size }
-        let supportedArch: Set<String> = ["arm64", "amd64"]
-        let arch = Array(Set(variants.map { $0.platform.architecture }).intersection(supportedArch)).sorted()
-        let created: String = {
-            guard let date = resource?.configuration.creationDate,
-                  date.timeIntervalSince1970 > 0 else { return "–" }
-            return date.formatted(Date.FormatStyle().day(.defaultDigits).month(.abbreviated).year(.defaultDigits))
-        }()
 
         let isBuilt = img.description.descriptor.annotations?[AnnotationKeys.containerizationImageName] != nil
 
@@ -1053,9 +1082,9 @@ final class LiveContainerService: ContainerServiceBase {
             repository: repository,
             tag: tag,
             digest: img.digest,
-            arch: arch,
-            sizeBytes: sizeBytes,
-            created: created,
+            arch: metadata?.arch ?? [],
+            sizeBytes: metadata?.sizeBytes ?? 0,
+            created: metadata?.created ?? "–",
             source: isBuilt ? .built : .pulled,
             usage: .unused  // resolved against containers/machines by ContainerImage.resolvingUsage in refreshAll
         )

--- a/BerthlyTests/ImageMetadataCacheReconcilerTests.swift
+++ b/BerthlyTests/ImageMetadataCacheReconcilerTests.swift
@@ -1,0 +1,103 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import Testing
+@testable import Berthly
+
+struct ImageMetadataCacheReconcilerTests {
+    @Test
+    func cachedDigestsAreNotRequestedAgain() async {
+        var decodeCalls = 0
+        let (results, cache) = await ImageMetadataCacheReconciler.reconcile(
+            digests: ["d1"],
+            cache: ["d1": "M1"]
+        ) { _ in
+            decodeCalls += 1
+            return "should-not-be-used"
+        }
+        let expected: [String: String] = ["d1": "M1"]
+        #expect(decodeCalls == 0)
+        #expect(results == expected)
+        #expect(cache == expected)
+    }
+
+    @Test
+    func sameDigestRetagsRequireOneDecode() async {
+        var decodeCalls = 0
+        let (results, cache) = await ImageMetadataCacheReconciler.reconcile(
+            digests: ["d1", "d1", "d1"],
+            cache: [String: String]()
+        ) { _ in
+            decodeCalls += 1
+            return "M1"
+        }
+        let expected: [String: String] = ["d1": "M1"]
+        #expect(decodeCalls == 1)
+        #expect(results == expected)
+        #expect(cache == expected)
+    }
+
+    @Test
+    func newDigestsRequireDecoding() async {
+        let (results, cache) = await ImageMetadataCacheReconciler.reconcile(
+            digests: ["d2"],
+            cache: [String: String]()
+        ) { digest in "decoded-\(digest)" }
+        let expected: [String: String] = ["d2": "decoded-d2"]
+        #expect(results == expected)
+        #expect(cache == expected)
+    }
+
+    @Test
+    func removedDigestsAreEvicted() async {
+        let (results, cache) = await ImageMetadataCacheReconciler.reconcile(
+            digests: ["d1"],
+            cache: ["d1": "M1", "d2": "M2"]
+        ) { _ in
+            Issue.record("decode should not run for an already-cached digest")
+            return nil
+        }
+        let expected: [String: String] = ["d1": "M1"]
+        #expect(results == expected)
+        #expect(cache == expected)
+    }
+
+    @Test
+    func failedDigestsRetryOnNextPollNotRepeatedlyWithinOnePoll() async {
+        var decodeCalls = 0
+        let (firstResults, firstCache) = await ImageMetadataCacheReconciler.reconcile(
+            digests: ["d3", "d3", "d3"],
+            cache: [String: String]()
+        ) { _ in
+            decodeCalls += 1
+            return nil
+        }
+        #expect(decodeCalls == 1)
+        #expect(firstResults.isEmpty)
+        #expect(firstCache.isEmpty)
+
+        let (secondResults, secondCache) = await ImageMetadataCacheReconciler.reconcile(
+            digests: ["d3"],
+            cache: firstCache
+        ) { _ in
+            decodeCalls += 1
+            return "M3"
+        }
+        let expected: [String: String] = ["d3": "M3"]
+        #expect(decodeCalls == 2)
+        #expect(secondResults == expected)
+        #expect(secondCache == expected)
+    }
+
+    @Test
+    func everyImageSharingADigestReceivesIdenticalMetadata() async {
+        let (results, _) = await ImageMetadataCacheReconciler.reconcile(
+            digests: ["d1", "d1"],
+            cache: [String: String]()
+        ) { _ in "M1" }
+        let imageDigests = ["d1", "d1"]
+        let resolved = imageDigests.map { results[$0] }
+        let expected: [String?] = ["M1", "M1"]
+        #expect(resolved == expected)
+    }
+}


### PR DESCRIPTION
## Summary
- Cache decoded image metadata (arch/size/created/inspect data) per content digest via a new `ImageMetadataCacheReconciler`, instead of `fetchImages()` calling `toImageResource()` (full manifest+config decode via the content store) for every image on every 5s poll tick. A digest is decoded at most once per poll even when multiple references share it (retags), and stale entries are evicted when their digest disappears.
- Also includes a docs-only commit adding the `performance-profiling` skill (`.claude/skills/performance-profiling/SKILL.md`), which was already committed on `main` ahead of origin.

## Test plan
- [x] `swiftlint lint --strict` clean on changed files
- [x] Full Xcode test suite green: 578 tests, 559 passed, 0 failed, 18 skipped (BerthlyE2ETests — expected outside `scripts/e2e.sh`)
- [x] New `ImageMetadataCacheReconcilerTests` (6 cases: cache hit, dedup on shared digest, new-digest decode, eviction, no-retry-within-a-poll but retry-next-poll, identical metadata for images sharing a digest) all pass