### PR TITLE
fix: add missing string catalog entries for build SSH toggle

### DIFF
--- a/Berthly/Localizable.xcstrings
+++ b/Berthly/Localizable.xcstrings
@@ -656,6 +656,9 @@
     "Following" : {
 
     },
+    "For %@ of private dependencies in the Dockerfile. Requires SSH_AUTH_SOCK to be set." : {
+
+    },
     "For a private image," : {
 
     },
@@ -678,6 +681,9 @@
 
     },
     "General" : {
+
+    },
+    "git clone" : {
 
     },
     "grows up to %@" : {


### PR DESCRIPTION
## Summary
- #110 added the Build sheet's "Forward SSH agent" toggle and its help text (which interpolates a styled `Text("git clone")`), but `Localizable.xcstrings` merged without entries for the two new strings — string-catalog extraction is triggered by Xcode's build system inconsistently, and it wasn't caught before that PR's final commit.
- Adds the two missing entries, matching the exact format and alphabetical placement Xcode itself generates (verified against a build that did regenerate them, then hand-applied since a later rebuild in this session didn't re-trigger extraction).

## Test plan
- [x] `xcodebuild build` succeeds
- [x] `Localizable.xcstrings` validates as well-formed JSON
- [x] `swiftlint lint --strict` — 0 violations