### PR TITLE
docs: bump PARITY.md audit banner to container CLI 1.2.0

### DIFF
--- a/PARITY.md
+++ b/PARITY.md
@@ -3,7 +3,7 @@
 How Berthly's GUI maps onto [Apple's `container`](https://github.com/apple/container)
 CLI, subcommand by subcommand — and the few places it deliberately doesn't.
 
-> Audited against **container CLI 1.1.0** (2026-07-15). When a change closes or
+> Audited against **container CLI 1.2.0** (2026-08-04). When a change closes or
 > opens a gap, update this file in the same commit.
 
 ## Containers


### PR DESCRIPTION
## Summary
- Bumps `PARITY.md`'s "Audited against container CLI 1.1.0" banner to 1.2.0.
- `--kernel-arg` and kernel-digest were already added to their respective tables in #78/#79's own commits.
- Swept the full 1.2.0 changelog for anything else parity-relevant: everything remaining is internal daemon hardening (XPC ID validation, symlink-follow fix, env-var/port-forward fixes), test/CI infra, or dependency bumps — no new client-visible CLI flags or subcommands.
- OCI maskedPaths/readonlyPaths (#80) stays untouched, correctly pending its own triage (still an open P3 spike).

## Why
Closes out the container 1.2.0 milestone's documentation debt (#77) — the audited-version claim was the one thing still stale after #75-#79/#84/#87/#92 landed.

Closes #77

## Test plan
Docs-only change, no code touched.