### PR TITLE
feat: add --kernel-arg support to Run/Create sheet

### DIFF
--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -2634,7 +2634,7 @@ final class LiveContainerService: ContainerServiceBase {
             entrypoint: nilIfEmpty(options.entrypoint),
             initImage: nil,
             kernel: nil,
-            kernelArgs: [],
+            kernelArgs: options.kernelArgs,
             labels: options.labels.sorted(by: { $0.key < $1.key }).map { "\($0.key)=\($0.value)" },
             mounts: options.mounts,
             name: nilIfEmpty(options.name),

--- a/Berthly/Core/Models.swift
+++ b/Berthly/Core/Models.swift
@@ -796,6 +796,7 @@ nonisolated struct RunOptions {
     var dnsOptions: [String] = []
     var dnsSearch: [String] = []
     var noDns: Bool = false
+    var kernelArgs: [String] = []
 }
 
 /// Captures stderr text alongside the exit code — unlike a build, run/create

--- a/Berthly/Localizable.xcstrings
+++ b/Berthly/Localizable.xcstrings
@@ -801,6 +801,9 @@
     "Kernel Binary" : {
 
     },
+    "Kernel boot arguments" : {
+
+    },
     "Labels" : {
 
     },

--- a/Berthly/Views/RunContainerSheet.swift
+++ b/Berthly/Views/RunContainerSheet.swift
@@ -112,6 +112,7 @@ struct RunContainerSheet: View {
     @State private var dnsOptions: [StringEntry] = []
     @State private var dnsSearch: [StringEntry] = []
     @State private var noDns = false
+    @State private var kernelArgs: [StringEntry] = []
 
     @State private var state = RunState()
 
@@ -333,7 +334,7 @@ struct RunContainerSheet: View {
             return filled(workdir) + filled(user) + filled(entrypoint) + filled(cidFile)
                 + [readOnly, initProcess, rosetta, ssh, interactive, tty, virtualization, insecureRegistry]
                     .count { $0 }
-                + filled(capAdd) + filled(capDrop)
+                + filled(capAdd) + filled(capDrop) + filled(kernelArgs)
         }
     }
 
@@ -527,6 +528,12 @@ struct RunContainerSheet: View {
 
         StringListEditor(title: "Add capabilities", placeholder: "CAP_NET_RAW, or ALL", identifierPrefix: "runCapAdd", entries: $capAdd)
         StringListEditor(title: "Drop capabilities", placeholder: "CAP_SYS_ADMIN, or ALL", identifierPrefix: "runCapDrop", entries: $capDrop)
+        StringListEditor(
+            title: "Kernel boot arguments",
+            placeholder: "lsm=lockdown,capability,landlock,yama,apparmor,bpf",
+            identifierPrefix: "runKernelArg",
+            entries: $kernelArgs
+        )
 
         VStack(alignment: .leading, spacing: 6) {
             Text("Container ID file")
@@ -697,7 +704,8 @@ struct RunContainerSheet: View {
             dnsDomain: dnsDomainTrimmed.isEmpty ? nil : dnsDomainTrimmed,
             dnsOptions: strings(from: dnsOptions),
             dnsSearch: strings(from: dnsSearch),
-            noDns: noDns
+            noDns: noDns,
+            kernelArgs: strings(from: kernelArgs)
         )
 
         // `runContainer` refreshes the container list before returning, so the new container is

--- a/BerthlyTests/BerthlyTests.swift
+++ b/BerthlyTests/BerthlyTests.swift
@@ -346,13 +346,15 @@ struct RunFlagsMappingTests {
             virtualization: true,
             capAdd: ["CAP_NET_RAW", "ALL"],
             capDrop: ["CAP_SYS_ADMIN"],
-            cidFile: "/tmp/cid.txt"
+            cidFile: "/tmp/cid.txt",
+            kernelArgs: ["lsm=lockdown,capability,landlock,yama,apparmor,bpf"]
         )
         let flags = LiveContainerService.runManagementFlags(for: options)
         #expect(flags.virtualization == true)
         #expect(flags.capAdd == ["CAP_NET_RAW", "ALL"])
         #expect(flags.capDrop == ["CAP_SYS_ADMIN"])
         #expect(flags.cidfile == "/tmp/cid.txt")
+        #expect(flags.kernelArgs == ["lsm=lockdown,capability,landlock,yama,apparmor,bpf"])
     }
 
     @Test func dnsFamilyMapsWhenNoDnsIsFalse() {

--- a/PARITY.md
+++ b/PARITY.md
@@ -25,9 +25,10 @@ CLI, subcommand by subcommand — and the few places it deliberately doesn't.
 
 The Run/Create sheet exposes the full flag surface: env + env-file, ports,
 volumes, mounts, tmpfs, networks, labels, entrypoint, workdir, user/uid/gid,
-cpus/memory, capabilities add/drop, ulimits, DNS (nameserver, domain, search,
-options, no-dns), platform/os/arch, read-only rootfs, init process, cidfile,
-interactive/tty, ssh, shm-size, Rosetta, virtualization.
+cpus/memory, capabilities add/drop, kernel boot arguments (`--kernel-arg`),
+ulimits, DNS (nameserver, domain, search, options, no-dns), platform/os/arch,
+read-only rootfs, init process, cidfile, interactive/tty, ssh, shm-size,
+Rosetta, virtualization.
 
 ## Images
 


### PR DESCRIPTION
## Summary
- container 1.2.0 added a repeatable `--kernel-arg` flag (apple/container#1744) for appending raw boot arguments to the kernel command line — e.g. adding `bpf` to the runtime's hardcoded LSM list to enable BPF LSM, previously impossible. `Flags.Management` gained a required `kernelArgs` parameter in the same release, confirming the API is reachable from Berthly's native XPC calls, not just the CLI.
- `RunOptions` gained `kernelArgs: [String]`, threaded through `LiveContainerService.runManagementFlags(for:)` into `Flags.Management.kernelArgs`.
- New "Kernel boot arguments" `StringListEditor` on the Run/Create sheet's Security tab, alongside the existing capAdd/capDrop editors it mirrors.
- `PARITY.md`'s flag-surface list updated in the same commit.
- `Localizable.xcstrings` synced for the new field's string.

## Why
Part of the container 1.2.0 milestone (#78) — the SPM bump (#75) surfaced this as a newly-required parameter, confirming the feature is implementable at the API level Berthly actually calls.

Closes #78

## Test plan
- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test -only-testing:BerthlyTests` — full suite passes, including new coverage for `kernelArgs` in `managementFlagsMapInteractiveVirtualizationCapsAndCidFile`
- [x] `swiftlint lint --strict` — 0 violations
- [x] Verified visually via Xcode's live preview renderer — confirmed the new field renders on the Security tab using the working `capAdd` pattern