### PR TITLE
chore: bump apple/container SPM pin to 1.2.2

### DIFF
--- a/Berthly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Berthly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/container",
       "state" : {
-        "revision" : "6e65319fe476ffe8db8ddaf828a537ed36fe2859",
-        "version" : "1.2.0"
+        "revision" : "0190097d06df0b9065f4c2d2c7873c649d81d493",
+        "version" : "1.2.2"
       }
     },
     {

--- a/Berthly/Core/ContainerCompatibility.swift
+++ b/Berthly/Core/ContainerCompatibility.swift
@@ -14,7 +14,7 @@ import Foundation
 /// which nonisolated callers (e.g. test suites) warn on under Swift 6 checking.
 nonisolated enum ContainerCompatibility {
     /// Keep in sync with the `container` SPM package pin (Package.resolved / Package.swift).
-    static let requiredVersion = "1.2.0"
+    static let requiredVersion = "1.2.2"
 
     /// One-line, hand-written summary of what `requiredVersion` adds — shown on the
     /// version-mismatch gate so an upgrade prompt isn't just two bare version numbers. Update

--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -2561,6 +2561,9 @@ final class LiveContainerService: ContainerServiceBase {
             contentStore: RemoteContentStoreClient(),
             buildArgs: options.buildArgs.sorted(by: { $0.key < $1.key }).map { "\($0.key)=\($0.value)" },
             secrets: secretsData,
+            // Berthly's build sheet has no ssh forwarding UI yet (see #110); "" matches
+            // upstream's BuildCommand default when --ssh isn't passed.
+            ssh: "",
             contextDir: options.contextPath,
             dockerfile: dockerfileData,
             dockerignore: dockerignoreData,
@@ -2722,6 +2725,9 @@ final class LiveContainerService: ContainerServiceBase {
             kernel: nil,
             kernelArgs: options.kernelArgs,
             labels: options.labels.sorted(by: { $0.key < $1.key }).map { "\($0.key)=\($0.value)" },
+            // maskedPaths/readonlyPaths (1.2.1, EXPERIMENTAL upstream) have no Berthly UI yet —
+            // empty means "use the runtime defaults" (see PARITY.md's Deliberate gaps).
+            maskedPaths: [],
             mounts: options.mounts,
             name: nilIfEmpty(options.name),
             networks: options.networks,
@@ -2730,6 +2736,7 @@ final class LiveContainerService: ContainerServiceBase {
             publishPorts: options.ports,
             publishSockets: [],
             readOnly: options.readOnly,
+            readonlyPaths: [],
             remove: options.remove,
             rosetta: options.rosetta,
             runtime: nil,


### PR DESCRIPTION
## Summary
- Bumps the `apple/container` SPM dependency from 1.2.0 to 1.2.2. Optional hygiene, not required for compatibility — `ContainerCompatibility`'s gate compares major.minor only, and 1.2.0 already accepted a 1.2.2 daemon with no functional gap.
- Also bumps `ContainerCompatibility.requiredVersion` to 1.2.2 to keep it in sync with the pin (per its own doc comment); no behavior change, since the comparator only looks at major.minor and both strings resolve to "1.2".
- Two mechanical fixes for API surface the 1.2.1/1.2.2 package added:
  - `Builder.BuildConfig` gained non-optional `ssh: String` — passed `""`, matching upstream's own `BuildCommand` default when `--ssh` isn't passed (no Berthly build sheet UI yet, tracked in #110).
  - `Flags.Management` gained `maskedPaths`/`readonlyPaths` — passed `[]`, which the vendored `Parser` treats identically to the flags not being passed at all (no Berthly UI, both still marked EXPERIMENTAL upstream).
- `containerization` stays pinned at 0.40.1 — unchanged upstream between 1.2.0 and 1.2.2.

## Test plan
- [x] `xcodebuild build` succeeds
- [x] `BerthlyTests` suite passes
- [x] `swiftlint lint --strict` — 0 violations

Fixes #109