### PR TITLE
test: add UI coverage for the sidebar's daemon warning state

### DIFF
--- a/Berthly/BerthlyApp.swift
+++ b/Berthly/BerthlyApp.swift
@@ -39,7 +39,9 @@ struct BerthlyApp: App {
     @AppStorage("showMenuBarIcon") private var showMenuBarIcon = true
 
     /// UI tests set `UITEST_USE_MOCK_SERVICE` to get deterministic state instead of a real
-    /// daemon connection, optionally seeded via `UITEST_INITIAL_DAEMON_STATE`.
+    /// daemon connection, optionally seeded via `UITEST_INITIAL_DAEMON_STATE` and
+    /// `UITEST_STARTUP_WARNING` (the latter for `DaemonStatusBar`'s "Running (warning)" state,
+    /// which only shows while `.connected` — the mock's default state).
     private static func makeService() -> ContainerServiceBase {
         let env = ProcessInfo.processInfo.environment
         guard env["UITEST_USE_MOCK_SERVICE"] != nil else {
@@ -54,6 +56,9 @@ struct BerthlyApp: App {
         case "versionMismatch":
             mock.daemonState = .versionMismatch(installed: "1.0.0", required: ContainerCompatibility.requiredVersion)
         default: break
+        }
+        if let warning = env["UITEST_STARTUP_WARNING"] {
+            mock.lastStartupWarning = warning
         }
         return mock
     }

--- a/BerthlyUITests/BerthlyUITests.swift
+++ b/BerthlyUITests/BerthlyUITests.swift
@@ -176,6 +176,27 @@ final class BerthlyUITests: XCTestCase {
         XCTAssertFalse(app.buttons["Start Container System"].exists)
     }
 
+    /// Regression: `DaemonStatusBar`'s "Running (warning)" state (icon/color/word swap, plus a
+    /// `.help()` tooltip carrying the actual message) had no UI coverage at all — set via
+    /// `UITEST_STARTUP_WARNING` seeding `lastStartupWarning` on the mock, which defaults to
+    /// `.connected` (the only state this row's warning path renders under).
+    @MainActor
+    func testDaemonStatusBarShowsWarningState() throws {
+        let app = XCUIApplication.berthly()
+        app.launchEnvironment["UITEST_USE_MOCK_SERVICE"] = "1"
+        app.launchEnvironment["UITEST_STARTUP_WARNING"] = "Couldn't install the default kernel: network error"
+        app.launch()
+
+        // The tooltip text itself (`.help(activeWarning ?? "")`) isn't reliably readable via
+        // XCUITest hover on macOS — see SystemViewTests.swift's header for the same finding on
+        // this codebase's other `.help()`-only rows. The status word swap is what's actually
+        // asserted; it's driven by the same `activeWarning` value the tooltip carries. Queried by
+        // its literal text, matching every other staticTexts lookup in this file — an
+        // accessibilityIdentifier on this Text was tried first, but its `.label` came back empty
+        // even though existence-matching (identifier-or-label) still worked.
+        XCTAssertTrue(app.staticTexts["Running (warning)"].waitForExistence(timeout: 10))
+    }
+
     /// First-launch guided install: the notInstalled gate offers an in-app install, which (in
     /// the mock) fakes download/verify/install and then connects. Asserts the full path from
     /// "Container Not Installed" through the confirm alert to connected content.


### PR DESCRIPTION
## Summary
- `DaemonStatusBar`'s "Running (warning)" state (icon/color/word swap when `lastStartupWarning` is set alongside `.connected`) had no UI coverage — not from the vminit/kernel bootstrap failures that originally produced it, nor from `resolvedSystemConfig()`'s decode-failure path added since (#87).
- Adds `UITEST_STARTUP_WARNING`, seeding `lastStartupWarning` on the mock (which defaults to `.connected` — the only state this row's warning path renders under), mirroring `UITEST_INITIAL_DAEMON_STATE`'s existing pattern.
- New `testDaemonStatusBarShowsWarningState` asserts the "Running (warning)" status word renders.

## Why
Closes #89. The tooltip text itself (`.help(activeWarning ?? "")`) isn't reliably readable via XCUITest hover on macOS — matches the finding already documented in `SystemViewTests.swift`'s header for this codebase's other `.help()`-only rows. Tried an `accessibilityIdentifier` on the status word `Text` to sidestep that; its `.label` came back empty even though identifier-based existence matching worked. A first attempt at a container-level identifier also collapsed the whole row into one merged accessibility element (SwiftUI child-flattening), hiding the inner `Text` entirely. Settled on querying by literal text, matching every other `staticTexts` lookup already in this file — no net changes to `SidebarView.swift` itself.

## Test plan
- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test -only-testing:BerthlyTests` — full suite passes
- [x] `swiftlint lint --strict` — 0 violations
- [x] New test validated 4x clean; confirmed no regression in the two other daemon-state UI tests (`testDaemonStoppedShowsStartButtonAndConnectsOnTap`, `testStartContainerSystemShowsProgress`)