### PR TITLE
docs: move roadmap messaging below Features, drop 2.0 label

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Berthly lives in your menu bar and opens a full SwiftUI window, giving Apple's c
 
 ![Berthly demo — open the menu-bar monitor, inspect live container metrics, and drag a Dockerfile from Finder to start a pre-filled image build](https://github.com/henrywang/Berthly/releases/download/media-assets/berthly-demo.gif)
 
-> **Berthly 2.0 is in progress** — multi-service Projects, volume backups, actionable diagnostics, and more, built around what makes Apple's container runtime distinct rather than cloning Docker Desktop or OrbStack feature-for-feature. Track it on the [public roadmap](https://github.com/users/henrywang/projects/3).
-
 ## Features
 
 - **Images** — list, pull from a registry, build from a Dockerfile, and inspect layers and metadata.
@@ -35,6 +33,8 @@ Berthly lives in your menu bar and opens a full SwiftUI window, giving Apple's c
 - **Keyboard-first** — ⌘K palette, ⌘1–6 section switching, ⌘⌥1–3 detail tabs, and full menu shortcuts for every action.
 
 ![The command palette (⌘K) matching lifecycle actions for a container](design/screenshots/command-palette.png)
+
+> **Berthly 1.1 is stable and shipping today.** Next up: multi-service Projects, volume backups, actionable diagnostics, and more — built around what makes Apple's container runtime distinct rather than cloning Docker Desktop or OrbStack feature-for-feature. Track it on the [public roadmap](https://github.com/users/henrywang/projects/3).
 
 ## Beyond the CLI
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,6 +22,9 @@ Releases. `scripts/release.sh` runs the whole pipeline.
    to the current latest release. Forgetting this step 404s the badge instead
    of silently serving a stale build, which is deliberate: broken is loud,
    wrong-version is not.
+   - Also update the roadmap blockquote below Features —
+     `Berthly <x.y> is stable and shipping today` — and drop any "Next up"
+     item that shipped in this release.
 3. **Commit** (the script warns on a dirty tree — the archive would include
    uncommitted changes).
 4. **Run** `scripts/release.sh`. It does, in order:


### PR DESCRIPTION
The blockquote sat between the demo GIF and the Features section,
telling a visitor the next version is pending before they've read
what ships now. Move it below Features and the command-palette
screenshot, and reframe it as shipped-plus-more (Berthly 1.1 is
stable today) instead of naming an unreleased 2.0.

Extend RELEASING.md step 2 so the new version-coupled prose line
gets updated alongside the download badge at each release.
