### PR TITLE
fix: don't show Error on a cancelled daemon start

### DIFF
--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -268,6 +268,23 @@ final class LiveContainerService: ContainerServiceBase {
     private nonisolated static let apiServerLabel = "com.apple.container.apiserver"
     private static let servicePrefix = "com.apple.container."
 
+    /// What `startDaemon()`'s connect-phase failure should do, given the error it caught.
+    /// Extracted pure so the CancellationError-vs-real-failure distinction — the actual bug
+    /// `runOperation`'s Cancel button used to hit — is unit-testable without a live daemon.
+    /// Cancelling `launchDaemonIfNeeded`/`pingDaemonWithRecovery`/`MachineClient().list()` doesn't
+    /// undo the launchd registration/kickstart already issued, so guessing a resulting state would
+    /// be just as likely wrong as right — `.repoll` defers to a fresh `poll()` to report whatever
+    /// actually happened instead of guessing, or misreporting it as a failure the way a bare
+    /// catch-all used to.
+    enum StartDaemonFailureOutcome: Equatable {
+        case repoll
+        case reportError(String)
+    }
+
+    nonisolated static func startDaemonFailureOutcome(for error: Error) -> StartDaemonFailureOutcome {
+        error is CancellationError ? .repoll : .reportError(error.localizedDescription)
+    }
+
     /// Native (launchd, no CLI shelling) implementation of `container system start`: registers
     /// (or restarts) the `container-apiserver` launchd service, waits for it to respond, and
     /// bootstraps the vminit filesystem image and default kernel on first run — without asking,
@@ -292,9 +309,20 @@ final class LiveContainerService: ContainerServiceBase {
             onLog?("Daemon responded — verifying the machine service…")
             _ = try await MachineClient().list()
         } catch {
-            daemonState = .error(error.localizedDescription)
-            isStarting = false
-            return
+            // This is also what makes `installContainer`/`upgradeContainer`'s trailing
+            // `startDaemon()` call behave correctly on cancel: since this method never throws,
+            // returning cleanly on `.repoll` (rather than reporting an error) means the caller
+            // doesn't see one either.
+            switch Self.startDaemonFailureOutcome(for: error) {
+            case .repoll:
+                isStarting = false
+                await poll()
+                return
+            case .reportError(let message):
+                daemonState = .error(message)
+                isStarting = false
+                return
+            }
         }
 
         let containerSystemConfig = await resolvedSystemConfig()

--- a/BerthlyTests/BerthlyTests.swift
+++ b/BerthlyTests/BerthlyTests.swift
@@ -4,6 +4,7 @@
 import ContainerAPIClient
 import ContainerPersistence
 import ContainerResource
+import ContainerizationError
 import ContainerizationExtras
 import ContainerizationOCI
 import Foundation
@@ -656,6 +657,24 @@ struct ContainerCompatibilityTests {
 
     @Test func extractVersionReturnsNilWhenNoVersionPresent() {
         #expect(ContainerCompatibility.extractVersion(from: "not-a-version") == nil)
+    }
+}
+
+// Regression: `startDaemon()`'s connect-phase catch-all used to treat a cancelled `runOperation`
+// (the "Start Container System" / install / upgrade progress screens' Cancel button) the same as
+// a real failure, landing on a confusing "Error" gate instead of returning cleanly.
+struct StartDaemonFailureOutcomeTests {
+
+    @Test func cancellationRepolls() {
+        #expect(LiveContainerService.startDaemonFailureOutcome(for: CancellationError()) == .repoll)
+    }
+
+    @Test func realFailureReportsItsMessage() {
+        let error = ContainerizationError(.internalError, message: "XPC connection error")
+        #expect(
+            LiveContainerService.startDaemonFailureOutcome(for: error)
+                == .reportError(error.localizedDescription)
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- `startDaemon()`'s connect-phase catch-all treated a cancelled `runOperation` the same as a real failure, setting `daemonState = .error(...)` — `DaemonGateView.runOperation` expects `CancellationError` specifically so its Cancel button can return quietly, but a bare catch-all upstream turned it into a confusing "Connection Error" screen instead.
- Extracts the distinction into a pure, testable `startDaemonFailureOutcome(for:)`: cancellation re-polls (the launchd registration/kickstart already issued can't be undone, so `poll()` reports whatever actually happened rather than guessing a state or misreporting it as a failure); anything else still reports the error as before.
- `installContainer`/`upgradeContainer` both end with a non-throwing `startDaemon(onLog:)` call, so they inherit this fix automatically — confirmed by re-reading both, no separate changes needed.
- Also resolves the "does a cancelled mid-download leave a safe, retryable state" question from #92: traced `SnapshotStore.unpack` in containerization's actual source — it writes to a temp dir and only commits via `moveItem` on success, checking `Task.checkCancellation()` per descriptor along the way. A cancelled/failed unpack never commits, so the next attempt's "already exists" guard correctly retries from scratch. Not a bug, just confirmation — no code change needed for that part.

## Why
Three call sites route through `runOperation` and could hit this: `installContainer`, `upgradeContainer`, and `startDaemon` via "Start Container System" (#84). `upgradeContainer` is the exact "Update Container to v1.2.0…" flow this whole milestone pushes every 1.1.0 user through — hitting Cancel mid-upgrade could've left them looking at an "Error" screen instead of cleanly back at the gate.

Closes #92

## Test plan
- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test -only-testing:BerthlyTests` — full suite passes, including new `StartDaemonFailureOutcomeTests`
- [x] `swiftlint lint --strict` — 0 violations
- No UI test: `MockContainerService.startDaemon()` is structurally non-throwing and doesn't call the real APIs this fix's catch block guards, so a mock-based UI test can't exercise this code path at all — the extracted pure function is the meaningful coverage available without a live daemon. Full end-to-end confidence would need `BerthlyE2ETests` (real daemon, cancellation injected mid-XPC-call); not added here given this is a narrow bug fix, not a new feature.