### PR TITLE
test: add E2E coverage for Build sheet SSH agent forwarding

### DIFF
--- a/Berthly/Views/BuildImageSheet.swift
+++ b/Berthly/Views/BuildImageSheet.swift
@@ -305,6 +305,7 @@ struct BuildImageSheet: View {
                     VStack(alignment: .leading, spacing: 4) {
                         Toggle("Forward SSH agent", isOn: $ssh)
                             .toggleStyle(.checkbox)
+                            .accessibilityIdentifier("buildSshToggle")
                         Text("For \(Text("git clone").fontDesign(.monospaced)) of private dependencies in the Dockerfile. Requires SSH_AUTH_SOCK to be set.")
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
@@ -385,6 +386,7 @@ struct BuildImageSheet: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(3)
+                    .accessibilityIdentifier("buildErrorMessage")
             }
             .padding(14)
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/BerthlyE2ETests/BerthlyE2ETests.swift
+++ b/BerthlyE2ETests/BerthlyE2ETests.swift
@@ -863,6 +863,81 @@ final class ResourceJourneyTests: BerthlyE2ETestCase {
                       "the built image should carry what the Dockerfile baked in:\n\(out.output)")
         // image (berthly-e2e/…) swept by prefix in tearDown.
     }
+
+    /// Proves the Build sheet's "Forward SSH agent" toggle (#110) actually wires a forwarded
+    /// agent socket into the builder — not just that a build with the box checked doesn't error.
+    /// The Dockerfile's own `RUN --mount=type=ssh` step is the oracle: it fails the build outright
+    /// if `SSH_AUTH_SOCK` isn't present and pointing at a real socket inside that step's
+    /// environment, so a passing build is real proof of forwarding, not a false positive from an
+    /// untested code path.
+    ///
+    /// Skips rather than fails when this Mac's SSH agent socket isn't visible to the *app*
+    /// process specifically (GUI launch doesn't reliably inherit a login shell's SSH_AUTH_SOCK) —
+    /// `LiveContainerService.buildConfigSSH`'s own up-front validation is the oracle for that: it
+    /// throws a specific, recognizable message before ever touching the builder, which surfaces
+    /// here as the sheet's failure state instead of the guest-side `RUN` failure a genuine
+    /// forwarding bug would produce.
+    @MainActor
+    func testBuildWithSSHForwardingMountsAgentSocket() throws {
+        try ContainerCLI.ensureImage(Self.fixtureImage)
+
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(Self.resourcePrefix)-ctx-\(UUID().uuidString.prefix(8))")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let dockerfile = """
+        FROM alpine:latest
+        RUN --mount=type=ssh sh -c 'test -n "$SSH_AUTH_SOCK" && test -S "$SSH_AUTH_SOCK"'
+        LABEL berthly.e2e=build
+        """
+        try dockerfile.write(to: dir.appendingPathComponent("Dockerfile"),
+                             atomically: true, encoding: .utf8)
+        let tag = "\(Self.resourcePrefix)/img-ssh-\(UUID().uuidString.prefix(8).lowercased()):1"
+
+        let app = XCUIApplication.berthlyE2E()
+        app.launch()
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 15))
+
+        XCTAssertTrue(app.openViaPalette("Build Image"))
+        let tagField = app.windows.textFields["buildTagField"]
+        XCTAssertTrue(tagField.waitForExistence(timeout: 5), "Build sheet should appear")
+        tagField.click(); tagField.typeText(tag)
+        let ctxField = app.windows.textFields["buildContextField"]
+        ctxField.click(); ctxField.typeText(dir.path)
+
+        app.buttons["buildAdvancedDisclosure"].click()
+        let sshToggle = app.windows.checkBoxes["buildSshToggle"]
+        XCTAssertTrue(sshToggle.waitForExistence(timeout: 5), "Advanced section should expand")
+        sshToggle.click()
+
+        app.buttons["buildSubmitButton"].click()
+        let finished = app.buttons.matching(NSPredicate(format: "label == 'Done' OR label == 'Close'")).firstMatch
+        XCTAssertTrue(finished.waitForExistence(timeout: 300),
+                      "build should finish, success or failure; sheet:\n\(app.windows.firstMatch.debugDescription)")
+
+        if finished.label == "Close" {
+            let errorText = app.windows.staticTexts["buildErrorMessage"]
+            let message = (errorText.value as? String) ?? errorText.label
+            finished.click()
+            // Only skip for LiveContainerService.buildConfigSSH's own pre-flight message — that's
+            // the app process reporting it never saw SSH_AUTH_SOCK, so forwarding was never even
+            // attempted (an environment limitation, not a feature bug). Any other failure —
+            // including the guest-side RUN step failing — is a genuine regression, not a skip.
+            guard message.contains("SSH agent forwarding requested, but SSH_AUTH_SOCK is not set") else {
+                XCTFail("build failed for a reason other than a missing local SSH agent: \(message)")
+                return
+            }
+            throw XCTSkip("This Mac's SSH_AUTH_SOCK isn't visible to the app process, so forwarding was never attempted. Build error: \(message)")
+        }
+
+        finished.click()
+
+        // Oracle: the image exists — reaching here means the RUN --mount=type=ssh step actually
+        // found a real socket at $SSH_AUTH_SOCK inside the guest, or the build would have failed.
+        XCTAssertEqual(try ContainerCLI.run(["image", "inspect", tag]).status, 0,
+                       "built image should be present")
+        // image (berthly-e2e/…) swept by prefix in tearDown.
+    }
 }
 
 /// Registry journey (user-suggested, 2026-07-16): stands up a real, self-hosted, *anonymous*


### PR DESCRIPTION
## Summary
- Adds `ResourceJourneyTests.testBuildWithSSHForwardingMountsAgentSocket`: checks the Build sheet's "Forward SSH agent" toggle (#110), then builds an image whose Dockerfile has a `RUN --mount=type=ssh sh -c 'test -n "$SSH_AUTH_SOCK" && test -S "$SSH_AUTH_SOCK"'` step. That step is the oracle — it fails the build outright unless a real forwarded socket is present inside the guest, so a passing build is genuine proof of forwarding, not just proof that a build with the box checked didn't error.
- Skips (not fails) specifically when `LiveContainerService.buildConfigSSH`'s own pre-flight validation reports `SSH_AUTH_SOCK` isn't visible to the app process — GUI-launched apps don't reliably inherit a login shell's agent socket, so that's an environment limitation, not a feature bug. Any other failure — including the guest-side `RUN` step actually failing — still fails the test; the skip path checks the exact validation message text, not just "any failure."
- Adds `accessibilityIdentifier`s the test needed: `buildSshToggle` on the toggle, `buildErrorMessage` on the sheet's failure text — both previously unqueryable except by label/text matching.

## Test plan
- [x] `xcodebuild build` succeeds
- [x] `BerthlyTests` suite passes (no logic changes, but ran for regression safety)
- [x] `BerthlyUITests` build-sheet mock tests pass (`testBuildContinuesInBackgroundAndSurfacesInBuildsIndicator`, `testBuildSheetOpensAndClosesWithoutCrashing`) — confirms the two new identifiers don't disturb existing sheet behavior
- [x] `scripts/e2e.sh ResourceJourneyTests/testBuildWithSSHForwardingMountsAgentSocket` against the real local daemon — **passed** (not skipped) in ~25s: this machine's `SSH_AUTH_SOCK` is visible to the app, and forwarding genuinely works end to end
- [x] `swiftlint lint --strict` — 0 violations

Fixes #119