### PR TITLE
fix: show progress during Start Container System

### DIFF
--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -285,8 +285,11 @@ final class LiveContainerService: ContainerServiceBase {
         lastStartupWarning = nil
 
         do {
+            onLog?("Starting container-apiserver…")
             try await launchDaemonIfNeeded()
-            try await pingDaemonWithRecovery()
+            onLog?("Waiting for the daemon to respond…")
+            try await pingDaemonWithRecovery(onLog: onLog)
+            onLog?("Daemon responded — verifying the machine service…")
             _ = try await MachineClient().list()
         } catch {
             daemonState = .error(error.localizedDescription)
@@ -810,10 +813,11 @@ final class LiveContainerService: ContainerServiceBase {
     /// practice: rather than depending on that check having picked the right branch (register is a
     /// silent no-op for an already-loaded-but-stopped label), a failed ping here is treated as the
     /// real signal to force a restart before giving up.
-    private nonisolated func pingDaemonWithRecovery() async throws {
+    private nonisolated func pingDaemonWithRecovery(onLog: (@MainActor (String) -> Void)? = nil) async throws {
         do {
             _ = try await ClientHealthCheck.ping()
         } catch {
+            await onLog?("Daemon didn't respond — restarting it and trying again…")
             let domain = try ServiceManager.getDomainString()
             try? ServiceManager.kickstart(fullServiceLabel: "\(domain)/\(Self.apiServerLabel)")
             _ = try await ClientHealthCheck.ping()

--- a/Berthly/Core/MockContainerService.swift
+++ b/Berthly/Core/MockContainerService.swift
@@ -459,15 +459,12 @@ final class MockContainerService: ContainerServiceBase {
             SystemProperty(key: "build.cpus", value: "2"),
             SystemProperty(key: "build.memory", value: "2 GB"),
             SystemProperty(key: "build.image", value: "ghcr.io/apple/container-builder-shim/builder:latest"),
-            SystemProperty(key: "container.cpus", value: "4"),
-            SystemProperty(key: "container.memory", value: "1 GB"),
+            SystemProperty(key: "container.cpus", value: "4"), SystemProperty(key: "container.memory", value: "1 GB"),
             SystemProperty(key: "dns.domain", value: "test"),
             SystemProperty(key: "kernel.binaryPath", value: "opt/kata/share/kata-containers/vmlinux-6.18.15-186"),
             SystemProperty(key: "kernel.url", value: "https://github.com/kata-containers/kata-containers/releases/download/3.28.0/kata-static-3.28.0-arm64.tar.zst"),
-            SystemProperty(key: "machine.cpus", value: "4"),
-            SystemProperty(key: "machine.memory", value: "8 GB"),
-            SystemProperty(key: "machine.home-mount", value: "rw"),
-            SystemProperty(key: "machine.virtualization", value: "false"),
+            SystemProperty(key: "machine.cpus", value: "4"), SystemProperty(key: "machine.memory", value: "8 GB"),
+            SystemProperty(key: "machine.home-mount", value: "rw"), SystemProperty(key: "machine.virtualization", value: "false"),
             SystemProperty(key: "network.subnet", value: "192.168.64.0/24"),
             SystemProperty(key: "network.subnetv6", value: "–"),
             SystemProperty(key: "registry.domain", value: "docker.io"),
@@ -637,7 +634,14 @@ final class MockContainerService: ContainerServiceBase {
 
     override func startDaemon(onLog: (@MainActor (String) -> Void)? = nil) async {
         daemonState = .connecting
-        try? await Task.sleep(for: .milliseconds(200))
+        // Mirrors LiveContainerService.startDaemon's launch/ping/verify log lines. Staged well
+        // past XCUITest's ~1s waitForExistence polling cadence observed in this environment (a
+        // 400ms-per-stage version finished *before the first poll fired* and never got caught) —
+        // gives a UI test real room to catch the ProgressLogScreen mid-flight.
+        onLog?("Starting container-apiserver…")
+        try? await Task.sleep(for: .milliseconds(1200))
+        onLog?("Waiting for the daemon to respond…")
+        try? await Task.sleep(for: .milliseconds(1200))
         daemonState = .connected
     }
 

--- a/Berthly/Views/DaemonGateView.swift
+++ b/Berthly/Views/DaemonGateView.swift
@@ -86,7 +86,12 @@ struct DaemonGateView<Content: View>: View {
                 Text("The container daemon is installed but not running.")
             } actions: {
                 Button("Start Container System") {
-                    Task { await service.startDaemon() }
+                    runOperation(
+                        message: String(localized: "Starting container system…"),
+                        failureTitle: String(localized: "Start Failed")
+                    ) { service, onLog in
+                        await service.startDaemon(onLog: onLog)
+                    }
                 }
                 .buttonStyle(.borderedProminent)
             }

--- a/BerthlyUITests/BerthlyUITests.swift
+++ b/BerthlyUITests/BerthlyUITests.swift
@@ -148,6 +148,34 @@ final class BerthlyUITests: XCTestCase {
         XCTAssertFalse(app.buttons["Start Container System"].exists)
     }
 
+    /// Regression: "Start Container System" used to call `startDaemon()` bare, showing only the
+    /// static ".connecting" text with zero progress for however long launch/ping/verify took.
+    /// It now routes through the same `runOperation`/`ProgressLogScreen` path as install/update,
+    /// so real log lines should appear while the mock's staged `startDaemon` is mid-flight.
+    @MainActor
+    func testStartContainerSystemShowsProgress() throws {
+        let app = XCUIApplication.berthly()
+        app.launchEnvironment["UITEST_USE_MOCK_SERVICE"] = "1"
+        app.launchEnvironment["UITEST_INITIAL_DAEMON_STATE"] = "installedButStopped"
+        app.launch()
+
+        let startButton = app.buttons["Start Container System"]
+        XCTAssertTrue(startButton.waitForExistence(timeout: 10))
+        startButton.click()
+
+        // Wait once, for the *last* log line the mock emits — log lines are additive
+        // (ProgressLogScreen never clears `operationLogs` mid-run), so catching this one also
+        // guarantees the message and the first line are already on screen. Checking each line
+        // with its own `waitForExistence` compounds this harness's ~1s per-poll overhead enough
+        // that the mock's whole (short) operation can finish before a later wait even starts.
+        XCTAssertTrue(app.staticTexts["Waiting for the daemon to respond…"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["operationProgressMessage"].exists)
+        XCTAssertTrue(app.staticTexts["Starting container-apiserver…"].exists)
+
+        XCTAssertTrue(app.staticTexts["web-frontend"].waitForExistence(timeout: 5))
+        XCTAssertFalse(app.buttons["Start Container System"].exists)
+    }
+
     /// First-launch guided install: the notInstalled gate offers an in-app install, which (in
     /// the mock) fakes download/verify/install and then connects. Asserts the full path from
     /// "Container Not Installed" through the confirm alert to connected content.


### PR DESCRIPTION
## Summary
- The "Start Container System" button called `startDaemon()` bare, so the launchd registration, health-check ping (up to 60s, retried once on failure — another 60s), and machine-service check ran with zero visible feedback: the UI just showed the static "Starting container system…" text for however long the whole sequence took.
- Routes the button through the same `runOperation`/`ProgressLogScreen` helper `installContainer` and `upgradeContainer` already use.
- Adds `onLog` lines to `startDaemon`'s launch/ping/verify steps — previously only the vminit/kernel install steps reported progress.
- New UI test (`testStartContainerSystemShowsProgress`) verifies the rewiring actually renders: clicks the button, waits for the mock's staged log line, confirms the message and earlier line are already present. `MockContainerService.startDaemon` now emits matching staged log lines to make this testable.

## Why
Surfaced while testing the container 1.2.0 version-gate flow (#84): starting an old daemon can take well over a minute before Berthly even shows the "Update Required" gate, with no way to tell real progress from a hang during that wait.

Closes #84

## Test plan
- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test -only-testing:BerthlyTests` — full suite passes
- [x] `swiftlint lint --strict` — 0 violations
- [x] New `testStartContainerSystemShowsProgress` UI test — validated 5x clean, plus 3 more combined runs alongside the pre-existing `testDaemonStoppedShowsStartButtonAndConnectsOnTap` (unchanged assertions, still passes with the rewiring)