### PR TITLE
fix: stop silently discarding a user's config on decode failure

### DIFF
--- a/Berthly/Core/ContainerServiceBase.swift
+++ b/Berthly/Core/ContainerServiceBase.swift
@@ -33,10 +33,11 @@ class ContainerServiceBase {
     var isCheckingImageUpdates = false
 
     /// Set when `startDaemon()` connects fine but a background bootstrap step (installing the
-    /// vminit filesystem image or default kernel) failed — the daemon reports `.connected`
-    /// regardless (it's the correct state for most purposes), so without this the failure is
-    /// otherwise invisible until an unrelated later operation fails for a confusing reason.
-    /// `nil` means no warning; cleared at the start of every `startDaemon()` call.
+    /// vminit filesystem image or default kernel, or loading the user's `config.toml`) failed —
+    /// the daemon reports `.connected` regardless (it's the correct state for most purposes), so
+    /// without this the failure is otherwise invisible until an unrelated later operation fails
+    /// for a confusing reason. `nil` means no warning; cleared at the start of every
+    /// `startDaemon()` call.
     var lastStartupWarning: String?
 
     /// The running daemon's version, from the health-check ping. `nil` before the first

--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -58,9 +58,39 @@ final class LiveContainerService: ContainerServiceBase {
 
     private func resolvedSystemConfig() async -> ContainerSystemConfig {
         if systemConfig == nil {
-            systemConfig = try? await ConfigurationLoader.load()
+            let result: Result<ContainerSystemConfig, Error>
+            do {
+                result = .success(try await ConfigurationLoader.load())
+            } catch {
+                Self.log.error("failed to load system config", metadata: ["error": "\(error)"])
+                result = .failure(error)
+            }
+            let (config, warning) = Self.mapSystemConfigLoadResult(result)
+            systemConfig = config
+            if let warning {
+                lastStartupWarning = warning
+            }
         }
         return systemConfig ?? ContainerSystemConfig()
+    }
+
+    /// `ConfigurationLoader.load()` only throws when a config file exists on disk but fails to
+    /// parse or decode — it already returns cleanly with defaults when no file is present at all
+    /// (`loadAndDecode`'s all-paths-missing short-circuit). So any caught error here means the
+    /// user's actual customized `config.toml` is being discarded, not just "there was nothing to
+    /// load" — worth a warning rather than a silent `try?` fallback to defaults.
+    nonisolated static func mapSystemConfigLoadResult(
+        _ result: Result<ContainerSystemConfig, Error>
+    ) -> (config: ContainerSystemConfig, warning: String?) {
+        switch result {
+        case .success(let config):
+            return (config, nil)
+        case .failure(let error):
+            return (
+                ContainerSystemConfig(),
+                "Couldn't load your container configuration, so Berthly is using defaults instead: \(error.localizedDescription)"
+            )
+        }
     }
 
     private static let contextsURL: URL = {

--- a/BerthlyTests/SystemPageMappingTests.swift
+++ b/BerthlyTests/SystemPageMappingTests.swift
@@ -126,6 +126,32 @@ struct SystemConfigMappingTests {
     }
 }
 
+private struct FakeDecodeError: LocalizedError {
+    var errorDescription: String? { "kernel.digest is required when kernel.url is not the default URL" }
+}
+
+// Regression: `resolvedSystemConfig()` used to `try?` this outcome, silently discarding a
+// user's entire customized config.toml (not just the field that failed) whenever it existed
+// but failed to decode — see the load-vs-decode distinction documented on
+// `mapSystemConfigLoadResult` itself.
+struct SystemConfigLoadResultMappingTests {
+
+    @Test func successPassesTheConfigThroughWithNoWarning() {
+        let config = ContainerSystemConfig()
+        let (resolved, warning) = LiveContainerService.mapSystemConfigLoadResult(.success(config))
+
+        #expect(resolved.build.image == config.build.image)
+        #expect(warning == nil)
+    }
+
+    @Test func failureFallsBackToDefaultsWithAWarning() {
+        let (resolved, warning) = LiveContainerService.mapSystemConfigLoadResult(.failure(FakeDecodeError()))
+
+        #expect(resolved.build.image == ContainerSystemConfig().build.image)
+        #expect(warning?.contains("kernel.digest is required") == true)
+    }
+}
+
 struct DaemonLogEventFormattingTests {
 
     @Test func joinsTimeLevelAndMessageWithTabs() {


### PR DESCRIPTION
## Summary
- `resolvedSystemConfig()` used `try?` around `ConfigurationLoader.load()`, so any decode failure silently fell back to an all-defaults `ContainerSystemConfig` — not just the field that failed, the user's entire `config.toml` (DNS, build settings, kernel, everything).
- `ConfigurationLoader.load()` only throws when a config file exists on disk but fails to parse/decode; it already returns cleanly with defaults when no file is present at all — so every error caught here represents real discarded user data, not an absent-file no-op.
- container 1.2.0 made this concrete: `KernelConfig`'s decoder now throws when `kernel.url` is customized without a paired `kernel.digest` (apple/container#1703). Any Berthly user who ran `container system kernel set --tar <url>` pre-1.2.0 has exactly that config shape, and would silently lose their whole system config on next load once the daemon is upgraded.
- Extracts the load-outcome handling into a pure, testable `mapSystemConfigLoadResult(_:)` and surfaces a failure through the existing `lastStartupWarning` mechanism instead of swallowing it.

## Why
Found while implementing #79 (kernel digest verification) — this milestone's own version bump is what triggers the failure for affected users, so it needs fixing in the same milestone.

Closes #87

## Test plan
- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test -only-testing:BerthlyTests` — full suite passes, including new `SystemConfigLoadResultMappingTests` covering both the success and failure paths
- [x] `swiftlint lint --strict` — 0 violations
- [x] No View files touched — no UI test needed for this change (tracked separately in #89: the sidebar's warning-state rendering itself has no UI coverage yet, pre-existing gap this PR surfaces a second producer into)