### PR TITLE
test: add large mock inventory UI test for correctness and performance

### DIFF
--- a/.claude/skills/performance-profiling/SKILL.md
+++ b/.claude/skills/performance-profiling/SKILL.md
@@ -193,6 +193,13 @@ one script:
 trap 'kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true' EXIT
 ```
 
+If the launch, sampling, `leaks`, and Time Profiler steps can't literally run in
+one continuous shell (an agent tool that resets shell state between calls, not a
+human's Terminal session), `disown "$pid"` after launch and persist `$pid` to a
+file instead of relying on a variable to survive; reread it from the file in the
+next step to reattach and clean up. Without `disown`, the background job is tied
+to that shell and can be reaped when the tool ends the shell between steps.
+
 Allow at least 15 seconds of warm-up, then sample for at least 45 seconds so
 multiple five-second polls occur. Capture `%CPU` and RSS once per second,
 reporting average, maximum, minimum, and first-to-last RSS. Treat one-time
@@ -245,6 +252,11 @@ Verify all of the following:
 - The target PID and binary are the process launched for this checkout.
 - The end reason is the time limit, not a crash.
 - Samples cover warmed steady state rather than only startup.
+
+Zero rows in the exported `time-profile` table is a valid outcome for a
+genuinely idle process (e.g. large-dataset mock mode with ~0% `ps` CPU) — it
+means there was nothing to sample, not that the trace failed. Trust the TOC
+checks above over the row count.
 
 `xctrace` may return a nonzero status when it terminates a launched target at the
 time limit. Never ignore a nonzero status blindly: accept the trace only after

--- a/.claude/skills/performance-profiling/SKILL.md
+++ b/.claude/skills/performance-profiling/SKILL.md
@@ -50,6 +50,7 @@ xcodebuild test \
   -only-testing:BerthlyUITests/BerthlyUITests/testMemoryAndCPUUsageDuringSheetChurn \
   -only-testing:BerthlyUITests/BerthlyUITests/testMemoryAndCPUUsageDuringTerminalTabChurn \
   -only-testing:BerthlyUITests/BerthlyUITests/testLaunchPerformance \
+  -only-testing:BerthlyUITests/LargeInventoryTests/testLargeInventorySectionAndDetailPerformance \
   | tee /tmp/berthly-performance.log
 ```
 
@@ -74,11 +75,15 @@ xcodebuild test -quiet \
   | tee /tmp/berthly-unit-tests.log
 ```
 
-Confirm that `MockContainerServiceTests/doesNotLeakAfterGoingOutOfScope()` and
-`BuildJobManagerTests/doesNotLeakAfterGoingOutOfScope()` appear as passed. A
+Confirm that `MockContainerServiceTests/doesNotLeakAfterGoingOutOfScope()`,
+`MockContainerServiceTests/doesNotLeakWithLargeDatasetAfterGoingOutOfScope()`,
+and `BuildJobManagerTests/doesNotLeakAfterGoingOutOfScope()` appear as passed. A
 mistyped `-only-testing` filter can select zero Swift Testing tests while
 `xcodebuild` still exits successfully, so never infer execution from exit status
-alone.
+alone — Swift Testing identifiers need the trailing `()` (e.g.
+`-only-testing:"BerthlyTests/MockContainerServiceTests/doesNotLeakAfterGoingOutOfScope()"`,
+quoted so the shell doesn't eat the parens); omitting it silently matches
+nothing rather than erroring.
 
 ## Interpreting XCTest metrics
 
@@ -165,6 +170,12 @@ Launch the executable directly so the shell captures Berthly's PID; `$!` from
 # Deterministic mock baseline
 UITEST_USE_MOCK_SERVICE=1 "$executable" >/tmp/berthly-profile-app.log 2>&1 &
 pid=$!
+
+# Deterministic mock baseline, large inventory (100 containers, 20 machines,
+# 50 images, 40 volumes, 20 networks) — for stress-profiling idle CPU/RSS or
+# leaks against LargeMockFixture's dataset instead of the small default one.
+# UITEST_USE_MOCK_SERVICE=1 UITEST_MOCK_DATASET=large "$executable" >/tmp/berthly-profile-app.log 2>&1 &
+# pid=$!
 
 # Live-service polling profile
 # "$executable" >/tmp/berthly-profile-app.log 2>&1 &

--- a/Berthly/BerthlyApp.swift
+++ b/Berthly/BerthlyApp.swift
@@ -45,7 +45,8 @@ struct BerthlyApp: App {
         guard env["UITEST_USE_MOCK_SERVICE"] != nil else {
             return LiveContainerService()
         }
-        let mock = MockContainerService()
+        let dataset: MockDataset = env["UITEST_MOCK_DATASET"] == "large" ? .large : .default
+        let mock = MockContainerService(dataset: dataset)
         switch env["UITEST_INITIAL_DAEMON_STATE"] {
         case "installedButStopped": mock.daemonState = .installedButStopped
         case "notInstalled":        mock.daemonState = .notInstalled

--- a/Berthly/Core/LargeMockFixture.swift
+++ b/Berthly/Core/LargeMockFixture.swift
@@ -1,0 +1,236 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import Foundation
+
+enum MockDataset: Equatable {
+    case `default`
+    case large
+}
+
+extension MockContainerService {
+    func applyLargeFixture() {
+        let fixture = LargeMockFixture.make()
+        containers = fixture.containers
+        images = fixture.images
+        volumes = fixture.volumes
+        networks = fixture.networks
+        machines = fixture.machines
+        imageUpdateInfo = [:]
+        lastImageUpdateCheck = nil
+        imageInspectData = [:]
+        buildContexts = [:]
+    }
+}
+
+struct LargeMockFixture: Equatable {
+    let containers: [Container]
+    let images: [ContainerImage]
+    let volumes: [Volume]
+    let networks: [Network]
+    let machines: [Machine]
+
+    static func make() -> LargeMockFixture {
+        let containers = makeContainers()
+        let machines = makeMachines()
+        let images = ContainerImage.resolvingUsage(
+            makeImages(),
+            containers: containers,
+            machines: machines
+        )
+        let volumes = Volume.resolvingMounts(makeVolumes(), containers: containers)
+        let networks = makeNetworks(containers: containers, machines: machines)
+        return LargeMockFixture(
+            containers: containers,
+            images: images,
+            volumes: volumes,
+            networks: networks,
+            machines: machines
+        )
+    }
+
+    private static func makeContainers() -> [Container] {
+        let referenceDate = Date(timeIntervalSince1970: 1_767_225_600)
+        return (0..<100).map { index in
+            let status = containerStatus(index)
+            let volumeIndex = index.isMultiple(of: 3) ? index % 30 : nil
+            let mounts = volumeIndex.map {
+                [ContainerMount(
+                    source: volumeName($0),
+                    destination: "/data/\(padded(index))",
+                    volumeName: volumeName($0),
+                    isReadOnly: index.isMultiple(of: 6)
+                )]
+            } ?? []
+            return Container(
+                id: containerName(index),
+                name: containerName(index),
+                image: imageReference(index % 40),
+                imageDigest: imageDigest(index % 40),
+                status: status,
+                ports: index.isMultiple(of: 5)
+                    ? [PortMapping(host: 10_000 + index, container: 8_000)]
+                    : [],
+                cpuPercent: status == .running ? Double((index * 7) % 80) + 0.5 : 0,
+                memoryMB: status == .running ? 64 + (index % 8) * 32 : 0,
+                memoryLimitMB: 512 + (index % 4) * 256,
+                networkIOString: status == .running ? "\(index + 1) KB/s" : "–",
+                uptime: status == .running ? "\(index + 1)m" : "–",
+                command: index == 42
+                    ? "/usr/local/bin/large-inventory-worker --queue=events --concurrency=16"
+                    : "sleep 3600",
+                mounts: mounts,
+                networks: containerNetworks(index),
+                environment: ["BERTHLY_FIXTURE_INDEX=\(index)"],
+                startedDate: status == .running
+                    ? referenceDate.addingTimeInterval(TimeInterval(-index * 60))
+                    : nil
+            )
+        }
+    }
+
+    private static func makeMachines() -> [Machine] {
+        (0..<20).map { index in
+            let cpus = 1 + index % 4
+            let memoryGB = 1 + index % 8
+            return Machine(
+                id: machineName(index),
+                name: machineName(index),
+                image: imageReference(40 + index % 5),
+                status: index < 12 ? .running : .stopped,
+                isUtility: index == 19,
+                diskUsedGB: Double(index + 1) * 0.25,
+                diskTotalGB: 8,
+                uptimeString: index < 12 ? "\(index + 1)h" : "–",
+                kernel: "6.12.4-arm64",
+                resources: "\(cpus) vCPU · \(memoryGB) GB",
+                created: "2026-01-01",
+                homeMount: machineHomeMount(index),
+                isDefault: index == 0
+            )
+        }
+    }
+
+    private static func makeImages() -> [ContainerImage] {
+        (0..<50).map { index in
+            let repository = index == 49
+                ? "registry.example.internal/berthly/large-inventory/unused-diagnostic-image"
+                : "local/fixture-image-\(padded(index))"
+            return ContainerImage(
+                id: "\(repository):v1",
+                repository: repository,
+                tag: "v1",
+                digest: imageDigest(index),
+                arch: index.isMultiple(of: 4) ? ["arm64", "amd64"] : ["arm64"],
+                sizeBytes: Int64(32 + index * 3) * 1_048_576,
+                created: "2026-01-01",
+                source: index.isMultiple(of: 2) ? .built : .pulled,
+                usage: .unused
+            )
+        }
+    }
+
+    private static func makeVolumes() -> [Volume] {
+        (0..<40).map { index in
+            let name = volumeName(index)
+            return Volume(
+                id: name,
+                name: name,
+                type: index < 30 ? .named : .anonymous,
+                usedMB: 16 + index * 8,
+                allocatedMB: 1_024,
+                driver: "local",
+                source: "/mock/volumes/\(name)/volume.img",
+                created: "2026-01-01",
+                labels: ["berthly.fixture=large"],
+                options: ["size=1G"],
+                mounts: [],
+                fs: "ext4",
+                reclaimable: true
+            )
+        }
+    }
+
+    private static func makeNetworks(containers: [Container], machines: [Machine]) -> [Network] {
+        (0..<20).map { index in
+            let id = networkName(index)
+            let containerEndpoints = containers
+                .filter { $0.networks.contains(id) }
+                .enumerated()
+                .map { offset, container in
+                    NetworkEndpoint(
+                        id: "endpoint-\(container.id)-\(id)",
+                        name: container.name,
+                        ipv4: "10.\(index + 20).0.\(offset + 10)",
+                        kind: "CONTAINER",
+                        isRunning: container.status == .running,
+                        aliases: [container.name]
+                    )
+                }
+            var machineEndpoints: [NetworkEndpoint] = []
+            if index < 10 {
+                let machine = machines[index]
+                machineEndpoints.append(NetworkEndpoint(
+                    id: "endpoint-\(machine.id)-\(id)",
+                    name: machine.name,
+                    ipv4: "10.\(index + 20).0.200",
+                    kind: "MACHINE",
+                    isRunning: machine.status == .running,
+                    aliases: [machine.name]
+                ))
+            }
+            return Network(
+                id: id,
+                name: id,
+                driver: index.isMultiple(of: 3) ? .hostOnly : .nat,
+                subnet: "10.\(index + 20).0.0/24",
+                gateway: "10.\(index + 20).0.1",
+                isDefault: index == 0,
+                scope: "local",
+                ipv6Enabled: index.isMultiple(of: 5),
+                egress: index.isMultiple(of: 3) ? "" : "NAT → en0",
+                attachable: true,
+                backend: "vmnet",
+                endpoints: containerEndpoints + machineEndpoints
+            )
+        }
+    }
+
+    private static func containerStatus(_ index: Int) -> ContainerStatus {
+        switch index % 10 {
+        case 0...5: .running
+        case 6...7: .stopped
+        case 8: .paused
+        default: .error
+        }
+    }
+
+    private static func containerNetworks(_ index: Int) -> [String] {
+        guard !index.isMultiple(of: 10) else { return [] }
+        let primary = networkName(index % 20)
+        guard index.isMultiple(of: 4) else { return [primary] }
+        return [primary, networkName((index + 1) % 20)]
+    }
+
+    private static func machineHomeMount(_ index: Int) -> MachineHomeMount {
+        switch index % 3 {
+        case 0: .readWrite
+        case 1: .readOnly
+        default: .none
+        }
+    }
+
+    private static func containerName(_ index: Int) -> String { "container-\(padded(index))" }
+    private static func machineName(_ index: Int) -> String { "machine-\(padded(index))" }
+    private static func volumeName(_ index: Int) -> String { "volume-\(padded(index))" }
+    private static func networkName(_ index: Int) -> String { "network-\(padded(index))" }
+    private static func imageDigest(_ index: Int) -> String { "sha256:fixture\(padded(index))" }
+
+    private static func imageReference(_ index: Int) -> String {
+        "local/fixture-image-\(padded(index)):v1"
+    }
+
+    private static func padded(_ index: Int) -> String {
+        String(format: "%03d", index)
+    }
+}

--- a/Berthly/Core/MockContainerService.swift
+++ b/Berthly/Core/MockContainerService.swift
@@ -21,7 +21,7 @@ extension Container {
 @MainActor
 final class MockContainerService: ContainerServiceBase {
 
-    override init() {
+    init(dataset: MockDataset = .default) {
         super.init()
         daemonState = .connected
         installedContainerVersion = ContainerCompatibility.requiredVersion
@@ -86,6 +86,8 @@ final class MockContainerService: ContainerServiceBase {
             "local/web:1.4": BuildContext(contextPath: "/Users/dev/projects/web", dockerfilePath: nil),
             "local/api:2.1": BuildContext(contextPath: "/Users/dev/projects/api", dockerfilePath: "Containerfile")
         ]
+
+        if dataset == .large { applyLargeFixture() }
     }
 
     private static func mockInspectData() -> [String: ImageInspectData] {

--- a/Berthly/Views/ComputeListView.swift
+++ b/Berthly/Views/ComputeListView.swift
@@ -80,7 +80,10 @@ struct ComputeListView: View {
                                     .tag(entry.tag)
                                     .listRowSeparator(.hidden)
                             }
-                        } header: { ComputeSectionHeader("RUNNING \(runningCount)") }
+                        } header: {
+                            ComputeSectionHeader("RUNNING \(runningCount)")
+                                .accessibilityIdentifier("computeRunningSummary")
+                        }
                     }
                     if stoppedCount > 0 {
                         Section {
@@ -94,12 +97,17 @@ struct ComputeListView: View {
                                     .tag(entry.tag)
                                     .listRowSeparator(.hidden)
                             }
-                        } header: { ComputeSectionHeader("STOPPED \(stoppedCount)") }
+                        } header: {
+                            ComputeSectionHeader("STOPPED \(stoppedCount)")
+                                .accessibilityIdentifier("computeStoppedSummary")
+                        }
                     }
                 }
                 // Kill the hairline AppKit draws under the pinned first section header — see
                 // NonFloatingListHeaders.
                 .nonFloatingSectionHeaders()
+                .accessibilityElement(children: .contain)
+                .accessibilityIdentifier("computeList")
                 // ⌫ on a selected, stopped row — same confirm-then-delete flow as the row's
                 // hover trash button and context menu, just reached by keyboard.
                 .onDeleteCommand { deleteTarget = deletableSelection }

--- a/Berthly/Views/ContainerDetailView.swift
+++ b/Berthly/Views/ContainerDetailView.swift
@@ -121,6 +121,7 @@ private struct ContainerDetailContent: View {
                     Text(container.name)
                         .font(.title2.weight(.bold))
                         .lineLimit(1)
+                        .accessibilityIdentifier("containerDetailTitle")
                     StatusBadge(status: container.status)
                 }
                 HStack(spacing: 4) {

--- a/Berthly/Views/ImageDetailView.swift
+++ b/Berthly/Views/ImageDetailView.swift
@@ -122,6 +122,7 @@ private struct ImageDetailContent: View {
                     .font(.title3.weight(.semibold))
                     .fontDesign(.monospaced)
                     .lineLimit(1)
+                    .accessibilityIdentifier("imageDetailTitle")
                 // When the pane squeezes this row (detail min is 320pt), whole elements drop
                 // instead of degrading in place — squeezing wraps the badges mid-word ("arm6/4")
                 // and truncating leaves ellipsis soup ("18… · 2…"). Size/created go first (the

--- a/Berthly/Views/ImagesListView.swift
+++ b/Berthly/Views/ImagesListView.swift
@@ -258,6 +258,7 @@ private struct ImageRow: View {
                     Text(image.fullName)
                         .font(.system(.body, design: .monospaced, weight: .medium))
                         .lineLimit(1)
+                        .accessibilityIdentifier("imageRow-\(image.id)")
                     HStack(spacing: 4) {
                         ForEach(image.arch, id: \.self) { arch in
                             Text(arch)

--- a/Berthly/Views/MachineDetailView.swift
+++ b/Berthly/Views/MachineDetailView.swift
@@ -107,6 +107,7 @@ private struct MachineDetailContent: View {
                     Text(machine.name)
                         .font(.title2.weight(.bold))
                         .lineLimit(1)
+                        .accessibilityIdentifier("machineDetailTitle")
                     StatusBadge(status: machine.status)
                     if machine.isDefault {
                         DefaultChip()

--- a/Berthly/Views/NetworkDetailView.swift
+++ b/Berthly/Views/NetworkDetailView.swift
@@ -87,6 +87,7 @@ private struct NetworkDetailContent: View {
                         .font(.title3.weight(.semibold))
                         .lineLimit(1)
                         .truncationMode(.middle)
+                        .accessibilityIdentifier("networkDetailTitle")
                     TintedChip(text: network.driver.rawValue,
                                 color: network.driver == .nat ? .berthlyAccent : .statusPaused)
                     if network.isDefault {

--- a/Berthly/Views/NetworksListView.swift
+++ b/Berthly/Views/NetworksListView.swift
@@ -188,6 +188,7 @@ private struct NetworkRow: View {
                             .font(.system(.body, design: .default, weight: .medium))
                             .lineLimit(1)
                             .truncationMode(.middle)
+                            .accessibilityIdentifier("networkRow-\(network.name)")
                         if network.isDefault {
                             TintedChip(text: "DEFAULT", color: .secondary)
                         }

--- a/Berthly/Views/Sidebar/SidebarView.swift
+++ b/Berthly/Views/Sidebar/SidebarView.swift
@@ -28,6 +28,7 @@ struct SidebarView: View {
             SidebarRow(icon: "shippingbox", label: "Compute",
                        badge: runningComputeCount, badgeTint: .statusRunning)
                 .tag(SidebarSelection.compute)
+                .accessibilityIdentifier("sidebarCompute")
                 .help(runningComputeCount > 0
                       ? "\(runningComputeCount) running"
                       : "No containers or machines running")
@@ -35,10 +36,13 @@ struct SidebarView: View {
             Section("LIBRARY") {
                 SidebarRow(icon: "cylinder", label: "Volumes", badge: service.volumes.count)
                     .tag(SidebarSelection.volumes)
+                    .accessibilityIdentifier("sidebarVolumes")
                 SidebarRow(icon: "arrow.triangle.branch", label: "Networks", badge: service.networks.count)
                     .tag(SidebarSelection.networks)
+                    .accessibilityIdentifier("sidebarNetworks")
                 SidebarRow(icon: "square.stack.3d.up", label: "Images", badge: service.images.count)
                     .tag(SidebarSelection.images)
+                    .accessibilityIdentifier("sidebarImages")
                 SidebarRow(icon: "building.columns", label: "Registries", badge: service.registries.count)
                     .tag(SidebarSelection.registries)
             }

--- a/Berthly/Views/VolumeDetailView.swift
+++ b/Berthly/Views/VolumeDetailView.swift
@@ -89,6 +89,7 @@ private struct VolumeDetailContent: View {
                         .fontDesign(.monospaced)
                         .lineLimit(1)
                         .truncationMode(.middle)
+                        .accessibilityIdentifier("volumeDetailTitle")
                     TintedChip(text: volume.type == .named ? "named" : "anonymous",
                                color: volume.type == .named ? .statusRunning : .purple)
                     if volume.reclaimable {

--- a/Berthly/Views/VolumesListView.swift
+++ b/Berthly/Views/VolumesListView.swift
@@ -160,6 +160,7 @@ private struct VolumeRow: View {
                         .font(.system(.body, design: .monospaced, weight: .medium))
                         .lineLimit(1)
                         .truncationMode(.tail)
+                        .accessibilityIdentifier("volumeRow-\(volume.name)")
                     Text(mountSummary(volume))
                         .font(.caption)
                         .foregroundStyle(.secondary)

--- a/BerthlyTests/BerthlyTests.swift
+++ b/BerthlyTests/BerthlyTests.swift
@@ -857,6 +857,18 @@ struct MockContainerServiceTests {
         #expect(weakRef == nil)
     }
 
+    /// Same rationale as `doesNotLeakAfterGoingOutOfScope`, scoped to `applyLargeFixture()`'s
+    /// path: a hundred-plus-resource fixture assignment is a plausible spot for an accidental
+    /// strong self-capture that the small default fixture wouldn't surface.
+    @Test func doesNotLeakWithLargeDatasetAfterGoingOutOfScope() {
+        weak var weakRef: MockContainerService?
+        do {
+            let service = MockContainerService(dataset: .large)
+            weakRef = service
+        }
+        #expect(weakRef == nil)
+    }
+
     @Test func killContainerStopsARunningContainerImmediately() async throws {
         let mock = MockContainerService()
         let running = try #require(mock.containers.first(where: { $0.status == .running }))

--- a/BerthlyTests/LargeMockFixtureTests.swift
+++ b/BerthlyTests/LargeMockFixtureTests.swift
@@ -1,0 +1,127 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import Testing
+@testable import Berthly
+
+@MainActor
+struct LargeMockFixtureTests {
+
+    @Test func generatesExpectedInventory() {
+        let fixture = LargeMockFixture.make()
+
+        #expect(fixture.containers.count == 100)
+        #expect(fixture.machines.count == 20)
+        #expect(fixture.images.count == 50)
+        #expect(fixture.volumes.count == 40)
+        #expect(fixture.networks.count == 20)
+        #expect(fixture.containers.first?.id == "container-000")
+        #expect(fixture.containers.last?.id == "container-099")
+        #expect(fixture.machines.first?.id == "machine-000")
+        #expect(fixture.machines.last?.id == "machine-019")
+    }
+
+    @Test func generatesUniqueResourceIdentities() {
+        let fixture = LargeMockFixture.make()
+
+        #expect(Set(fixture.containers.map(\.id)).count == fixture.containers.count)
+        #expect(Set(fixture.containers.map(\.name)).count == fixture.containers.count)
+        #expect(Set(fixture.machines.map(\.id)).count == fixture.machines.count)
+        #expect(Set(fixture.machines.map(\.name)).count == fixture.machines.count)
+        #expect(Set(fixture.images.map(\.id)).count == fixture.images.count)
+        #expect(Set(fixture.volumes.map(\.id)).count == fixture.volumes.count)
+        #expect(Set(fixture.networks.map(\.id)).count == fixture.networks.count)
+    }
+
+    @Test func includesExpectedStatesAndEdgeCases() {
+        let fixture = LargeMockFixture.make()
+
+        #expect(fixture.containers.count { $0.status == .running } == 60)
+        #expect(fixture.containers.count { $0.status == .stopped } == 20)
+        #expect(fixture.containers.count { $0.status == .paused } == 10)
+        #expect(fixture.containers.count { $0.status == .error } == 10)
+        #expect(fixture.machines.count { $0.status == .running } == 12)
+        #expect(fixture.machines.count { $0.status == .stopped } == 8)
+        #expect(fixture.machines.count { $0.isUtility } == 1)
+        #expect(fixture.machines.count { $0.isDefault } == 1)
+        #expect(fixture.containers.contains { $0.networks.isEmpty })
+        #expect(fixture.containers.contains { $0.networks.count > 1 })
+        #expect(fixture.volumes.contains { $0.mounts.isEmpty })
+        #expect(fixture.volumes.contains { !$0.mounts.isEmpty })
+        #expect(fixture.networks.contains { $0.driver == .nat })
+        #expect(fixture.networks.contains { $0.driver == .hostOnly })
+        #expect(fixture.images.contains { $0.fullName.count > 70 })
+        #expect(fixture.images.contains { $0.usage == .unused })
+        #expect(fixture.images.contains {
+            if case .usedBy = $0.usage { return true }
+            return false
+        })
+    }
+
+    @Test func resolvesEveryImageReference() {
+        let fixture = LargeMockFixture.make()
+        let images = fixture.images
+
+        for reference in fixture.containers.map(\.image) + fixture.machines.map(\.image) {
+            #expect(images.contains { image in
+                reference == image.id || reference == image.fullName || reference == image.digest
+            })
+        }
+    }
+
+    @Test func derivesVolumeMountsFromContainers() throws {
+        let fixture = LargeMockFixture.make()
+
+        for volume in fixture.volumes {
+            let expected = fixture.containers.flatMap { container in
+                container.mounts
+                    .filter { $0.volumeName == volume.name }
+                    .map { VolumeMount(
+                        containerName: container.name,
+                        mountPath: $0.destination,
+                        mode: $0.isReadOnly ? "RO" : "RW"
+                    ) }
+            }
+            #expect(volume.mounts == expected)
+            #expect(volume.reclaimable == volume.mounts.isEmpty)
+        }
+
+        for container in fixture.containers {
+            for mount in container.mounts {
+                let volumeName = try #require(mount.volumeName)
+                #expect(fixture.volumes.contains { $0.name == volumeName })
+            }
+        }
+    }
+
+    @Test func keepsNetworkAttachmentsAndEndpointsConsistent() {
+        let fixture = LargeMockFixture.make()
+
+        for container in fixture.containers {
+            for networkID in container.networks {
+                let network = fixture.networks.first { $0.id == networkID }
+                #expect(network != nil)
+                #expect(network?.endpoints.contains {
+                    $0.kind == "CONTAINER" && $0.name == container.name
+                } == true)
+            }
+        }
+
+        for network in fixture.networks {
+            for endpoint in network.endpoints where endpoint.kind == "CONTAINER" {
+                let container = fixture.containers.first { $0.name == endpoint.name }
+                #expect(container?.networks.contains(network.id) == true)
+            }
+            for endpoint in network.endpoints where endpoint.kind == "MACHINE" {
+                #expect(fixture.machines.contains { $0.name == endpoint.name })
+            }
+        }
+    }
+
+    @Test func generationIsDeterministic() {
+        let first = LargeMockFixture.make()
+        let second = LargeMockFixture.make()
+
+        #expect(first == second)
+    }
+}

--- a/BerthlyUITests/LargeInventoryTests.swift
+++ b/BerthlyUITests/LargeInventoryTests.swift
@@ -1,0 +1,180 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import XCTest
+
+final class LargeInventoryTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+        XCUIApplication.terminateRunningBerthly()
+    }
+
+    @MainActor
+    func testLargeInventorySupportsNavigationAndLifecycleWorkflows() throws {
+        let app = launchLargeInventory()
+        let firstContainer = app.staticTexts["computeRow-container-000"]
+        XCTAssertTrue(firstContainer.waitForExistence(timeout: 10))
+        firstContainer.click()
+        assertTitle(app.staticTexts["containerDetailTitle"], equals: "container-000")
+
+        setComputeFilter("machine-018", in: app)
+        let machine = app.staticTexts["machineRow-machine-018"]
+        XCTAssertTrue(machine.waitForExistence(timeout: 5))
+        machine.click()
+        assertTitle(app.staticTexts["machineDetailTitle"], equals: "machine-018")
+        clearComputeFilter(in: app)
+
+        firstContainer.click()
+        XCTAssertTrue(app.staticTexts["containerDetailTitle"].waitForExistence(timeout: 5))
+        app.typeKey(.escape, modifierFlags: [])
+        XCTAssertTrue(app.staticTexts["containerDetailTitle"].waitForNonExistence(timeout: 5))
+        let computeList = app.descendants(matching: .any)["computeList"]
+        XCTAssertTrue(computeList.waitForExistence(timeout: 5))
+        let computeOutline = computeList.descendants(matching: .outline).firstMatch
+        XCTAssertTrue(computeOutline.waitForExistence(timeout: 5))
+        for _ in 0..<3 {
+            computeOutline.scroll(byDeltaX: 0, deltaY: -10_000)
+        }
+        // container-099 is the last *container* row, seven stopped-machine rows above the actual
+        // bottom edge — landing a scroll-to-max click there avoids the boundary row (machine-018,
+        // dead last in the list), where the same click reproducibly raced a stale/degenerate frame.
+        let tailContainer = app.staticTexts["computeRow-container-099"]
+        let tailIsHittable = NSPredicate(format: "hittable == true")
+        expectation(for: tailIsHittable, evaluatedWith: tailContainer)
+        waitForExpectations(timeout: 5)
+        tailContainer.click()
+        assertTitle(app.staticTexts["containerDetailTitle"], equals: "container-099")
+
+        setComputeFilter("container-000", in: app)
+        XCTAssertTrue(firstContainer.waitForExistence(timeout: 5))
+        firstContainer.click()
+        clearComputeFilter(in: app)
+        let stopButton = app.buttons["containerStopButton"]
+        XCTAssertTrue(stopButton.waitForExistence(timeout: 5))
+        stopButton.click()
+        let startButton = app.buttons["containerStartButton"]
+        XCTAssertTrue(startButton.waitForExistence(timeout: 5))
+        startButton.click()
+        XCTAssertTrue(stopButton.waitForExistence(timeout: 5))
+
+        setComputeFilter("container-097", in: app)
+        let deleteRow = app.staticTexts["computeRow-container-097"]
+        XCTAssertTrue(deleteRow.waitForExistence(timeout: 5))
+        deleteRow.rightClick()
+        let deleteMenuItem = app.menuItems["Delete…"]
+        XCTAssertTrue(deleteMenuItem.waitForExistence(timeout: 5))
+        deleteMenuItem.click()
+        let confirmDelete = app.buttons["containerDeleteConfirmButton"]
+        XCTAssertTrue(confirmDelete.waitForExistence(timeout: 5))
+        confirmDelete.click()
+        XCTAssertTrue(deleteRow.waitForNonExistence(timeout: 5))
+        clearComputeFilter(in: app)
+
+        selectSidebar("sidebarImages", in: app)
+        XCTAssertTrue(app.staticTexts["containerDetailTitle"].waitForNonExistence(timeout: 5))
+        let image = app.staticTexts["imageRow-local/fixture-image-000:v1"]
+        XCTAssertTrue(image.waitForExistence(timeout: 5))
+        image.click()
+        XCTAssertTrue(app.staticTexts["imageDetailTitle"].waitForExistence(timeout: 5))
+
+        selectSidebar("sidebarVolumes", in: app)
+        XCTAssertTrue(app.staticTexts["imageDetailTitle"].waitForNonExistence(timeout: 5))
+        let volume = app.staticTexts["volumeRow-volume-000"]
+        XCTAssertTrue(volume.waitForExistence(timeout: 5))
+        volume.click()
+        XCTAssertTrue(app.staticTexts["volumeDetailTitle"].waitForExistence(timeout: 5))
+
+        selectSidebar("sidebarNetworks", in: app)
+        XCTAssertTrue(app.staticTexts["volumeDetailTitle"].waitForNonExistence(timeout: 5))
+        let network = app.staticTexts["networkRow-network-000"]
+        XCTAssertTrue(network.waitForExistence(timeout: 5))
+        network.click()
+        XCTAssertTrue(app.staticTexts["networkDetailTitle"].waitForExistence(timeout: 5))
+
+        selectSidebar("sidebarCompute", in: app)
+        XCTAssertTrue(app.staticTexts["networkDetailTitle"].waitForNonExistence(timeout: 5))
+        XCTAssertTrue(firstContainer.waitForExistence(timeout: 5))
+    }
+
+    @MainActor
+    func testLargeInventorySectionAndDetailPerformance() throws {
+        let app = launchLargeInventory()
+        let container = app.staticTexts["computeRow-container-000"]
+        XCTAssertTrue(container.waitForExistence(timeout: 10))
+
+        let options = XCTMeasureOptions()
+        options.iterationCount = 3
+
+        measure(metrics: [XCTMemoryMetric(), XCTCPUMetric()], options: options) {
+            container.click()
+            XCTAssertTrue(app.staticTexts["containerDetailTitle"].waitForExistence(timeout: 5))
+
+            selectSidebar("sidebarImages", in: app)
+            let image = app.staticTexts["imageRow-local/fixture-image-000:v1"]
+            XCTAssertTrue(image.waitForExistence(timeout: 5))
+            image.click()
+            XCTAssertTrue(app.staticTexts["imageDetailTitle"].waitForExistence(timeout: 5))
+
+            selectSidebar("sidebarVolumes", in: app)
+            let volume = app.staticTexts["volumeRow-volume-000"]
+            XCTAssertTrue(volume.waitForExistence(timeout: 5))
+            volume.click()
+            XCTAssertTrue(app.staticTexts["volumeDetailTitle"].waitForExistence(timeout: 5))
+
+            selectSidebar("sidebarNetworks", in: app)
+            let network = app.staticTexts["networkRow-network-000"]
+            XCTAssertTrue(network.waitForExistence(timeout: 5))
+            network.click()
+            XCTAssertTrue(app.staticTexts["networkDetailTitle"].waitForExistence(timeout: 5))
+
+            selectSidebar("sidebarCompute", in: app)
+            XCTAssertTrue(app.staticTexts["networkDetailTitle"].waitForNonExistence(timeout: 5))
+            XCTAssertTrue(container.waitForExistence(timeout: 5))
+        }
+    }
+
+    @MainActor
+    private func launchLargeInventory() -> XCUIApplication {
+        let app = XCUIApplication.berthly()
+        app.launchEnvironment["UITEST_USE_MOCK_SERVICE"] = "1"
+        app.launchEnvironment["UITEST_MOCK_DATASET"] = "large"
+        app.launch()
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+        return app
+    }
+
+    @MainActor
+    private func selectSidebar(_ identifier: String, in app: XCUIApplication) {
+        let destination = app.descendants(matching: .any)[identifier]
+        XCTAssertTrue(destination.waitForExistence(timeout: 5))
+        destination.click()
+    }
+
+    @MainActor
+    private func setComputeFilter(_ text: String, in app: XCUIApplication) {
+        app.typeKey("f", modifierFlags: .command)
+        let search = app.searchFields.firstMatch
+        XCTAssertTrue(search.waitForExistence(timeout: 5))
+        search.click()
+        app.typeKey("a", modifierFlags: .command)
+        search.typeText(text)
+    }
+
+    @MainActor
+    private func clearComputeFilter(in app: XCUIApplication) {
+        let search = app.searchFields.firstMatch
+        XCTAssertTrue(search.waitForExistence(timeout: 5))
+        search.click()
+        app.typeKey("a", modifierFlags: .command)
+        app.typeKey(.delete, modifierFlags: [])
+        XCTAssertTrue(app.staticTexts["computeRunningSummary"].waitForExistence(timeout: 5))
+    }
+
+    @MainActor
+    private func assertTitle(_ title: XCUIElement, equals expected: String) {
+        XCTAssertTrue(title.waitForExistence(timeout: 5))
+        let displayedText = title.label.isEmpty ? title.value as? String : title.label
+        XCTAssertEqual(displayedText, expected)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `UITEST_MOCK_DATASET=large` and `LargeMockFixture` (100 containers, 20 machines, 50 images, 40 volumes, 20 networks, deterministically generated) so `MockContainerService` can seed a large, internally-consistent inventory without touching the default fixture or real daemon
- Add `BerthlyUITests/LargeInventoryTests`: a correctness journey (navigation, selection, virtualized-list scrolling, search, lifecycle, sidebar switching) and a CPU/memory performance test over the large dataset
- Add `BerthlyTests/LargeMockFixtureTests` proving the fixture's determinism, uniqueness, and cross-resource reference consistency (volume mounts, network endpoints, image usage)
- Add accessibility identifiers needed to query rows/details/sidebar entries by id rather than label or index
- Add a leak-lifecycle test for `MockContainerService(dataset: .large)` (the existing one only covered the default init)
- Update the `performance-profiling` skill: fold the new tests into its existing-measurements checklist, document `UITEST_MOCK_DATASET=large` as an idle-sampling launch variant, and capture two lessons from actually running the idle+leaks+Time-Profiler pass against it

## Test plan
- [x] `swiftlint lint --strict` — 0 violations
- [x] `BerthlyTests/LargeMockFixtureTests` — all pass
- [x] Full `BerthlyTests` — 197/197 pass
- [x] Full mock-mode `BerthlyUITests` — 70/70 pass, 2 expected E2E skips
- [x] `LargeInventoryTests` correctness test — 10/10 clean runs (after retargeting the tail-scroll assertion off the list's literal last row, which raced a click on the clamped scroll boundary)
- [x] `LargeInventoryTests` performance test — 3 iterations, CPU/memory metrics recorded (RSD checked; 4/5 submetrics stable enough to baseline, `Memory Physical` delta is noise and intentionally left unbaselined)
- [x] Idle profiling pass (`ps` RSS/CPU, `leaks`, Time Profiler) against `.large` mock mode — 0 leaks, RSS settles flat after one warm-up step, ~0% idle CPU