### PR TITLE
feat: explain why an upgrade is required on the version-mismatch gate

### DIFF
--- a/Berthly/Core/ContainerCompatibility.swift
+++ b/Berthly/Core/ContainerCompatibility.swift
@@ -16,6 +16,12 @@ nonisolated enum ContainerCompatibility {
     /// Keep in sync with the `container` SPM package pin (Package.resolved / Package.swift).
     static let requiredVersion = "1.2.0"
 
+    /// One-line, hand-written summary of what `requiredVersion` adds — shown on the
+    /// version-mismatch gate so an upgrade prompt isn't just two bare version numbers. Update
+    /// this by hand alongside `requiredVersion` bumps; it's not generated from upstream's
+    /// changelog.
+    static let requiredVersionRationale = "Adds kernel boot-arg support and kernel archive integrity checks."
+
     /// How an incompatible install relates to the required version. `tooOld` is fixable in place
     /// with the upstream update script; `tooNew` (newer major) is not — downgrading requires a
     /// full uninstall, so the only safe advice is to update Berthly instead.

--- a/Berthly/Views/DaemonGateView.swift
+++ b/Berthly/Views/DaemonGateView.swift
@@ -212,7 +212,16 @@ struct DaemonGateView<Content: View>: View {
                 Label("Update Required", systemImage: "exclamationmark.triangle")
                     .accessibilityIdentifier("updateRequiredGateTitle")
             } description: {
-                Text("Installed: v\(installed) · Required: v\(required) or newer")
+                VStack(spacing: 6) {
+                    Text("Installed: v\(installed) · Required: v\(required) or newer")
+                    Text(ContainerCompatibility.requiredVersionRationale)
+                        .font(.callout)
+                    Link(
+                        "See what's new",
+                        destination: URL(string: "https://github.com/apple/container/releases/tag/\(required)")!
+                    )
+                    .font(.callout)
+                }
             } actions: {
                 Button("Update Container to v\(required)…") {
                     showUpdateConfirm = true


### PR DESCRIPTION
## Summary
- `VersionMismatchGate` showed only "Installed: vX · Required: vY or newer" — no context for what the user's actually being asked to accept before hitting the destructive-alert warning about stopping every container on the Mac.
- Adds `ContainerCompatibility.requiredVersionRationale`, a hand-written one-line summary updated by hand alongside `requiredVersion` bumps (not generated from upstream's changelog).
- Adds a "See what's new" link to the matching GitHub release notes (`https://github.com/apple/container/releases/tag/<version>`).

## Why
Closes #81. Design approach (one-liner + link, vs. either alone) was discussed and picked before implementing.

## Test plan
- [x] `xcodebuild build` succeeds
- [x] `xcodebuild test -only-testing:BerthlyTests` — full suite passes
- [x] `swiftlint lint --strict` — 0 violations
- [x] Verified visually via Xcode's live preview renderer — renders exactly as designed
- [x] Confirmed the existing `testVersionMismatchGateUpdatesAndConnects` UI test still passes unaffected