### PR TITLE
test: add kernel-arg coverage to the Run E2E journey test

### DIFF
--- a/Berthly/Localizable.xcstrings
+++ b/Berthly/Localizable.xcstrings
@@ -1005,7 +1005,7 @@
     "Ports" : {
 
     },
-    "Pre-filled from config.toml's recommended kernel — edit to install a different one." : {
+    "Pre-filled from config.toml's recommended kernel — edit to install a different one. The digest is verified against the archive before install; a remote URL requires one." : {
 
     },
     "Properties" : {
@@ -1242,6 +1242,9 @@
     "Security" : {
 
     },
+    "See what's new" : {
+
+    },
     "Select a section" : {
 
     },
@@ -1339,6 +1342,9 @@
     "Start Container System" : {
 
     },
+    "Start Failed" : {
+
+    },
     "Start immediately" : {
 
     },
@@ -1352,6 +1358,9 @@
 
     },
     "Start the machine to open a shell." : {
+
+    },
+    "Starting container system…" : {
 
     },
     "Starting container…" : {

--- a/BerthlyE2ETests/BerthlyE2ETests.swift
+++ b/BerthlyE2ETests/BerthlyE2ETests.swift
@@ -431,6 +431,19 @@ final class RunContainerJourneyTests: BerthlyE2ETestCase {
         type("/tmp", into: "runWorkdirField")
         type("405", into: "runUserField")
         app.checkBoxes["runReadOnlyToggle"].click()
+        // kernel-arg has no representation in `container inspect`'s JSON at all — traced through
+        // containerization's source: it only ever reaches Kernel.commandLine.kernelArgs, which
+        // feeds the VM's actual boot command line, not ManagedContainer's persisted
+        // configuration. /proc/cmdline below is the only oracle that can prove this reached the
+        // daemon; testRunOptionsReachDaemon's JSON assertions can't see it.
+        //
+        // Its Add button sits below the Security ScrollView's clipped bounds. Unlike capDrop
+        // (skipped above), XCUITest reports `isHittable == true` here regardless — the check
+        // doesn't account for ancestor clipping — so a plain `.click()` synthesizes an event at
+        // an off-screen point and silently no-ops. Scroll the row into the visible frame first.
+        app.windows.scrollViews.firstMatch.scroll(byDeltaX: 0, deltaY: -600)
+        app.buttons["runKernelArgAddButton"].click()
+        type("berthly_e2e_marker=1", into: "runKernelArgField")
 
         app.buttons["runSubmitButton"].click()
         XCTAssertTrue(app.buttons["Show Container"].waitForExistence(timeout: 120),
@@ -448,6 +461,10 @@ final class RunContainerJourneyTests: BerthlyE2ETestCase {
         let uid = try ContainerCLI.exec(containerName, ["id", "-u"])
         XCTAssertEqual(uid.output.trimmingCharacters(in: .whitespacesAndNewlines), "405",
                        "process should run as the configured uid")
+
+        let cmdline = try ContainerCLI.exec(containerName, ["cat", "/proc/cmdline"])
+        XCTAssertTrue(cmdline.output.contains("berthly_e2e_marker=1"),
+                      "--kernel-arg should reach the VM's actual boot command line:\n\(cmdline.output)")
 
         let write = try ContainerCLI.exec(containerName, ["touch", "/should-fail"])
         XCTAssertNotEqual(write.status, 0, "read-only root filesystem should reject writes")


### PR DESCRIPTION
## Summary
- Adds `--kernel-arg` coverage to `testRunOptionsTakeEffectViaExec`. `container inspect`'s JSON has no representation of kernel args (they only reach `Kernel.commandLine.kernelArgs`, which feeds the VM's boot command line, not `ManagedContainer`'s persisted config), so `cat /proc/cmdline` via exec is the oracle.
- Fixes the kernel-arg row being unreachable in the test: XCUITest's `isHittable` doesn't account for `ScrollView` clipping, so a plain `.click()` on the Add button (below the visible scroll bounds) synthesized an off-screen event and silently no-op'd. Scrolls the row into view first.
- Syncs `Localizable.xcstrings` for strings that shipped in #91, #93, and #96 but never got committed alongside those PRs.

Closes #86

## Test plan
- [x] `./scripts/e2e.sh RunContainerJourneyTests/testRunOptionsTakeEffectViaExec` passes against a real daemon
- [x] `./scripts/e2e.sh RunContainerJourneyTests` (full class, 5 tests) passes with no regressions
- [x] `swiftlint lint --strict` — 0 violations