### PR TITLE
feat: add non-blocking in-app update for patch-behind container installs

### DIFF
--- a/Berthly/BerthlyApp.swift
+++ b/Berthly/BerthlyApp.swift
@@ -55,6 +55,11 @@ struct BerthlyApp: App {
         case "checking":            mock.daemonState = .checking
         case "versionMismatch":
             mock.daemonState = .versionMismatch(installed: "1.0.0", required: ContainerCompatibility.requiredVersion)
+        case "patchBehind":
+            // Same major.minor as required (stays `.connected`, nothing blocks) but behind the
+            // exact pinned patch — exercises SystemView's non-blocking update affordance, distinct
+            // from the hard `.versionMismatch` gate above.
+            mock.installedContainerVersion = "1.2.0"
         default: break
         }
         if let warning = env["UITEST_STARTUP_WARNING"] {

--- a/Berthly/Core/ContainerCompatibility.swift
+++ b/Berthly/Core/ContainerCompatibility.swift
@@ -60,6 +60,17 @@ nonisolated enum ContainerCompatibility {
             || requiredComponents == installedComponents
     }
 
+    /// Same major.minor as `requiredVersion` (so `mismatch` sees it as fully compatible and
+    /// never blocks the app) but behind the exact pinned patch — e.g. daemon 1.2.0 against a
+    /// Berthly pinned to `requiredVersion` 1.2.2. `mismatch` deliberately ignores patch, so this
+    /// is the only check that notices; without it, a patch-gated capability (`isAtLeast`, e.g.
+    /// running-container export added in 1.2.1) can sit unreachable with no signal why. Drives
+    /// the System page's non-blocking "Update available" affordance, distinct from the hard
+    /// `.versionMismatch` gate that `mismatch` drives.
+    static func isPatchBehind(installed: String, required: String = requiredVersion) -> Bool {
+        isCompatible(installed: installed, required: required) && !isAtLeast(installed: installed, required)
+    }
+
     /// The health-check ping's `apiServerVersion` isn't a bare version string — it's
     /// `ReleaseVersion.singleLine(appName:)`'s output, e.g. "container-apiserver version 1.0.0
     /// (build: release, commit: abc1234)". Pull the numeric version out of that (or any other

--- a/Berthly/Localizable.xcstrings
+++ b/Berthly/Localizable.xcstrings
@@ -912,6 +912,9 @@
     "New VMs pick up the kernel · running containers are unaffected." : {
 
     },
+    "Newer than Berthly supports" : {
+
+    },
     "No builder found. Create one with `container builder create`." : {
 
     },
@@ -1578,10 +1581,16 @@
     "Unused" : {
 
     },
+    "Up to date" : {
+
+    },
     "update" : {
 
     },
     "Update" : {
+
+    },
+    "Update available" : {
 
     },
     "Update available — pull and recreate to apply it" : {

--- a/Berthly/Views/DaemonGateView.swift
+++ b/Berthly/Views/DaemonGateView.swift
@@ -4,6 +4,62 @@
 import AppKit
 import SwiftUI
 
+/// Runs a privileged daemon maintenance operation (install/start/upgrade) and holds its progress
+/// state. Lives in `DaemonGateView` and is injected via `.environment`, so a trigger buried
+/// inside `content()` — e.g. `SystemView`'s non-blocking patch-update button — can start an
+/// operation whose progress screen still survives that same page disappearing mid-flight when
+/// `upgradeContainer` stops the daemon out from under it.
+@Observable
+@MainActor
+final class DaemonOperationCoordinator {
+    private(set) var message: String?
+    private(set) var logs: [String] = []
+    private(set) var error: OperationError?
+    private var task: Task<Void, Never>?
+
+    struct OperationError: Identifiable {
+        let id = UUID()
+        let title: String
+        let message: String
+    }
+
+    func clearError() {
+        error = nil
+    }
+
+    /// Cancellation (the progress screen's Cancel) is not an error — the service kills the
+    /// elevated process and the coordinator just returns to the gate.
+    func cancel() {
+        task?.cancel()
+    }
+
+    /// Activates the app first so the admin-password dialog appears on the user's current space
+    /// instead of wherever the app's window happens to live.
+    func run(
+        message: String,
+        failureTitle: String,
+        service: ContainerServiceBase,
+        _ work: @escaping (ContainerServiceBase, @MainActor @escaping (String) -> Void) async throws -> Void
+    ) {
+        NSApp.activate(ignoringOtherApps: true)
+        self.message = message
+        logs = []
+        task = Task {
+            do {
+                try await work(service) { [weak self] line in
+                    self?.logs.append(line)
+                }
+            } catch is CancellationError {
+                // User hit Cancel — no alert.
+            } catch {
+                self.error = OperationError(title: failureTitle, message: error.localizedDescription)
+            }
+            self.message = nil
+            task = nil
+        }
+    }
+}
+
 /// Replaces content with a contextual screen when the daemon isn't connected.
 /// Sidebar is always visible; only the content/detail area is gated.
 struct DaemonGateView<Content: View>: View {
@@ -14,16 +70,10 @@ struct DaemonGateView<Content: View>: View {
     /// the operation itself changes `daemonState` (stop → installedButStopped → connecting…),
     /// which tears the current gate down mid-flight. State at this level survives those
     /// transitions, so the progress screen stays up until the operation actually finishes.
-    @State private var operationMessage: String?
-    @State private var operationLogs: [String] = []
-    @State private var operationTask: Task<Void, Never>?
-    @State private var operationError: OperationError?
-
-    private struct OperationError: Identifiable {
-        let id = UUID()
-        let title: String
-        let message: String
-    }
+    /// Injected into the environment so a non-blocking trigger buried in `content()` (e.g.
+    /// `SystemView`'s patch-update button) can start an operation whose progress screen still
+    /// survives that same page disappearing mid-flight.
+    @State private var operationCoordinator = DaemonOperationCoordinator()
 
     init(@ViewBuilder content: @escaping () -> Content) {
         self.content = content
@@ -31,27 +81,28 @@ struct DaemonGateView<Content: View>: View {
 
     var body: some View {
         Group {
-            if let message = operationMessage {
-                ProgressLogScreen(message: message, logLines: operationLogs) {
-                    operationTask?.cancel()
+            if let message = operationCoordinator.message {
+                ProgressLogScreen(message: message, logLines: operationCoordinator.logs) {
+                    operationCoordinator.cancel()
                 }
             } else {
                 gate
             }
         }
+        .environment(operationCoordinator)
         .alert(
             // `String(localized:)` throughout the operation strings: they travel through plain
             // `String` properties into `Text`/`.alert`'s verbatim StringProtocol overloads, so
             // unlike literals they aren't auto-localized at the point of display.
-            operationError?.title ?? String(localized: "Operation Failed"),
+            operationCoordinator.error?.title ?? String(localized: "Operation Failed"),
             isPresented: Binding(
-                get: { operationError != nil },
-                set: { if !$0 { operationError = nil } }
+                get: { operationCoordinator.error != nil },
+                set: { if !$0 { operationCoordinator.clearError() } }
             )
         ) {
-            Button("OK") { operationError = nil }
+            Button("OK") { operationCoordinator.clearError() }
         } message: {
-            Text(operationError?.message ?? "")
+            Text(operationCoordinator.error?.message ?? "")
         }
     }
 
@@ -71,9 +122,10 @@ struct DaemonGateView<Content: View>: View {
 
         case .notInstalled:
             InstallGate {
-                runOperation(
+                operationCoordinator.run(
                     message: String(localized: "Installing container v\(ContainerCompatibility.requiredVersion)…"),
-                    failureTitle: String(localized: "Install Failed")
+                    failureTitle: String(localized: "Install Failed"),
+                    service: service
                 ) { service, onLog in
                     try await service.installContainer(onLog: onLog)
                 }
@@ -86,9 +138,10 @@ struct DaemonGateView<Content: View>: View {
                 Text("The container daemon is installed but not running.")
             } actions: {
                 Button("Start Container System") {
-                    runOperation(
+                    operationCoordinator.run(
                         message: String(localized: "Starting container system…"),
-                        failureTitle: String(localized: "Start Failed")
+                        failureTitle: String(localized: "Start Failed"),
+                        service: service
                     ) { service, onLog in
                         await service.startDaemon(onLog: onLog)
                     }
@@ -104,9 +157,10 @@ struct DaemonGateView<Content: View>: View {
                 // nil can't actually happen (the state only exists because the check failed),
                 // but falling into the upgrade gate is the sane answer if it somehow does.
                 VersionMismatchGate(installed: installed, required: required) {
-                    runOperation(
+                    operationCoordinator.run(
                         message: String(localized: "Updating container to v\(required)…"),
-                        failureTitle: String(localized: "Update Failed")
+                        failureTitle: String(localized: "Update Failed"),
+                        service: service
                     ) { service, onLog in
                         try await service.upgradeContainer(onLog: onLog)
                     }
@@ -126,33 +180,6 @@ struct DaemonGateView<Content: View>: View {
                 }
                 .buttonStyle(.bordered)
             }
-        }
-    }
-
-    /// Runs a privileged maintenance operation with the shared progress screen. Activates the
-    /// app first so the admin-password dialog appears on the user's current space instead of
-    /// wherever the app's window happens to live. Cancellation (the progress screen's Cancel)
-    /// is not an error — the service kills the elevated process and we just return to the gate.
-    private func runOperation(
-        message: String,
-        failureTitle: String,
-        _ work: @escaping (ContainerServiceBase, @MainActor @escaping (String) -> Void) async throws -> Void
-    ) {
-        NSApp.activate(ignoringOtherApps: true)
-        operationMessage = message
-        operationLogs = []
-        operationTask = Task {
-            do {
-                try await work(service) { line in
-                    operationLogs.append(line)
-                }
-            } catch is CancellationError {
-                // User hit Cancel — no alert.
-            } catch {
-                operationError = OperationError(title: failureTitle, message: error.localizedDescription)
-            }
-            operationMessage = nil
-            operationTask = nil
         }
     }
 

--- a/Berthly/Views/SystemView.swift
+++ b/Berthly/Views/SystemView.swift
@@ -84,7 +84,9 @@ private func pathRow(_ label: LocalizedStringKey, _ text: String) -> some View {
 
 private struct DaemonVersionSection: View {
     @Environment(ContainerServiceBase.self) private var service
+    @Environment(DaemonOperationCoordinator.self) private var operationCoordinator
     @State private var showStopConfirm = false
+    @State private var showPatchUpdateConfirm = false
     @State private var isStopping = false
 
     private var mismatch: ContainerCompatibility.Mismatch? {
@@ -94,28 +96,56 @@ private struct DaemonVersionSection: View {
 
     private var isCompatible: Bool { mismatch == nil }
 
+    private var isPatchBehind: Bool {
+        guard let installed = service.installedContainerVersion else { return false }
+        return ContainerCompatibility.isPatchBehind(installed: installed)
+    }
+
     private var statusText: String {
         switch mismatch {
-        case nil: "Up to date"
+        case nil: isPatchBehind ? "Update available" : "Up to date"
         case .tooOld: "Update available"
         case .tooNew: "Newer than Berthly supports"
         }
+    }
+
+    private var statusSymbol: String {
+        if isPatchBehind { return "arrow.up.circle.fill" }
+        return isCompatible ? "checkmark.circle.fill" : "exclamationmark.circle.fill"
+    }
+
+    private var statusColor: Color {
+        if isPatchBehind { return .berthlyAccent }
+        return isCompatible ? .statusRunning : .statusError
     }
 
     var body: some View {
         Section {
             LabeledContent("Status") {
                 HStack(spacing: 5) {
-                    Image(systemName: isCompatible ? "checkmark.circle.fill" : "exclamationmark.circle.fill")
+                    Image(systemName: statusSymbol)
                         .imageScale(.small)
                     Text(statusText)
                         .font(.callout.weight(.medium))
                 }
-                .foregroundStyle(isCompatible ? Color.statusRunning : Color.statusError)
+                .foregroundStyle(statusColor)
             }
 
             LabeledContent("Installed") { monoValue(service.installedContainerVersion ?? "Unknown") }
             LabeledContent("Required") { monoValue(ContainerCompatibility.requiredVersion) }
+
+            // Non-blocking: unlike the hard `.versionMismatch` gate (major.minor floor, handled
+            // entirely by DaemonGateView), a patch-behind daemon is still fully compatible, so
+            // this page stays reachable and the update is opt-in. `upgradeContainer` still stops
+            // the daemon mid-flight, tearing this page down — routing through
+            // `operationCoordinator` (owned by DaemonGateView, injected via environment) keeps
+            // the progress screen alive across that teardown instead of losing it.
+            if isPatchBehind {
+                Button("Update Container to v\(ContainerCompatibility.requiredVersion)…") {
+                    showPatchUpdateConfirm = true
+                }
+                .accessibilityIdentifier("updatePatchButton")
+            }
 
             // SystemView only renders behind DaemonGateView while the daemon is `.connected`, so
             // the daemon is always running here — a Stop control is the only lifecycle action that
@@ -125,13 +155,6 @@ private struct DaemonVersionSection: View {
                 showStopConfirm = true
             }
             .disabled(isStopping)
-
-            // No update button here, deliberately: an incompatible install flips `daemonState`
-            // to `.versionMismatch` on the next poll, and DaemonGateView blocks this whole page
-            // behind the gate that owns the update flow (with progress state that survives the
-            // daemon restarting mid-update — state held here would be torn down with the page).
-            // The status row can still disagree with "Up to date" for a moment mid-poll, so it
-            // stays informational.
         } header: {
             sectionHeader("Container Daemon", systemImage: "shippingbox")
         }
@@ -146,6 +169,23 @@ private struct DaemonVersionSection: View {
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("This stops every running container on this Mac, not just ones Berthly manages.")
+        }
+        .alert("Update container to v\(ContainerCompatibility.requiredVersion)?", isPresented: $showPatchUpdateConfirm) {
+            Button("Update", role: .destructive) {
+                operationCoordinator.run(
+                    message: String(localized: "Updating container to v\(ContainerCompatibility.requiredVersion)…"),
+                    failureTitle: String(localized: "Update Failed"),
+                    service: service
+                ) { service, onLog in
+                    try await service.upgradeContainer(onLog: onLog)
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("""
+                This stops every running container on this Mac, not just ones Berthly manages, \
+                while the update runs. You'll be asked for your admin password.
+                """)
         }
     }
 }
@@ -929,5 +969,6 @@ private struct DaemonLogView: View {
     )
     return SystemView()
         .environment(mock as ContainerServiceBase)
+        .environment(DaemonOperationCoordinator())
         .frame(width: 520, height: 1400)
 }

--- a/BerthlyTests/ContainerCompatibilityTests.swift
+++ b/BerthlyTests/ContainerCompatibilityTests.swift
@@ -108,4 +108,27 @@ struct ContainerCompatibilityTests {
     @Test func isAtLeastMalformedIsFalse() {
         #expect(!ContainerCompatibility.isAtLeast(installed: "garbage", "1.2.1"))
     }
+
+    // isPatchBehind drives the System page's non-blocking "Update available" affordance: same
+    // major.minor as required (mismatch sees it as compatible, app stays unblocked) but behind
+    // the exact pinned patch.
+    @Test func isPatchBehindOlderPatchSameMinorIsTrue() {
+        #expect(ContainerCompatibility.isPatchBehind(installed: "1.2.0", required: "1.2.2"))
+    }
+
+    @Test func isPatchBehindExactMatchIsFalse() {
+        #expect(!ContainerCompatibility.isPatchBehind(installed: "1.2.2", required: "1.2.2"))
+    }
+
+    @Test func isPatchBehindNewerPatchIsFalse() {
+        #expect(!ContainerCompatibility.isPatchBehind(installed: "1.2.3", required: "1.2.2"))
+    }
+
+    @Test func isPatchBehindOlderMinorIsFalse() {
+        #expect(!ContainerCompatibility.isPatchBehind(installed: "1.1.9", required: "1.2.2"))
+    }
+
+    @Test func isPatchBehindNewerMajorIsFalse() {
+        #expect(!ContainerCompatibility.isPatchBehind(installed: "2.0.0", required: "1.2.2"))
+    }
 }

--- a/BerthlyUITests/SystemViewTests.swift
+++ b/BerthlyUITests/SystemViewTests.swift
@@ -189,4 +189,38 @@ final class SystemViewTests: XCTestCase {
         XCTAssertTrue(emptyState.waitForExistence(timeout: 10),
                       "the builder should be gone entirely after deleting the only one")
     }
+
+    // MARK: - Patch-behind update
+
+    /// Patch-behind (same major.minor as required, so `daemonState` stays `.connected` and
+    /// nothing blocks) is a different code path from `BerthlyUITests`'
+    /// `testVersionMismatchGateUpdatesAndConnects`: the trigger lives on this page, not behind
+    /// `DaemonGateView`, but still has to route through the same `DaemonOperationCoordinator` so
+    /// the progress screen survives `upgradeContainer` stopping the daemon out from under the
+    /// page that started it.
+    @MainActor
+    func testPatchUpdateSurvivesDaemonRestart() throws {
+        let app = XCUIApplication.berthly()
+        app.launchEnvironment["UITEST_USE_MOCK_SERVICE"] = "1"
+        app.launchEnvironment["UITEST_INITIAL_DAEMON_STATE"] = "patchBehind"
+        app.launch()
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+        app.staticTexts["System"].click()
+
+        XCTAssertTrue(app.buttons["updatePatchButton"].waitForExistence(timeout: 10))
+        app.buttons["updatePatchButton"].click()
+
+        let confirmButton = app.sheets.firstMatch.buttons["Update"]
+        let progressText = app.staticTexts["operationProgressMessage"]
+        XCTAssertTrue(confirmButton.waitForExistence(timeout: 5), "Update confirmation alert should appear")
+        confirmButton.click()
+
+        XCTAssertTrue(
+            progressText.waitForExistence(timeout: 3),
+            "Update progress screen should appear and survive daemon state changes"
+        )
+
+        XCTAssertFalse(app.buttons["updatePatchButton"].waitForExistence(timeout: 10),
+                        "Patch-update button should disappear once the installed version catches up")
+    }
 }


### PR DESCRIPTION
## Summary

`ContainerCompatibility.mismatch()` deliberately compares major.minor only —
patch releases are ignored, since a patch bump upstream is additive/bugfix,
not an API break. That means a daemon on the same major.minor as
`requiredVersion` (e.g. installed `1.2.0` vs pinned `1.2.2`) reads as fully
compatible: no gate, no prompt, and — since `SystemView.swift` never called
`upgradeContainer`/`installContainer` outside `DaemonGateView`'s blocking
gate — no way in the app to actually reach the pinned patch.

That left patch-gated capabilities (`ContainerCompatibility.isAtLeast`, e.g.
running-container export added in 1.2.1, #107) silently unreachable on an
otherwise-healthy install, with zero UI signal why. Discovered directly:
this machine's real daemon reports 1.2.0 against Berthly's 1.2.2 pin, and
nothing in the app said so.

## Changes

- `ContainerCompatibility.isPatchBehind(installed:required:)` — same
  major.minor as required (so `mismatch` still reads compatible) but behind
  the exact pinned patch.
- System page: Status row now shows "Update available" for a patch-behind
  install, plus a new "Update Container to v1.2.2…" button (non-blocking —
  the page stays reachable, unlike the hard version-mismatch gate).
- `upgradeContainer` still stops the daemon mid-flight, which would tear
  `SystemView` down before the update finishes. The progress-tracking state
  that used to be private `@State` inside `DaemonGateView` is lifted into a
  new `DaemonOperationCoordinator` (`@Observable`, injected via
  `.environment`), so both `DaemonGateView`'s own triggers (install/start/
  hard-mismatch-update) and the System page's new button share one place
  that survives the daemon-restart teardown.
- Added the three string-catalog entries ("Up to date", "Update available",
  "Newer than Berthly supports") that were missing from
  `Localizable.xcstrings` even before this change — the `.tooOld`/`.tooNew`
  cases existed in source but were apparently never extracted. Caught while
  reusing that same `statusText` switch.

## Test plan

- `swiftlint lint --strict` — 0 violations
- `BerthlyTests` (unit) — full suite passes, including new
  `isPatchBehind` cases (exact match, older patch same minor, newer patch,
  older minor, newer major)
- `BerthlyUITests` (mock mode) — `testNotInstalledGateInstallsAndConnects`
  and `testVersionMismatchGateUpdatesAndConnects` pass unchanged (regression
  check on the `DaemonGateView` refactor), plus a new
  `SystemViewTests.testPatchUpdateSurvivesDaemonRestart` covering the new
  button end-to-end in mock mode, including that the progress screen
  survives the daemon-restart teardown
- Manual verification against the real local daemon (1.2.0, pinned 1.2.2):
  built and launched the app, confirmed the System page shows "Update
  available" / Installed 1.2.0 / Required 1.2.2 / "Update Container to
  v1.2.2…" — screenshot-verified. Did not click through the actual upgrade
  (admin-elevated system change); that's for the user to trigger deliberately.

Fixes #123
