### PR TITLE
fix: re-measure compute row heights after a section move

### DIFF
--- a/Berthly/Design/ListRowHeightRefresher.swift
+++ b/Berthly/Design/ListRowHeightRefresher.swift
@@ -1,0 +1,78 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import AppKit
+import SwiftUI
+
+/// Re-measures a SwiftUI `List`'s row heights after rows move between sections.
+///
+/// Moving a row across sections is a delete+insert (see `ComputeListView`'s entry wrappers). If
+/// anything forces an AppKit layout pass while that insert animation is in flight — the detail
+/// pane re-rendering on the same status change is enough — the backing `NSTableView` latches the
+/// row's *interim* animation height and keeps it: 24pt instead of 43pt, image subtitle clipped
+/// outside the row bounds, surviving every later poll until the list is rebuilt. Both `Text`s are
+/// still in the row (and a genuinely one-line row measures 28pt, not 24) — only the table's
+/// cached height is wrong, which is why no SwiftUI-side layout fix reaches it: `fixedSize` and
+/// disabling the transaction's animations both leave it latched.
+///
+/// `noteHeightOfRows` makes the table re-query every row height. Registering it through
+/// `CATransaction.setCompletionBlock` from `updateNSView` joins the transaction committing the
+/// row move, so it runs strictly after that animation finishes — same rationale as
+/// `TerminalHostView.scheduleFocusGrab`, where a fixed wall-clock delay proved unreliable
+/// whenever a slowed commit pushed the animation past the timer.
+///
+/// Attach via `.refreshesRowHeights(on:)` with a value that changes whenever rows change section.
+struct ListRowHeightRefresher<Trigger: Equatable>: NSViewRepresentable {
+    let trigger: Trigger
+
+    func makeNSView(context: Context) -> NSView {
+        context.coordinator.lastTrigger = trigger
+        return NSView()
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        // Only on an actual section change: re-measuring on every update pass would fire during
+        // unrelated redraws (hover, selection, stats ticks) for no benefit.
+        guard context.coordinator.lastTrigger != trigger else { return }
+        context.coordinator.lastTrigger = trigger
+        CATransaction.setCompletionBlock {
+            guard let table = Self.table(around: nsView), table.numberOfRows > 0 else { return }
+            table.noteHeightOfRows(withIndexesChanged: IndexSet(integersIn: 0 ..< table.numberOfRows))
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    final class Coordinator {
+        var lastTrigger: Trigger?
+    }
+
+    /// As a `.background`, this sits in a sibling subtree of the list's scroll view — walk a few
+    /// ancestors up and search their descendants (same approach as `NonFloatingListHeaders`).
+    private static func table(around view: NSView) -> NSTableView? {
+        var ancestor: NSView? = view
+        for _ in 0 ..< 6 {
+            guard let current = ancestor else { return nil }
+            if let table = firstTableView(in: current) { return table }
+            ancestor = current.superview
+        }
+        return nil
+    }
+
+    private static func firstTableView(in root: NSView) -> NSTableView? {
+        var queue: [NSView] = [root]
+        while !queue.isEmpty {
+            let view = queue.removeFirst()
+            if let table = view as? NSTableView { return table }
+            queue.append(contentsOf: view.subviews)
+        }
+        return nil
+    }
+}
+
+extension View {
+    /// See `ListRowHeightRefresher`.
+    func refreshesRowHeights(on trigger: some Equatable) -> some View {
+        background(ListRowHeightRefresher(trigger: trigger))
+    }
+}

--- a/Berthly/Views/ComputeListView.swift
+++ b/Berthly/Views/ComputeListView.swift
@@ -106,6 +106,14 @@ struct ComputeListView: View {
                 // Kill the hairline AppKit draws under the pinned first section header — see
                 // NonFloatingListHeaders.
                 .nonFloatingSectionHeaders()
+                // Starting/stopping moves a row across sections; without this the table can keep
+                // the row's mid-animation height (24pt, subtitle clipped) — see
+                // ListRowHeightRefresher. Keyed on the row identities so a simultaneous
+                // start+stop, which leaves both counts unchanged, still triggers a re-measure.
+                .refreshesRowHeights(on: runningContainerEntries.map(\.id)
+                    + runningMachineEntries.map(\.id)
+                    + stoppedContainerEntries.map(\.id)
+                    + stoppedMachineEntries.map(\.id))
                 .accessibilityElement(children: .contain)
                 .accessibilityIdentifier("computeList")
                 // ⌫ on a selected, stopped row — same confirm-then-delete flow as the row's


### PR DESCRIPTION
Fixes #74

## The bug

Starting a container from the detail pane left its list row at **half height** — name only, image subtitle clipped — and it stayed that way through every later poll.

Reproduces on a **fresh launch**: select a stopped container, click Start. Measured 6/8 on the unfixed build.

## Root cause

Moving a row between RUNNING and STOPPED is a delete+insert. The detail pane re-renders on that same status change, which forces an AppKit layout pass while the insert animation is still in flight — and `NSTableView` then keeps the row's **interim** animation height forever (24pt instead of 43pt).

Two measurements pin this down:

- A subtitle-less row measures **28pt**, so 24pt is not a one-line layout — it's a frozen animation frame.
- Both `Text` elements remain in the accessibility tree while latched, so only the row's frame height distinguishes the states.

Having a row **selected** was load-bearing in every run: no selection means no detail pane, and it never latched.

## The fix

`ListRowHeightRefresher` calls `noteHeightOfRows(withIndexesChanged:)` to make the table re-query row heights, registered via `CATransaction.setCompletionBlock` from `updateNSView` so it runs strictly after the row-move animation — the same rationale as `TerminalHostView.scheduleFocusGrab`, where a fixed wall-clock delay proved unreliable under a slowed commit. Keyed on row identities rather than counts, so a simultaneous start+stop still triggers a re-measure.

Scoped to Compute deliberately: Volumes (NAMED/ANONYMOUS) and Images (BUILT/PULLED) have sections, but rows never migrate between them.

## Relationship to the 2026-07-18 fix

2bb6c82 fixed one *trigger* — the terminal's `makeFirstResponder` — by deferring it, and that fix still works (verified). But the underlying vulnerability was never addressed, so any other mid-animation layout pass re-opened it. Unlike the focus grab, the detail pane updating on a status change can't be deferred; it's the app doing its job. This change repairs the consequence instead, so it's trigger-agnostic and covers the July case too.

## Verification

- **12/12 clean** across Overview / Logs / Terminal tabs against a scripted fresh-launch real-daemon repro, vs. **6/8 reproducing** on the unfixed build.
- Visually confirmed the full two-line row renders after the transition.
- `swiftlint --strict` clean; `BerthlyTests` pass.

**Rejected alternatives** (both still latched): `.fixedSize(horizontal: false, vertical: true)` on the row (6/6 bugged) and `.transaction { $0.disablesAnimations = true }` on the List (2/6). The latch lives in the table's height cache, below anything SwiftUI layout can reach.

## No regression test — deliberately

Neither test layer can see this bug, and I verified that rather than assuming it:

- **Mock UI tests** set `UITEST_USE_MOCK_SERVICE`, which enables `BerthlyApp.disableAnimations` — no animation, no interim height to latch.
- **E2E**: I wrote the test. It passed **3/3 on the broken build**, and still 3/3 after removing every accessibility query from the transition window. Meanwhile a non-XCUITest harness reproduced the bug on the *same binary* — XCUITest's automation mode suppresses the latch.

A test that cannot fail when the regression is present is worse than none, so it was removed. The guard is the doc comment on `ListRowHeightRefresher`, which records the mechanism, the measurements, and the approaches that don't work.
