### PR TITLE
feat: stream progress logs in Run Container and Create Machine sheets

### DIFF
--- a/Berthly/Core/ContainerServiceBase.swift
+++ b/Berthly/Core/ContainerServiceBase.swift
@@ -83,8 +83,8 @@ class ContainerServiceBase {
     }
     func buildImage(options: BuildOptions, onLog: @MainActor @escaping (String) -> Void) async throws {}
     @discardableResult
-    func runContainer(options: RunOptions) async throws -> String { "" }
-    func createMachine(options: MachineCreateOptions) async throws {}
+    func runContainer(options: RunOptions, onLog: (@MainActor (String) -> Void)? = nil) async throws -> String { "" }
+    func createMachine(options: MachineCreateOptions, onLog: (@MainActor (String) -> Void)? = nil) async throws {}
     func createVolume(options: VolumeCreateOptions) async throws {}
     func createNetwork(options: NetworkCreateOptions) async throws {}
 

--- a/Berthly/Core/DownloadProgress.swift
+++ b/Berthly/Core/DownloadProgress.swift
@@ -16,12 +16,20 @@ import TerminalProgress
 /// `downloadedBytes` is monotonic either way, so bucketing on it is stable even though
 /// `totalBytes` can grow as more of it is discovered — which is why we throttle on downloaded
 /// bytes, not on a percent-of-total that would jump around.
+///
+/// Multi-stage callers (`container run`/`create machine`'s `containerConfigFromFlags`) route
+/// image, kernel, and init-image fetches through one `progressUpdate` stream, distinguishing
+/// stages via `.setDescription` (e.g. "Fetching init image", matching the CLI's own `[4/6]`
+/// labels — see `Utility.containerConfigFromFlags`). A new description resets the byte counters
+/// (each stage's bytes are independent) and always yields a line, even with zero bytes moved yet,
+/// so a stage transition is visible immediately rather than only once its first byte arrives.
 nonisolated struct DownloadProgress {
     let label: String
     let bucketBytes: Int64
     private(set) var downloadedBytes: Int64 = 0
     private(set) var totalBytes: Int64 = 0
     private var lastEmittedBucket: Int64 = -1
+    private var stageLabel: String?
 
     // 10 MiB buckets: frequent enough that a slow connection still shows steady movement,
     // without flooding the log.
@@ -32,23 +40,33 @@ nonisolated struct DownloadProgress {
 
     /// Fold in a batch of events. Returns a log line to append iff a new `bucketBytes` boundary
     /// was crossed (which includes the very first size event — that's the "download started"
-    /// signal). Returns `nil` when no download bytes moved (e.g. a cached fetch emits no size
-    /// events, so no misleading "Downloading…" line ever appears).
+    /// signal) or the stage description changed. Returns `nil` when neither happened (e.g. a
+    /// cached fetch emits no size events, so no misleading "Downloading…" line ever appears).
     mutating func apply(_ events: [ProgressUpdateEvent]) -> String? {
         var sawSize = false
+        var stageChanged = false
         for event in events {
             switch event {
             case .addSize(let n): downloadedBytes += n; sawSize = true
             case .setSize(let n): downloadedBytes = n; sawSize = true
             case .addTotalSize(let n): totalBytes += n
             case .setTotalSize(let n): totalBytes = n
+            case .setDescription(let description):
+                guard description != stageLabel else { break }
+                stageLabel = description
+                downloadedBytes = 0
+                totalBytes = 0
+                lastEmittedBucket = -1
+                stageChanged = true
             default: break
             }
         }
-        guard sawSize else { return nil }
-        let bucket = downloadedBytes / bucketBytes
-        guard bucket > lastEmittedBucket else { return nil }
-        lastEmittedBucket = bucket
+        guard sawSize || stageChanged else { return nil }
+        if sawSize {
+            let bucket = downloadedBytes / bucketBytes
+            guard bucket > lastEmittedBucket || stageChanged else { return nil }
+            lastEmittedBucket = bucket
+        }
         return logLine
     }
 
@@ -56,11 +74,13 @@ nonisolated struct DownloadProgress {
     /// is dropped until it's known, since it isn't always reported until the download starts.
     /// Formatting is shared with the rest of the app's byte displays via `formatDiskBytes`.
     var logLine: String {
+        let prefix = stageLabel ?? label
+        guard downloadedBytes > 0 || totalBytes > 0 else { return "\(prefix)…" }
         let downloaded = formatDiskBytes(UInt64(downloadedBytes))
         if totalBytes > 0 {
-            return "\(label)… \(downloaded) / \(formatDiskBytes(UInt64(totalBytes)))"
+            return "\(prefix)… \(downloaded) / \(formatDiskBytes(UInt64(totalBytes)))"
         }
-        return "\(label)… \(downloaded)"
+        return "\(prefix)… \(downloaded)"
     }
 }
 

--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -55,6 +55,8 @@ final class LiveContainerService: ContainerServiceBase {
     private var imageMetadataCache: [String: CachedImageMetadata] = [:]
     private static let log = Logger(label: "app.berthly.container")
     private nonisolated static let pushOperationTracker = PushOperationTracker()
+    // `?? { _ in }` inline doesn't infer `@Sendable` from context — a typed constant does.
+    private nonisolated static let noopProgressHandler: ProgressUpdateHandler = { _ in }
 
     private func resolvedSystemConfig() async -> ContainerSystemConfig {
         if systemConfig == nil {
@@ -2741,7 +2743,7 @@ final class LiveContainerService: ContainerServiceBase {
     /// `start && attach` captures the container's own stdout via our own pipe and waits for exit
     /// — for one-shot commands like `pwd`. This app never attaches an interactive terminal.
     @discardableResult
-    override func runContainer(options: RunOptions) async throws -> String {
+    override func runContainer(options: RunOptions, onLog: (@MainActor (String) -> Void)? = nil) async throws -> String {
         let id = Utility.createContainerID(name: options.name)
         guard ManagedContainer.nameValid(id) else {
             throw ContainerizationError(.invalidArgument, message: "container ID \(id) is not a valid container ID")
@@ -2753,6 +2755,12 @@ final class LiveContainerService: ContainerServiceBase {
         }
 
         let containerSystemConfig = await resolvedSystemConfig()
+        // Fetching, not just unpacking, is the slow part (a first boot needing a fresh kernel or
+        // vminit image can take minutes) — `.setDescription` events distinguish those stages from
+        // whatever DownloadReporter's caller-supplied label would otherwise say.
+        let reporter = onLog.map { onLog in
+            DownloadReporter(label: "Fetching image", onLog: onLog)
+        }
         let (containerConfig, kernel, initImage) = try await Utility.containerConfigFromFlags(
             id: id,
             image: options.reference,
@@ -2763,7 +2771,7 @@ final class LiveContainerService: ContainerServiceBase {
             registry: Self.runRegistryFlags(for: options),
             imageFetch: Flags.ImageFetch(maxConcurrentDownloads: 3),
             containerSystemConfig: containerSystemConfig,
-            progressUpdate: { _ in },
+            progressUpdate: reporter?.handler ?? Self.noopProgressHandler,
             log: Self.log
         )
 
@@ -2903,7 +2911,7 @@ final class LiveContainerService: ContainerServiceBase {
     /// Native (XPC API, no CLI shelling) implementation of `container machine create`. Reuses
     /// `MachineClient.machineConfigFromFlags` for image fetch/unpack and machine config assembly,
     /// same as `runContainer` reuses `Utility.containerConfigFromFlags`.
-    override func createMachine(options: MachineCreateOptions) async throws {
+    override func createMachine(options: MachineCreateOptions, onLog: (@MainActor (String) -> Void)? = nil) async throws {
         let id = try Self.machineID(for: options)
         guard ManagedContainer.nameValid(id) else {
             throw ContainerizationError(.invalidArgument, message: "machine ID \(id) is not a valid machine ID")
@@ -2913,6 +2921,9 @@ final class LiveContainerService: ContainerServiceBase {
         let bootConfig = try containerSystemConfig.machine.with(Self.machineBootConfigOverrides(for: options))
 
         let client = MachineClient()
+        let reporter = onLog.map { onLog in
+            DownloadReporter(label: "Fetching image", onLog: onLog)
+        }
         let (config, resources) = try await MachineClient.machineConfigFromFlags(
             id: id,
             image: options.reference,
@@ -2920,7 +2931,7 @@ final class LiveContainerService: ContainerServiceBase {
             registry: Self.machineRegistryFlags(for: options),
             imageFetch: Flags.ImageFetch(maxConcurrentDownloads: 3),
             containerSystemConfig: containerSystemConfig,
-            progressUpdate: { _ in }
+            progressUpdate: reporter?.handler ?? Self.noopProgressHandler
         )
         // The image fetch/unpack above can take a while; bail before creating anything if the
         // caller (e.g. a cancelled "Create machine" sheet) no longer wants this.

--- a/Berthly/Core/MockContainerService.swift
+++ b/Berthly/Core/MockContainerService.swift
@@ -820,15 +820,16 @@ final class MockContainerService: ContainerServiceBase {
 // MARK: - Fake progress reporting (issue #97)
 
 extension MockContainerService {
-    /// Shared by `runContainer` and `createMachine` — a short sleep before each line, mirroring
-    /// how a real fetch reports staged progress.
+    /// Shared by `runContainer` and `createMachine`, mirroring how a real fetch reports staged
+    /// progress. Log-then-sleep (matching `startDaemon`'s onLog pacing) gives even the *last*
+    /// line a full 1200ms on screen before the sheet flips to its success state — staged well
+    /// past XCUITest's ~1s `waitForExistence` polling cadence, so a UI test has real room to
+    /// catch the log mid-flight instead of racing a run that finishes before the first poll fires.
     fileprivate func emitFakeProgress(_ lines: [String], onLog: (@MainActor (String) -> Void)?) async throws {
         for line in lines {
-            try? await Task.sleep(for: .milliseconds(150))
-            try Task.checkCancellation()
             onLog?(line)
+            try? await Task.sleep(for: .milliseconds(1200))
+            try Task.checkCancellation()
         }
-        try? await Task.sleep(for: .milliseconds(100))
-        try Task.checkCancellation()
     }
 }

--- a/Berthly/Core/MockContainerService.swift
+++ b/Berthly/Core/MockContainerService.swift
@@ -556,9 +556,8 @@ final class MockContainerService: ContainerServiceBase {
     }
 
     @discardableResult
-    override func runContainer(options: RunOptions) async throws -> String {
-        try? await Task.sleep(for: .milliseconds(400))
-        try Task.checkCancellation()
+    override func runContainer(options: RunOptions, onLog: (@MainActor (String) -> Void)? = nil) async throws -> String {
+        try await emitFakeProgress(["Fetching image… 12.0 MB / 45.0 MB", "Unpacking image…"], onLog: onLog)
 
         let id = (options.name?.isEmpty == false ? options.name! : nil) ?? UUID().uuidString
         let ports = options.ports.compactMap { spec -> PortMapping? in
@@ -598,9 +597,8 @@ final class MockContainerService: ContainerServiceBase {
         return options.command.isEmpty ? "" : "(mock output for: \(options.command.joined(separator: " ")))"
     }
 
-    override func createMachine(options: MachineCreateOptions) async throws {
-        try? await Task.sleep(for: .milliseconds(500))
-        try Task.checkCancellation()
+    override func createMachine(options: MachineCreateOptions, onLog: (@MainActor (String) -> Void)? = nil) async throws {
+        try await emitFakeProgress(["Fetching image… 20.0 MB / 60.0 MB", "Unpacking image…"], onLog: onLog)
 
         let id = (options.name?.isEmpty == false ? options.name! : nil) ?? UUID().uuidString
         let cpus = options.cpus ?? 2
@@ -816,5 +814,21 @@ final class MockContainerService: ContainerServiceBase {
             }
             continuation.onTermination = { _ in task.cancel() }
         }
+    }
+}
+
+// MARK: - Fake progress reporting (issue #97)
+
+extension MockContainerService {
+    /// Shared by `runContainer` and `createMachine` — a short sleep before each line, mirroring
+    /// how a real fetch reports staged progress.
+    fileprivate func emitFakeProgress(_ lines: [String], onLog: (@MainActor (String) -> Void)?) async throws {
+        for line in lines {
+            try? await Task.sleep(for: .milliseconds(150))
+            try Task.checkCancellation()
+            onLog?(line)
+        }
+        try? await Task.sleep(for: .milliseconds(100))
+        try Task.checkCancellation()
     }
 }

--- a/Berthly/Views/MachineCreateSheet.swift
+++ b/Berthly/Views/MachineCreateSheet.swift
@@ -16,6 +16,7 @@ private final class MachineCreateState {
     var isRunning = false
     var result: Result?
     var runTask: Task<Void, Never>?
+    var logLines: [String] = []
 }
 
 private enum HomeMountChoice: String, CaseIterable {
@@ -209,11 +210,16 @@ struct MachineCreateSheet: View {
             }
 
         case nil:
-            HStack(spacing: 8) {
-                ProgressView().controlSize(.small)
-                Text("Creating…")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text("Creating…")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                if !state.logLines.isEmpty {
+                    ProgressLogView(lines: state.logLines, identifier: "machineCreateProgressLog")
+                }
             }
             .padding(14)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -233,6 +239,7 @@ struct MachineCreateSheet: View {
 
         state.isRunning = true
         state.result = nil
+        state.logLines = []
 
         let options = MachineCreateOptions(
             reference: ref,
@@ -248,7 +255,9 @@ struct MachineCreateSheet: View {
 
         state.runTask = Task {
             do {
-                try await service.createMachine(options: options)
+                try await service.createMachine(options: options) { line in
+                    state.logLines.append(line)
+                }
                 state.result = .success(reference: nameTrimmed.isEmpty ? ref : nameTrimmed)
             } catch is CancellationError {
                 state.result = nil

--- a/Berthly/Views/RunContainerSheet.swift
+++ b/Berthly/Views/RunContainerSheet.swift
@@ -19,6 +19,7 @@ private final class RunState {
     var isRunning = false
     var result: Result?
     var runTask: Task<Void, Never>?
+    var logLines: [String] = []
 }
 
 // MARK: - Sheet
@@ -592,11 +593,16 @@ struct RunContainerSheet: View {
             }
 
         case nil:
-            HStack(spacing: 8) {
-                ProgressView().controlSize(.small)
-                Text(progressLabel)
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(spacing: 8) {
+                    ProgressView().controlSize(.small)
+                    Text(progressLabel)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                if !state.logLines.isEmpty {
+                    ProgressLogView(lines: state.logLines, identifier: "runProgressLog")
+                }
             }
             .padding(14)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -665,6 +671,7 @@ struct RunContainerSheet: View {
 
         state.isRunning = true
         state.result = nil
+        state.logLines = []
 
         let options = RunOptions(
             reference: ref,
@@ -714,7 +721,9 @@ struct RunContainerSheet: View {
 
         state.runTask = Task {
             do {
-                let output = try await service.runContainer(options: options)
+                let output = try await service.runContainer(options: options) { line in
+                    state.logLines.append(line)
+                }
                 let newID = service.containers.map(\.id).first { !preRunIDs.contains($0) }
                 state.result = .success(
                     reference: nameTrimmed.isEmpty ? ref : nameTrimmed,

--- a/Berthly/Views/SheetFormEditors.swift
+++ b/Berthly/Views/SheetFormEditors.swift
@@ -431,6 +431,45 @@ struct LocalImageReferenceField: View {
     }
 }
 
+// MARK: - Scrolling progress log (Run Container / Create Machine)
+
+/// A plain-`String` scrolling log, auto-following the newest line — for sheets whose submit
+/// action reports progress via an `onLog` callback (`RunContainerSheet`, `MachineCreateSheet`).
+/// Same look as `DaemonGateView.ProgressLogScreen`'s log block, plus auto-scroll like
+/// `TransferLogView`; kept separate from both since neither's host view is a fit here (one's
+/// `fileprivate` to a different gate flow, the other keys its lines by a `tag`/`text` struct this
+/// plain-string `onLog` stream doesn't have).
+struct ProgressLogView: View {
+    let lines: [String]
+    var identifier: String?
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 2) {
+                    ForEach(Array(lines.enumerated()), id: \.offset) { index, line in
+                        Text(line)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .id(index)
+                    }
+                }
+                .padding(10)
+            }
+            .frame(maxHeight: 120)
+            .background(.background, in: RoundedRectangle(cornerRadius: 8))
+            .overlay(RoundedRectangle(cornerRadius: 8).stroke(.separator, lineWidth: 0.5))
+            .accessibilityIdentifier(identifier ?? "")
+            .onChange(of: lines.count) { _, _ in
+                if let last = lines.indices.last {
+                    withAnimation { proxy.scrollTo(last, anchor: .bottom) }
+                }
+            }
+        }
+    }
+}
+
 // MARK: - Return-key sheet submission
 
 extension View {

--- a/BerthlyTests/BerthlyTests.swift
+++ b/BerthlyTests/BerthlyTests.swift
@@ -1211,6 +1211,15 @@ struct MockContainerServiceTests {
         #expect(created?.status == .running)
     }
 
+    @Test func runContainerReportsProgressViaOnLog() async throws {
+        let mock = MockContainerService()
+        let options = RunOptions(reference: "local/newapp:1.0", name: "newapp-6")
+        var lines: [String] = []
+        try await mock.runContainer(options: options) { lines.append($0) }
+
+        #expect(!lines.isEmpty)
+    }
+
     @Test func createMachineWithBootAppendsRunningMachine() async throws {
         let mock = MockContainerService()
         let countBefore = mock.machines.count

--- a/BerthlyTests/DownloadProgressTests.swift
+++ b/BerthlyTests/DownloadProgressTests.swift
@@ -73,4 +73,34 @@ import TerminalProgress
         let line = p.apply([.setTotalSize(50 * 1_048_576), .setSize(1_048_576)])
         #expect(line!.contains("50.0 MB"))
     }
+
+    // MARK: - setDescription (multi-stage callers, e.g. `container run`'s fetch → unpack → kernel
+    // → init-image sequence, all reported through one progressUpdate stream)
+
+    @Test func setDescriptionEmitsALineEvenWithoutBytes() {
+        var p = DownloadProgress(label: "Fetching image", bucketBytes: 1_000_000)
+        let line = p.apply([.setDescription("Unpacking image")])
+        #expect(line == "Unpacking image…")
+    }
+
+    @Test func setDescriptionOverridesTheFallbackLabel() {
+        var p = DownloadProgress(label: "Fetching image", bucketBytes: 1_000_000)
+        let line = p.apply([.setDescription("Fetching init image"), .addSize(1_048_576)])
+        #expect(line!.hasPrefix("Fetching init image… "))
+    }
+
+    @Test func repeatingTheSameDescriptionIsNotAStageChange() {
+        var p = DownloadProgress(label: "Fetching image", bucketBytes: 1_000_000)
+        _ = p.apply([.setDescription("Fetching kernel")])
+        // Same description again, no new bytes — not a fresh transition, so no line.
+        #expect(p.apply([.setDescription("Fetching kernel")]) == nil)
+    }
+
+    @Test func newStageResetsByteCounters() {
+        var p = DownloadProgress(label: "Fetching image", bucketBytes: 1_000_000)
+        _ = p.apply([.addSize(2_000_000), .addTotalSize(5_000_000)])
+        _ = p.apply([.setDescription("Fetching kernel")])
+        #expect(p.downloadedBytes == 0)
+        #expect(p.totalBytes == 0)
+    }
 }

--- a/BerthlyUITests/BerthlyUITests.swift
+++ b/BerthlyUITests/BerthlyUITests.swift
@@ -176,6 +176,56 @@ final class BerthlyUITests: XCTestCase {
         XCTAssertFalse(app.buttons["Start Container System"].exists)
     }
 
+    /// Issue #97: RunContainerSheet's "Starting…" state used to be a bare spinner with no
+    /// indication of what was happening (a first boot needing a fresh kernel/init-image fetch
+    /// could sit there for minutes). Same "wait for the last line" technique as
+    /// `testStartContainerSystemShowsProgress` — logLines is append-only within a run, so
+    /// catching the last line also guarantees the first one already rendered.
+    @MainActor
+    func testRunContainerShowsProgressLog() throws {
+        let app = XCUIApplication.berthly()
+        app.launchEnvironment["UITEST_USE_MOCK_SERVICE"] = "1"
+        app.launch()
+
+        let runButton = app.buttons["runToolbarButton"]
+        XCTAssertTrue(runButton.waitForExistence(timeout: 10))
+        runButton.click()
+        app.buttons["Run Container"].click()
+
+        let referenceField = app.windows.textFields.firstMatch
+        XCTAssertTrue(referenceField.waitForExistence(timeout: 5), "RunContainerSheet image field should appear")
+        referenceField.click()
+        referenceField.typeText("local/web:1.4")
+        app.buttons["runSubmitButton"].click()
+
+        XCTAssertTrue(app.staticTexts["Unpacking image…"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Fetching image… 12.0 MB / 45.0 MB"].exists)
+    }
+
+    /// Same regression and technique as `testRunContainerShowsProgressLog`, for
+    /// MachineCreateSheet's "Creating…" state.
+    @MainActor
+    func testCreateMachineShowsProgressLog() throws {
+        let app = XCUIApplication.berthly()
+        app.launchEnvironment["UITEST_USE_MOCK_SERVICE"] = "1"
+        app.launch()
+
+        app.typeKey("k", modifierFlags: .command)
+        let searchField = app.textFields["commandPaletteSearchField"]
+        XCTAssertTrue(searchField.waitForExistence(timeout: 5))
+        searchField.typeText("create machine")
+        app.typeKey(.return, modifierFlags: [])
+
+        let referenceField = app.windows.textFields.firstMatch
+        XCTAssertTrue(referenceField.waitForExistence(timeout: 5), "MachineCreateSheet image field should appear")
+        referenceField.click()
+        referenceField.typeText("ubuntu:24.04")
+        app.buttons["machineCreateSubmitButton"].click()
+
+        XCTAssertTrue(app.staticTexts["Unpacking image…"].waitForExistence(timeout: 5))
+        XCTAssertTrue(app.staticTexts["Fetching image… 20.0 MB / 60.0 MB"].exists)
+    }
+
     /// Regression: `DaemonStatusBar`'s "Running (warning)" state (icon/color/word swap, plus a
     /// `.help()` tooltip carrying the actual message) had no UI coverage at all — set via
     /// `UITEST_STARTUP_WARNING` seeding `lastStartupWarning` on the mock, which defaults to

--- a/BerthlyUITests/BerthlyUITests.swift
+++ b/BerthlyUITests/BerthlyUITests.swift
@@ -196,7 +196,11 @@ final class BerthlyUITests: XCTestCase {
         XCTAssertTrue(referenceField.waitForExistence(timeout: 5), "RunContainerSheet image field should appear")
         referenceField.click()
         referenceField.typeText("local/web:1.4")
-        app.buttons["runSubmitButton"].click()
+        // Return, not a coordinate `.click()` on runSubmitButton — on a loaded CI runner XCUITest
+        // can fail to compute a hittable point in time and fall back to a stale center point,
+        // missing the button (see the ui-testing skill's CI flake notes). A key event has no
+        // coordinates to race; the sheet already bubbles Return from any field to submit.
+        app.typeKey(.return, modifierFlags: [])
 
         XCTAssertTrue(app.staticTexts["Unpacking image…"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["Fetching image… 12.0 MB / 45.0 MB"].exists)
@@ -220,7 +224,8 @@ final class BerthlyUITests: XCTestCase {
         XCTAssertTrue(referenceField.waitForExistence(timeout: 5), "MachineCreateSheet image field should appear")
         referenceField.click()
         referenceField.typeText("ubuntu:24.04")
-        app.buttons["machineCreateSubmitButton"].click()
+        // Return, not a coordinate click — see testRunContainerShowsProgressLog's comment.
+        app.typeKey(.return, modifierFlags: [])
 
         XCTAssertTrue(app.staticTexts["Unpacking image…"].waitForExistence(timeout: 5))
         XCTAssertTrue(app.staticTexts["Fetching image… 20.0 MB / 60.0 MB"].exists)


### PR DESCRIPTION
## Summary
- `RunContainerSheet` and `MachineCreateSheet` showed only a bare spinner + "Starting…"/"Creating…" during a run/create, with zero feedback while a first boot fetches a kernel or init image (can take minutes). `LiveContainerService` already threw this progress away via `progressUpdate: { _ in }`.
- Wires `runContainer`/`createMachine`'s `progressUpdate` into the existing `onLog` pattern (`DaemonGateView`'s install/update flows, `BuildImageSheet`) via `DownloadReporter`.
- Extends `DownloadProgress` to surface stage descriptions ("Fetching init image", etc. — the same labels the CLI's own `[N/6]` progress uses) so a stage transition is visible immediately, not just once bytes start moving.
- Both sheets render the log via a new shared `ProgressLogView` (auto-scrolling, same visual style as the existing daemon-start log).
- Fixes the mock's fake-progress timing along the way: at 150ms/line the whole run finished before XCUITest's first ~1s poll ever fired (same failure mode already documented and fixed on `startDaemon`'s mock). Log-then-sleep at 1200ms/line, matching `startDaemon`, gives even the last line a full 1200ms on screen before the sheet flips to its success state.

Closes #97

## Test plan
- [x] Manual verification against the real daemon: removed a cached 9GB image, ran it through the UI, confirmed live byte-progress lines ("Fetching image… 220.0 MB / 274.0 MB") streamed and the container started successfully.
- [x] `BerthlyTests` — new `DownloadProgressTests` cases for stage-description behavior, plus a `MockContainerService` onLog test. Full suite passes.
- [x] `BerthlyUITests` — new `testRunContainerShowsProgressLog` / `testCreateMachineShowsProgressLog`, run 4x each with no flakes. Existing submit-related tests re-verified against the new mock timing.
- [x] `swiftlint lint --strict` — 0 violations