### PR TITLE
feat: add kernel archive digest verification

### DIFF
--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -850,6 +850,7 @@ final class LiveContainerService: ContainerServiceBase {
                 kernelFilePath: containerSystemConfig.kernel.binaryPath,
                 platform: .current,
                 progressUpdate: reporter?.handler,
+                expectedDigest: containerSystemConfig.kernel.digest,
                 force: true
             )
             onLog?("Default kernel installed")
@@ -1798,6 +1799,7 @@ final class LiveContainerService: ContainerServiceBase {
                 kernelFilePath: options.binaryPath,
                 platform: platform,
                 progressUpdate: progress,
+                expectedDigest: options.digest,
                 force: options.force
             )
         } else {
@@ -1816,6 +1818,7 @@ final class LiveContainerService: ContainerServiceBase {
             vminitImage: config.vminit.image,
             kernelBinaryPath: config.kernel.binaryPath,
             kernelURL: config.kernel.url.absoluteString,
+            kernelDigest: config.kernel.digest,
             builderImage: config.build.image
         )
     }

--- a/Berthly/Core/MockContainerService.swift
+++ b/Berthly/Core/MockContainerService.swift
@@ -502,7 +502,7 @@ final class MockContainerService: ContainerServiceBase {
             vminitImage: "ghcr.io/apple/containerization/vminit:latest",
             kernelBinaryPath: "/opt/kata/share/kata-containers/vmlinux-6.18.15-186",
             kernelURL: "https://github.com/kata-containers/kata-containers/releases/download/3.28.0/kata-static-3.28.0-arm64.tar.zst",
-            builderImage: "ghcr.io/apple/container-builder-shim/builder:latest"
+            kernelDigest: "sha256:f63d54abcd", builderImage: "ghcr.io/apple/container-builder-shim/builder:latest"
         )
     }
 

--- a/Berthly/Core/Models.swift
+++ b/Berthly/Core/Models.swift
@@ -644,12 +644,17 @@ nonisolated struct KernelSetOptions {
     var tarSource: String?
     var architecture: String  // "arm64" or "amd64"
     var force: Bool = false
+    /// `sha256:<hex>`-style digest verified against the downloaded/local tar archive before
+    /// install. Required upstream for remote tar URLs; optional (but still checked if given)
+    /// for local ones.
+    var digest: String?
 }
 
 struct SystemConfigInfo: Hashable {
     let vminitImage: String
     let kernelBinaryPath: String
     let kernelURL: String
+    let kernelDigest: String
     let builderImage: String
 }
 

--- a/Berthly/Views/SetKernelSheet.swift
+++ b/Berthly/Views/SetKernelSheet.swift
@@ -71,6 +71,7 @@ struct SetKernelSheet: View {
     @State private var binaryPath = ""
     @State private var tarSource = ""
     @State private var tarBinaryPath = ""
+    @State private var tarDigest = ""
     @State private var architecture: String = {
         #if arch(arm64)
         return "arm64"
@@ -175,6 +176,12 @@ struct SetKernelSheet: View {
         Section {
             pathField("Archive", prompt: "/path/to/kernel.tar.zst or https://…", text: $tarSource, chooser: pickTarFile)
             pathField("Path inside archive", prompt: "opt/kata/share/kata-containers/vmlinux", text: $tarBinaryPath, chooser: nil)
+            pathField(
+                "Digest",
+                prompt: digestIsRequired ? "sha256:… (required for a remote URL)" : "sha256:… (optional for a local file)",
+                text: $tarDigest,
+                chooser: nil
+            )
         } header: {
             HStack {
                 Text("Tar Archive")
@@ -186,7 +193,10 @@ struct SetKernelSheet: View {
                 }
             }
         } footer: {
-            Text("Pre-filled from config.toml's recommended kernel — edit to install a different one.")
+            Text("""
+                Pre-filled from config.toml's recommended kernel — edit to install a different one. \
+                The digest is verified against the archive before install; a remote URL requires one.
+                """)
         }
     }
 
@@ -260,13 +270,23 @@ struct SetKernelSheet: View {
         case .tar:
             return !tarSource.trimmingCharacters(in: .whitespaces).isEmpty
                 && !tarBinaryPath.trimmingCharacters(in: .whitespaces).isEmpty
+                && (!digestIsRequired || !tarDigest.trimmingCharacters(in: .whitespaces).isEmpty)
         }
+    }
+
+    /// Mirrors upstream's `container system kernel set --tar` rule: a remote URL must be
+    /// verified against a digest (there's no other integrity check on the download), while a
+    /// local archive already on disk can skip it.
+    private var digestIsRequired: Bool {
+        let trimmed = tarSource.trimmingCharacters(in: .whitespaces)
+        return trimmed.hasPrefix("http://") || trimmed.hasPrefix("https://")
     }
 
     private func prefillFromRecommended() {
         guard let config = service.systemConfigInfo else { return }
         tarSource = config.kernelURL
         tarBinaryPath = config.kernelBinaryPath
+        tarDigest = config.kernelDigest
     }
 
     private func prefillFromRecommendedIfEmpty() {
@@ -308,9 +328,11 @@ struct SetKernelSheet: View {
                         binaryPath: binaryPath, tarSource: nil, architecture: architecture, force: force
                     ))
                 case .tar:
+                    let trimmedDigest = tarDigest.trimmingCharacters(in: .whitespaces)
                     try await service.setKernel(
                         options: KernelSetOptions(
-                            binaryPath: tarBinaryPath, tarSource: tarSource, architecture: architecture, force: force
+                            binaryPath: tarBinaryPath, tarSource: tarSource, architecture: architecture, force: force,
+                            digest: trimmedDigest.isEmpty ? nil : trimmedDigest
                         ),
                         progress: state.handler
                     )

--- a/Berthly/Views/SystemView.swift
+++ b/Berthly/Views/SystemView.swift
@@ -925,7 +925,7 @@ private struct DaemonLogView: View {
         vminitImage: "ghcr.io/apple/containerization/vminit:latest",
         kernelBinaryPath: "/opt/kata/share/kata-containers/vmlinux-6.18.15-186",
         kernelURL: "https://github.com/kata-containers/kata-containers/releases/download/3.28.0/kata-static-3.28.0-arm64.tar.zst",
-        builderImage: "ghcr.io/apple/container-builder-shim/builder:latest"
+        kernelDigest: "sha256:f63d54abcd", builderImage: "ghcr.io/apple/container-builder-shim/builder:latest"
     )
     return SystemView()
         .environment(mock as ContainerServiceBase)

--- a/BerthlyTests/SystemPageMappingTests.swift
+++ b/BerthlyTests/SystemPageMappingTests.swift
@@ -121,6 +121,7 @@ struct SystemConfigMappingTests {
         #expect(info.vminitImage == config.vminit.image)
         #expect(info.kernelBinaryPath == config.kernel.binaryPath)
         #expect(info.kernelURL == config.kernel.url.absoluteString)
+        #expect(info.kernelDigest == config.kernel.digest)
         #expect(info.builderImage == config.build.image)
     }
 }

--- a/PARITY.md
+++ b/PARITY.md
@@ -87,7 +87,7 @@ Builds also start the builder on demand, like the CLI.
 | `start` / `stop` / `status` | Daemon controls + connection state throughout the app |
 | `df` | Disk usage cards with reclaimable-space breakdown |
 | `dns` | Local DNS domains list / create / delete |
-| `kernel` | Kernel info + Set Kernel sheet (binary, tar/URL, arch, force) |
+| `kernel` | Kernel info + Set Kernel sheet (binary, tar/URL, arch, force, digest) |
 | `logs` | Daemon Logs viewer |
 | `property` | System properties list |
 | `version` | Versions shown on the System page |


### PR DESCRIPTION
## Summary
- container 1.2.0 added digest verification for kernel archives (apple/container#1703): `kernel set --tar` accepts `--digest`, remote tar URLs require one, and the recommended default kernel now ships pinned sha256 digest metadata. containerization's `KernelConfig` gained a required `digest` field, and `ClientKernel.installKernelFromTar` an `expectedDigest` parameter — both reachable from Berthly's native XPC calls.
- `KernelSetOptions` gained `digest: String?`, threaded into `setKernel(options:)`'s `installKernelFromTar` call.
- `installDefaultKernelIfNeeded` now passes `expectedDigest: containerSystemConfig.kernel.digest` — the default kernel already carries a pinned digest from upstream.
- New "Digest" field on the Set Kernel sheet's Tar Archive section, required only for remote URLs (matching upstream's exact rule), prefilled by "Use Recommended" alongside the URL.
- `PARITY.md`'s System `kernel` row updated in the same commit.

## Why
Part of the container 1.2.0 milestone (#79). Mirrors the security posture Berthly already applies elsewhere (pkg signature verification against a pinned Apple identity) — kernel archives were the one download path left unverified.

Closes #79

## Test plan
- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test -only-testing:BerthlyTests` — full suite passes, including new `kernelDigest` coverage in `SystemConfigMappingTests`
- [x] `swiftlint lint --strict` — 0 violations
- [x] Verified visually via Xcode's live preview renderer — confirmed the Tar Archive section (including the recommended-URL prefill) renders correctly