### PR TITLE
chore: sync ContainerCompatibility.requiredVersion to 1.2.0

### DIFF
--- a/Berthly/Core/ContainerCompatibility.swift
+++ b/Berthly/Core/ContainerCompatibility.swift
@@ -14,7 +14,7 @@ import Foundation
 /// which nonisolated callers (e.g. test suites) warn on under Swift 6 checking.
 nonisolated enum ContainerCompatibility {
     /// Keep in sync with the `container` SPM package pin (Package.resolved / Package.swift).
-    static let requiredVersion = "1.1.0"
+    static let requiredVersion = "1.2.0"
 
     /// How an incompatible install relates to the required version. `tooOld` is fixable in place
     /// with the upstream update script; `tooNew` (newer major) is not — downgrading requires a

--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -445,7 +445,7 @@ final class LiveContainerService: ContainerServiceBase {
 
     /// The exact leaf-certificate identity `pkgutil --check-signature` prints for apple/container
     /// release pkgs, including Apple's Containerization team ID — verified against the real
-    /// signed 1.1.0 pkg. Deliberately NOT the generic "signed by a developer certificate issued
+    /// signed 1.2.0 pkg. Deliberately NOT the generic "signed by a developer certificate issued
     /// by Apple" status line: every registered Developer ID on earth matches that phrase, which
     /// would let any developer's pkg through this gate. If upstream ever rotates its signing
     /// identity, installs fail closed with the verification error until this is re-pinned

--- a/Berthly/Views/DaemonGateView.swift
+++ b/Berthly/Views/DaemonGateView.swift
@@ -336,7 +336,7 @@ struct DaemonGateView<Content: View>: View {
     }
     .environment({
         let s = MockContainerService()
-        s.daemonState = .versionMismatch(installed: "1.0.2", required: "1.1.0")
+        s.daemonState = .versionMismatch(installed: "1.0.2", required: "1.2.0")
         return s as ContainerServiceBase
     }())
     .frame(width: 600, height: 500)
@@ -348,7 +348,7 @@ struct DaemonGateView<Content: View>: View {
     }
     .environment({
         let s = MockContainerService()
-        s.daemonState = .versionMismatch(installed: "2.0.0", required: "1.1.0")
+        s.daemonState = .versionMismatch(installed: "2.0.0", required: "1.2.0")
         return s as ContainerServiceBase
     }())
     .frame(width: 600, height: 500)
@@ -364,9 +364,9 @@ struct DaemonGateView<Content: View>: View {
 
 #Preview("Operation in progress") {
     DaemonGateView<Text>.ProgressLogScreen(
-        message: "Updating container to v1.1.0…",
+        message: "Updating container to v1.2.0…",
         logLines: [
-            "Updating to release version 1.1.0",
+            "Updating to release version 1.2.0",
             "Downloading package from: https://github.com/apple/container/releases/…",
             "Installing package to /usr/local…"
         ],

--- a/BerthlyTests/BerthlyTests.swift
+++ b/BerthlyTests/BerthlyTests.swift
@@ -703,11 +703,11 @@ struct PrivilegedCommandHelperTests {
     }
 
     // The signature gate pins Apple's actual Containerization release identity (verified against
-    // the real signed 1.1.0 pkg). The generic "issued by Apple" status describes every Developer
+    // the real signed 1.2.0 pkg). The generic "issued by Apple" status describes every Developer
     // ID certificate, so it alone must never be enough — that's the hijacked-download case.
     @Test func signatureCheckAcceptsApplesContainerizationIdentity() {
         let realOutput = """
-        Package "container-1.1.0-installer-signed.pkg":
+        Package "container-1.2.0-installer-signed.pkg":
            Status: signed by a developer certificate issued by Apple for distribution
            Certificate Chain:
             1. Developer ID Installer: Apple Inc. - Containerization (UPBK2H6LZM)
@@ -717,7 +717,7 @@ struct PrivilegedCommandHelperTests {
 
     @Test func signatureCheckRejectsOtherDeveloperIDs() {
         let attackerOutput = """
-        Package "container-1.1.0-installer-signed.pkg":
+        Package "container-1.2.0-installer-signed.pkg":
            Status: signed by a developer certificate issued by Apple for distribution
            Certificate Chain:
             1. Developer ID Installer: Evil Corp LLC (ABC123XYZ0)
@@ -754,9 +754,9 @@ struct PrivilegedCommandHelperTests {
     /// staged copy, and install that same copy — closing the swap window between the user-space
     /// signature check and the root install.
     @Test func stagedInstallCommandVerifiesAndInstallsTheStagedCopy() {
-        let command = LiveContainerService.stagedInstallCommand(pkgPath: "/tmp/container-1.1.0-installer-signed.pkg")
+        let command = LiveContainerService.stagedInstallCommand(pkgPath: "/tmp/container-1.2.0-installer-signed.pkg")
         #expect(command.contains("/usr/bin/mktemp -d"))
-        #expect(command.contains("/bin/cp '/tmp/container-1.1.0-installer-signed.pkg' \"$staging/container.pkg\""))
+        #expect(command.contains("/bin/cp '/tmp/container-1.2.0-installer-signed.pkg' \"$staging/container.pkg\""))
         #expect(command.contains("pkgutil --check-signature \"$staging/container.pkg\""))
         #expect(command.contains("grep -e 'Developer ID Installer: Apple Inc. - Containerization (UPBK2H6LZM)'"))
         #expect(command.contains("installer -pkg \"$staging/container.pkg\" -target /"))


### PR DESCRIPTION
## Summary
- Bumps `ContainerCompatibility.requiredVersion` from `1.1.0` to `1.2.0`, matching the SPM pin landed in #82.
- Syncs every string coupled to it: `DaemonGateView` preview/progress copy, and the pkg-signature test fixtures in `BerthlyTests.swift`. `MockContainerService` and `SystemView` already read the constant, so they follow automatically.
- Updates the doc comment on `LiveContainerService.appleSignatureMarkers` claiming this was "verified against the real signed 1.2.0 pkg" — downloaded the actual `container-1.2.0-installer-signed.pkg` release asset and confirmed via `pkgutil --check-signature` that the signing identity is unchanged (`Developer ID Installer: Apple Inc. - Containerization (UPBK2H6LZM)`) before making that claim true.

`ContainerCompatibilityTests` in `BerthlyTests.swift` still use `1.1.0` in several cases — left as-is, since those test the general compatibility algorithm with self-contained version pairs, not the app's actual pinned constant.

## Why
Once #75 bumped the SPM pin, the app was built against the 1.2.0 client library while its own version gate still accepted a 1.1.0 daemon — an inconsistency the gate exists to prevent. This closes it: a 1.1.0 daemon now correctly surfaces the version-mismatch gate.

Closes #76

## Test plan
- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test -only-testing:BerthlyTests` — full suite passes
- [x] `swiftlint lint --strict` — 0 violations
- [x] Manually verified the 1.2.0 pkg's signing identity against the pinned markers