### PR TITLE
feat: add SSH agent forwarding to the Build sheet

### DIFF
--- a/Berthly/Core/BuildJobManager.swift
+++ b/Berthly/Core/BuildJobManager.swift
@@ -159,7 +159,7 @@ final class BuildJobManager {
 
 extension BuildContext {
     /// The persistable subset of `BuildOptions` (machine-specific fields like
-    /// cpus/memory/secrets/pull intentionally reset on Rebuild).
+    /// cpus/memory/secrets/pull/ssh intentionally reset on Rebuild).
     nonisolated init(options: BuildOptions) {
         self.init(
             contextPath: options.contextPath,

--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -1471,12 +1471,17 @@ final class LiveContainerService: ContainerServiceBase {
 
     /// Native replication of `container builder start` with default resources: reuses the same
     /// create-or-bootstrap path builds go through (`startBuilderContainer`), so a matching stopped
-    /// builder is booted in place and a config-drifted one is recreated. Log output is dropped —
-    /// the row's spinner covers the (fast, image-already-present) boot; first-ever builder
-    /// creation with its image download normally happens via a build, which does stream logs.
+    /// builder is booted in place and a config-drifted one (image/cpu/memory/ssh — see the `ssh:
+    /// false` note below) is recreated. Log output is dropped — the row's spinner covers the
+    /// (fast, image-already-present) boot; first-ever builder creation with its image download
+    /// normally happens via a build, which does stream logs.
     override func startBuilder(_ id: String) async throws {
         let config = await resolvedSystemConfig()
-        try await startBuilderContainer(containerSystemConfig: config, cpus: nil, memory: nil, onLog: { _ in })
+        // Matches the CLI's plain `container builder start`, which has no --ssh flag and so
+        // always passes ssh: false to BuilderStart.start() — an ssh-enabled builder started
+        // manually here (rather than by a build requesting it) gets recreated without forwarding,
+        // same as upstream.
+        try await startBuilderContainer(containerSystemConfig: config, cpus: nil, memory: nil, ssh: false, onLog: { _ in })
         await refresh()
     }
 
@@ -2324,20 +2329,64 @@ final class LiveContainerService: ContainerServiceBase {
         return try raw.split(separator: ",").map { try Platform(from: $0.trimmingCharacters(in: .whitespaces)) }
     }
 
-    /// Dials the running builder over VSOCK; if that fails (not running yet), starts it via
-    /// `startBuilderContainer` (our replication of the CLI's non-public `BuilderStart.start`)
-    /// and retries every 5s, up to a 300s deadline — matching `BuildCommand.run`'s own retry loop.
+    /// Maps `BuildOptions.ssh` onto `Builder.BuildConfig.ssh`'s string encoding — `"default"`
+    /// forwards the host's SSH agent socket, `""` requests nothing. Throws up front when the box
+    /// is checked but there's no socket to forward, matching `BuildCommand`'s own `--ssh`
+    /// validation ("`--ssh default requires SSH_AUTH_SOCK to be set`") — the alternative is
+    /// silently telling buildkit to expect a forwarded agent that `startBuilderContainer` (via
+    /// `resolveBuilderSSH`) never actually wires into the builder container, which would surface
+    /// as a confusing failure deep inside a `RUN --mount=type=ssh` step instead of here.
+    nonisolated static func buildConfigSSH(for options: BuildOptions, environment: [String: String] = ProcessInfo.processInfo.environment) throws -> String {
+        guard options.ssh else { return "" }
+        guard environment["SSH_AUTH_SOCK"] != nil else {
+            throw ContainerizationError(.invalidArgument, message: "SSH agent forwarding requested, but SSH_AUTH_SOCK is not set.")
+        }
+        return "default"
+    }
+
+    /// Whether the builder container should actually get SSH agent forwarding: the user asked for
+    /// it *and* a socket is available to forward. Matches upstream's `BuilderStart.start()`
+    /// (`ssh && ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"] != nil`). By the time this
+    /// runs, `buildImage`'s `buildConfigSSH` call has already thrown if `options.ssh` were true
+    /// with no socket present, so this is a defensive mirror of upstream's own check (also covers
+    /// the direct `startBuilder(_:)` System-page path, which always passes `ssh: false` and never
+    /// touches `buildConfigSSH` at all) rather than the sole gate.
+    nonisolated static func resolveBuilderSSH(requested: Bool, environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool {
+        requested && environment["SSH_AUTH_SOCK"] != nil
+    }
+
+    /// Resolves the builder to this build's requested cpus/memory/ssh, then dials it over VSOCK.
+    /// `startBuilderContainer` runs first, unconditionally — not just when a dial fails — so an
+    /// already-running builder whose settings no longer match gets recreated instead of silently
+    /// reused. Matches `BuildCommand.run`'s own ordering (its comment: "Ensure the builder is
+    /// started (or restarted) with the correct SSH configuration before attempting to dial. This
+    /// handles the case where the builder is already running but was not started with SSH
+    /// forwarding enabled."). Cheap when nothing changed — the running-builder path in
+    /// `startBuilderContainer` is a health ping, a `client.get`, and an early return, no image
+    /// fetch or container churn — so this doesn't slow down the common case. One side effect:
+    /// requesting a differing cpus/memory (not just ssh) now also recreates the builder — matching
+    /// upstream, and fixing a latent gap where those changes were previously silently ignored
+    /// whenever the builder happened to already be running (recreation only used to run once dial
+    /// failed) — but it does mean a malformed `--memory` string, which `Parser.resources` rejects,
+    /// now surfaces even on that path instead of being silently skipped. The dial itself still
+    /// retries every 5s up to a 300s deadline, since `startBuilderContainer` returning doesn't
+    /// guarantee the shim's gRPC server inside the guest is already accepting connections.
     private func dialOrStartBuilder(
         containerSystemConfig: ContainerSystemConfig,
         cpus: Int64?,
         memory: String?,
+        ssh: Bool,
         onLog: @MainActor @escaping (String) -> Void
     ) async throws -> (builder: ContainerBuild.Builder, group: MultiThreadedEventLoopGroup) {
         let deadline = Date().addingTimeInterval(300)
-        // Whether we've had to start the builder this call. Gates the user-facing messages so the
-        // common fast path (builder already running → first dial succeeds) stays silent, and the
-        // retry loop announces the start exactly once instead of on every failed dial.
-        var announcedStart = false
+        // `startBuilderContainer` only calls `onLog` when it actually does work (fresh create or
+        // recreate) — this tracks that so "Build environment ready." only bookends a real start,
+        // not the silent fast path where a matching builder was already running.
+        var announcedWork = false
+        try await startBuilderContainer(containerSystemConfig: containerSystemConfig, cpus: cpus, memory: memory, ssh: ssh, onLog: { line in
+            announcedWork = true
+            onLog(line)
+        })
         while true {
             do {
                 let socket = try await ContainerClient().dial(id: ContainerBuild.Builder.builderContainerId, port: 8088)
@@ -2345,7 +2394,7 @@ final class LiveContainerService: ContainerServiceBase {
                 do {
                     let builder = try await ContainerBuild.Builder(socket: socket, group: group, logger: Self.log)
                     _ = try await builder.info()
-                    if announcedStart { onLog("Build environment ready.") }
+                    if announcedWork { onLog("Build environment ready.") }
                     return (builder, group)
                 } catch {
                     try? await group.shutdownGracefully()
@@ -2355,26 +2404,20 @@ final class LiveContainerService: ContainerServiceBase {
                 guard Date() < deadline else {
                     throw ContainerizationError(.timeout, message: "Timed out waiting for the builder to start.")
                 }
-                // Without this, the build log sits empty through the builder image download and VM
-                // boot (tens of seconds on first build) and looks hung.
-                if !announcedStart {
-                    onLog("Starting the build environment…")
-                    announcedStart = true
-                }
-                try await startBuilderContainer(containerSystemConfig: containerSystemConfig, cpus: cpus, memory: memory, onLog: onLog)
                 try await Task.sleep(for: .seconds(5))
             }
         }
     }
 
     /// Native replication of the CLI's non-public `BuilderStart.start()`: reuses a running/stopped
-    /// "buildkit" container when its image/cpu/memory still match, otherwise (re)creates it —
+    /// "buildkit" container when its image/cpu/memory/ssh still match, otherwise (re)creates it —
     /// fetching the builder image, wiring the tmpfs `/run` + virtiofs exports mounts, network, and
     /// kernel exactly as the CLI does — then bootstraps the `container-builder-shim` process.
     private func startBuilderContainer(
         containerSystemConfig: ContainerSystemConfig,
         cpus: Int64?,
         memory: String?,
+        ssh: Bool,
         onLog: @MainActor @escaping (String) -> Void
     ) async throws {
         let builderImage = containerSystemConfig.build.image
@@ -2391,6 +2434,7 @@ final class LiveContainerService: ContainerServiceBase {
             defaultCPUs: containerSystemConfig.build.cpus,
             defaultMemory: containerSystemConfig.build.memory
         )
+        let wantsSSH = Self.resolveBuilderSSH(requested: ssh)
 
         let client = ContainerClient()
         let builderContainerId = ContainerBuild.Builder.builderContainerId
@@ -2398,10 +2442,17 @@ final class LiveContainerService: ContainerServiceBase {
             let imageChanged = existing.configuration.image.reference != builderImage
             let cpuChanged = existing.configuration.resources.cpus != resources.cpus
             let memChanged = existing.configuration.resources.memoryInBytes != resources.memoryInBytes
-            let needsRecreate = imageChanged || cpuChanged || memChanged
+            // `config.ssh` gates the host↔guest agent-socket forwarding itself, set only at
+            // container creation — bootstrapBuilderShim's SSH_AUTH_SOCK env var alone (below)
+            // just tells the shim where to look, it can't wire up forwarding a stale container
+            // never had. So a request that flips ssh on/off must trigger a recreate too, exactly
+            // like an image/cpu/memory change.
+            let sshChanged = existing.configuration.ssh != wantsSSH
+            let needsRecreate = imageChanged || cpuChanged || memChanged || sshChanged
             switch existing.status {
             case .running:
                 guard needsRecreate else { return }
+                onLog("Restarting the build environment for updated settings…")
                 try await client.stop(id: existing.id)
                 try await client.delete(id: existing.id)
             case .stopped:
@@ -2409,12 +2460,15 @@ final class LiveContainerService: ContainerServiceBase {
                     try await bootstrapBuilderShim(client: client, id: existing.id)
                     return
                 }
+                onLog("Restarting the build environment for updated settings…")
                 try await client.delete(id: existing.id)
             case .stopping:
                 throw ContainerizationError(.invalidState, message: "Builder is stopping; wait until it's fully stopped before rebuilding.")
             case .unknown:
                 break
             }
+        } else {
+            onLog("Starting the build environment…")
         }
 
         let useRosetta = containerSystemConfig.build.rosetta
@@ -2451,6 +2505,7 @@ final class LiveContainerService: ContainerServiceBase {
 
         var config = ContainerConfiguration(id: builderContainerId, image: imageDesc, process: processConfig)
         config.resources = resources
+        config.ssh = wantsSSH
         config.labels = [
             ResourceLabelKeys.plugin: "builder",
             ResourceLabelKeys.role: ResourceRoleValues.builder
@@ -2529,11 +2584,12 @@ final class LiveContainerService: ContainerServiceBase {
         let secretsData = try Self.resolveBuildSecrets(options.secrets)
         let tags = try Self.buildTags(for: options)
         let platforms = try Self.buildPlatforms(for: options)
+        let sshConfig = try Self.buildConfigSSH(for: options)
 
         let containerSystemConfig = await resolvedSystemConfig()
         let builderConnection = try await dialOrStartBuilder(containerSystemConfig: containerSystemConfig,
                                                              cpus: options.cpus.map { Int64($0) },
-                                                             memory: options.memory, onLog: onLog)
+                                                             memory: options.memory, ssh: options.ssh, onLog: onLog)
         let builder = builderConnection.builder
         let builderGroup = builderConnection.group
         defer {
@@ -2561,9 +2617,7 @@ final class LiveContainerService: ContainerServiceBase {
             contentStore: RemoteContentStoreClient(),
             buildArgs: options.buildArgs.sorted(by: { $0.key < $1.key }).map { "\($0.key)=\($0.value)" },
             secrets: secretsData,
-            // Berthly's build sheet has no ssh forwarding UI yet (see #110); "" matches
-            // upstream's BuildCommand default when --ssh isn't passed.
-            ssh: "",
+            ssh: sshConfig,
             contextDir: options.contextPath,
             dockerfile: dockerfileData,
             dockerignore: dockerignoreData,

--- a/Berthly/Core/Models.swift
+++ b/Berthly/Core/Models.swift
@@ -751,6 +751,7 @@ nonisolated struct BuildOptions {
     var memory: String?
     var secrets: [String] = []
     var pull: Bool = false
+    var ssh: Bool = false
 }
 
 // MARK: - Run / Create container

--- a/Berthly/Views/BuildImageSheet.swift
+++ b/Berthly/Views/BuildImageSheet.swift
@@ -32,6 +32,7 @@ struct BuildImageSheet: View {
     @State private var memory: String = ""
     @State private var secrets: [StringEntry] = []
     @State private var pull: Bool = false
+    @State private var ssh: Bool = false
 
     @State private var job: BuildJob?
     @FocusState private var isTagFieldFocused: Bool
@@ -301,6 +302,14 @@ struct BuildImageSheet: View {
                         entries: $secrets
                     )
 
+                    VStack(alignment: .leading, spacing: 4) {
+                        Toggle("Forward SSH agent", isOn: $ssh)
+                            .toggleStyle(.checkbox)
+                        Text("For \(Text("git clone").fontDesign(.monospaced)) of private dependencies in the Dockerfile. Requires SSH_AUTH_SOCK to be set.")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+
                     Toggle("Pull latest base images", isOn: $pull)
                         .toggleStyle(.checkbox)
                 }
@@ -442,7 +451,8 @@ struct BuildImageSheet: View {
             cpus: Int(cpus.trimmingCharacters(in: .whitespaces)),
             memory: memoryTrimmed.isEmpty ? nil : memoryTrimmed,
             secrets: secrets.map { $0.value.trimmingCharacters(in: .whitespaces) }.filter { !$0.isEmpty },
-            pull: pull
+            pull: pull,
+            ssh: ssh
         )
 
         job = buildManager.start(options: options, service: service)

--- a/BerthlyTests/BerthlyTests.swift
+++ b/BerthlyTests/BerthlyTests.swift
@@ -159,6 +159,46 @@ struct BuildMappingTests {
         #expect(platforms.count == 1)
         #expect(platforms[0].os == "linux")
     }
+
+    // buildConfigSSH mirrors BuildCommand's own --ssh flag encoding: "default" or "" are the only
+    // two values it accepts (see its `ssh` validation switch), so those are the only two outputs.
+    @Test func buildConfigSSHRequestedMapsToDefaultWhenSocketPresent() throws {
+        let options = BuildOptions(reference: "local/web:1.0", contextPath: "/tmp/web", ssh: true)
+        let result = try LiveContainerService.buildConfigSSH(for: options, environment: ["SSH_AUTH_SOCK": "/tmp/agent.sock"])
+        #expect(result == "default")
+    }
+
+    @Test func buildConfigSSHNotRequestedMapsToEmptyString() throws {
+        let options = BuildOptions(reference: "local/web:1.0", contextPath: "/tmp/web", ssh: false)
+        let result = try LiveContainerService.buildConfigSSH(for: options, environment: [:])
+        #expect(result == "")
+    }
+
+    // Regression: requesting ssh forwarding with no agent socket available must fail fast, here —
+    // not as "default" silently reaching buildkit while `resolveBuilderSSH` (used by the builder
+    // container itself) independently degrades to no forwarding, which would surface as a
+    // confusing failure deep inside a `RUN --mount=type=ssh` step instead.
+    @Test func buildConfigSSHThrowsWhenRequestedWithNoSocket() {
+        let options = BuildOptions(reference: "local/web:1.0", contextPath: "/tmp/web", ssh: true)
+        #expect(throws: (any Error).self) {
+            try LiveContainerService.buildConfigSSH(for: options, environment: [:])
+        }
+    }
+
+    // resolveBuilderSSH decides whether the builder container actually gets agent forwarding —
+    // both "asked for it" and "a socket exists to forward" must hold, matching upstream's
+    // `ssh && SSH_AUTH_SOCK != nil` in BuilderStart.start().
+    @Test func resolveBuilderSSHTrueWhenRequestedAndSocketPresent() {
+        #expect(LiveContainerService.resolveBuilderSSH(requested: true, environment: ["SSH_AUTH_SOCK": "/tmp/agent.sock"]))
+    }
+
+    @Test func resolveBuilderSSHFalseWhenNotRequested() {
+        #expect(!LiveContainerService.resolveBuilderSSH(requested: false, environment: ["SSH_AUTH_SOCK": "/tmp/agent.sock"]))
+    }
+
+    @Test func resolveBuilderSSHFalseWhenNoSocketAvailable() {
+        #expect(!LiveContainerService.resolveBuilderSSH(requested: true, environment: [:]))
+    }
 }
 
 // MARK: - LiveContainerService run*Flags (pure RunOptions -> Flags.* mapping)

--- a/PARITY.md
+++ b/PARITY.md
@@ -34,7 +34,7 @@ Rosetta, virtualization.
 
 | CLI | Berthly |
 |---|---|
-| `build` | Build sheet (context, Dockerfile, tag, platform, build args, labels, target, no-cache, secrets, cpus/memory, pull) with streaming logs |
+| `build` | Build sheet (context, Dockerfile, tag, platform, build args, labels, target, no-cache, secrets, ssh, cpus/memory, pull) with streaming logs |
 | `pull` / `push` | Pull/Push sheets with progress; per-platform and insecure-registry options |
 | `save` / `load` | Save/Load OCI tar archive sheets |
 | `tag` | Tag sheet |


### PR DESCRIPTION
## Summary
- Adds a "Forward SSH agent" toggle to the Build sheet's Advanced section, backed by `BuildOptions.ssh` — closes the gap left after apple/container 1.2.1 added `--ssh` to `container build` (apple/container#1508) for forwarding an agent socket into the build container (needed for `git clone` of private Dockerfile dependencies).
- **Validates up front, matching upstream.** `LiveContainerService.buildConfigSSH(for:environment:)` throws immediately if the toggle is checked but `SSH_AUTH_SOCK` isn't set — the same check `BuildCommand`'s own `--ssh` flag does ("`--ssh default requires SSH_AUTH_SOCK to be set`"). Without this, the build would tell buildkit to expect a forwarded agent that the builder container never got wired up with (`ContainerConfiguration.ssh` gates the actual host↔guest socket forwarding, separately from the shim's `SSH_AUTH_SOCK` env var), surfacing as a confusing failure deep inside a `RUN --mount=type=ssh` step instead of a clear error at build start.
- **Fixes a real ordering bug that would otherwise make ssh forwarding silently not work.** `dialOrStartBuilder` used to only call `startBuilderContainer` (the create-or-recreate decision) when the first dial to an already-running builder failed. That meant a builder still running from an earlier, ssh-less build would just get reused — a later build that checks the box would silently get no forwarding. Restructured to call `startBuilderContainer` unconditionally before dialing, matching `BuildCommand.run`'s own ordering upstream (its comment: *"Ensure the builder is started (or restarted) with the correct SSH configuration before attempting to dial. This handles the case where the builder is already running but was not started with SSH forwarding enabled."*). Cheap when nothing changed — the running-builder path is a health ping, a `client.get`, and an early return.
- Side effect of that reordering, worth calling out explicitly: a differing `cpus`/`memory` request now also recreates an already-running builder — this matches upstream and fixes a latent gap (those changes previously went unnoticed against a running builder until it was next restarted from cold), but it does mean this PR's diff isn't purely additive to the recreate logic.
- `startBuilder(_:)` (System page's manual Start) always passes `ssh: false`, matching the CLI's plain `container builder start`, which has no `--ssh` flag — an ssh-enabled builder started manually there gets recreated without forwarding, same as upstream.

## Test plan
- [x] `xcodebuild build` succeeds
- [x] `BerthlyTests` suite passes, including new `buildConfigSSH`/`resolveBuilderSSH` coverage
- [x] `BerthlyUITests` build-sheet tests pass (`testBuildSheetOpensAndClosesWithoutCrashing`, `testBuildContinuesInBackgroundAndSurfacesInBuildsIndicator`, `testBuildSurvivesMainWindowCloseAndResultIsWaitingOnReopen`) — mock mode only, doesn't reach the restructured `dialOrStartBuilder` path
- [x] `scripts/e2e.sh ResourceJourneyTests/testBuildImageFromDockerfileThenRun` against a real local daemon — confirms the restructured dial-then-start ordering doesn't regress the ordinary (non-ssh) build path when a matching builder is already running
- [x] `swiftlint lint --strict` — 0 violations

Fixes #110