### PR TITLE
chore: bump container to 1.2.0, containerization to 0.40.1

### DIFF
--- a/Berthly.xcodeproj/project.pbxproj
+++ b/Berthly.xcodeproj/project.pbxproj
@@ -775,7 +775,7 @@
 			repositoryURL = "https://github.com/apple/container";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.1.0;
+				minimumVersion = 1.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Berthly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Berthly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/container",
       "state" : {
-        "revision" : "5973b9cc626a3e7a499bb316a958237ebe14e2ed",
-        "version" : "1.1.0"
+        "revision" : "6e65319fe476ffe8db8ddaf828a537ed36fe2859",
+        "version" : "1.2.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "44bec8b9933bc491d0cbf44abac90a1f6aaebf6b",
-        "version" : "0.35.0"
+        "revision" : "7800b4642171561c95b5f55500b19e5dce5acd45",
+        "version" : "0.40.1"
       }
     },
     {

--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -2257,7 +2257,7 @@ final class LiveContainerService: ContainerServiceBase {
                 let socket = try await ContainerClient().dial(id: ContainerBuild.Builder.builderContainerId, port: 8088)
                 let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
                 do {
-                    let builder = try ContainerBuild.Builder(socket: socket, group: group, logger: Self.log)
+                    let builder = try await ContainerBuild.Builder(socket: socket, group: group, logger: Self.log)
                     _ = try await builder.info()
                     if announcedStart { onLog("Build environment ready.") }
                     return (builder, group)
@@ -2334,7 +2334,9 @@ final class LiveContainerService: ContainerServiceBase {
         let useRosetta = containerSystemConfig.build.rosetta
         let shimArguments = ["--debug", "--vsock", useRosetta ? nil : "--enable-qemu"].compactMap { $0 }
 
-        try Utility.validEntityName(builderContainerId)
+        guard ManagedContainer.nameValid(builderContainerId) else {
+            throw ContainerizationError(.invalidArgument, message: "container ID \(builderContainerId) is not a valid container ID")
+        }
 
         // The slow part on first build. `fetch` streams size events only when it actually pulls —
         // a cached image resolves via `get` with no events — so the reporter emits its throttled
@@ -2632,6 +2634,7 @@ final class LiveContainerService: ContainerServiceBase {
             entrypoint: nilIfEmpty(options.entrypoint),
             initImage: nil,
             kernel: nil,
+            kernelArgs: [],
             labels: options.labels.sorted(by: { $0.key < $1.key }).map { "\($0.key)=\($0.value)" },
             mounts: options.mounts,
             name: nilIfEmpty(options.name),
@@ -2675,7 +2678,9 @@ final class LiveContainerService: ContainerServiceBase {
     @discardableResult
     override func runContainer(options: RunOptions) async throws -> String {
         let id = Utility.createContainerID(name: options.name)
-        try Utility.validEntityName(id)
+        guard ManagedContainer.nameValid(id) else {
+            throw ContainerizationError(.invalidArgument, message: "container ID \(id) is not a valid container ID")
+        }
 
         let client = ContainerClient()
         if (try? await client.get(id: id)) != nil {
@@ -2835,7 +2840,9 @@ final class LiveContainerService: ContainerServiceBase {
     /// same as `runContainer` reuses `Utility.containerConfigFromFlags`.
     override func createMachine(options: MachineCreateOptions) async throws {
         let id = try Self.machineID(for: options)
-        try Utility.validEntityName(id)
+        guard ManagedContainer.nameValid(id) else {
+            throw ContainerizationError(.invalidArgument, message: "machine ID \(id) is not a valid machine ID")
+        }
 
         let containerSystemConfig = await resolvedSystemConfig()
         let bootConfig = try containerSystemConfig.machine.with(Self.machineBootConfigOverrides(for: options))


### PR DESCRIPTION
## Summary
- Bumps the `container` SPM pin (1.1.0 → 1.2.0, `upToNextMinorVersion`) and its transitive `containerization` dependency (→ 0.40.1).
- Adapts the three call sites that used the removed `Utility.validEntityName` to `ManagedContainer.nameValid(_:)`, the same replacement upstream made in [apple/container#1956](https://github.com/apple/container/pull/1956) (name validation moved server-side into XPC request handling).
- Awaits `ContainerBuild.Builder.init`, which became `async` in 1.2.0.
- Satisfies the new `Flags.Management.kernelArgs: [String]` parameter with `[]` — no behavior change; surfacing `--kernel-arg` in the Run/Create sheet is tracked separately.

## Why
apple/container 1.2.0 shipped 2026-07-29. Berthly's `Package.resolved` was still pinned to 1.1.0/0.35.0, and `PARITY.md` is explicitly audited against 1.1.0. First step of the `v1.2.0` milestone (#75) — everything else in that milestone (`ContainerCompatibility.requiredVersion` sync, `PARITY.md` refresh, `--kernel-arg` UI, kernel digest verification) is blocked on this landing.

Closes #75

## Test plan
- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test -only-testing:BerthlyTests` — full suite passes
- [x] `swiftlint lint --strict` — 0 violations