### PR TITLE
fix: hide k8s cluster containers from the Compute list

### DIFF
--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -969,10 +969,15 @@ final class LiveContainerService: ContainerServiceBase {
         let builderSnaps = (try? await Self.fetchBuilderSnaps()) ?? []
         let builderIds = Set(builderSnaps.map { $0.id })
 
+        // k8s cluster containers (control-plane and workers) are infrastructure, same as builders —
+        // hidden from the Compute list rather than shown with Start/Stop actions that would leave
+        // ~/.kube/config out of sync with the cluster's actual state (see fetchK8sSnaps()).
+        let k8sIds = Set((try? await Self.fetchK8sSnaps())?.map { $0.id } ?? [])
+
         do {
             let allSnaps = try await ContainerClient().list()
             containers = allSnaps
-                .filter { !machineContainerIds.contains($0.id) && !builderIds.contains($0.id) }
+                .filter { !machineContainerIds.contains($0.id) && !builderIds.contains($0.id) && !k8sIds.contains($0.id) }
                 .map { mapContainer($0) }
         } catch {
             containers = []


### PR DESCRIPTION
## Summary
- A running `container k8s` cluster container (control-plane or worker node) showed up in the Compute list as an ordinary container with hover Start/Stop.
- Stopping a cluster container from Berthly doesn't refresh `~/.kube/config` the way `container k8s start` does — the cluster's container IP can change across restarts, so this left the kubeconfig entry pointing at a dead endpoint.
- Filters k8s cluster containers out of the Compute list entirely, matching the existing builder-hiding pattern and reusing `fetchK8sSnaps()` from #105/#111.

## Test plan
- [x] `xcodebuild build` succeeds
- [x] `BerthlyTests` suite passes
- [x] `swiftlint lint --strict` — 0 violations

Fixes #106