### PR TITLE
fix: adopt apple/container 1.3.0, replace removed "auto" registry scheme

### DIFF
--- a/Berthly.xcodeproj/project.pbxproj
+++ b/Berthly.xcodeproj/project.pbxproj
@@ -775,7 +775,7 @@
 			repositoryURL = "https://github.com/apple/container";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.2.0;
+				minimumVersion = 1.3.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Berthly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Berthly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/container",
       "state" : {
-        "revision" : "0190097d06df0b9065f4c2d2c7873c649d81d493",
-        "version" : "1.2.2"
+        "revision" : "d6de5694200468d99a61662bfb9bb3aba763e3e5",
+        "version" : "1.3.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "7800b4642171561c95b5f55500b19e5dce5acd45",
-        "version" : "0.40.1"
+        "revision" : "edaa0373d22041a88960484acfef9fe7d4baf675",
+        "version" : "0.41.0"
       }
     },
     {

--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -880,7 +880,9 @@ final class LiveContainerService: ContainerServiceBase {
             let image = try await ClientImage.pull(
                 reference: reference,
                 platform: nil,
-                scheme: .auto,
+                // Apple's registry — always https. Not routed through RegistrySchemeResolver so a
+                // user's internal DNS domain can't accidentally match this fixed reference.
+                scheme: .https,
                 containerSystemConfig: containerSystemConfig,
                 progressUpdate: reporter?.handler
             )
@@ -2049,8 +2051,9 @@ final class LiveContainerService: ContainerServiceBase {
     nonisolated static func resolveRegistryConnectionTarget(
         host: String, insecure: Bool, internalDnsDomain: String?
     ) throws -> (scheme: RequestScheme, host: String, port: Int?) {
-        let scheme = try RequestScheme(insecure ? "http" : "auto")
-            .schemeFor(host: host, internalDnsDomain: internalDnsDomain)
+        let scheme = RegistrySchemeResolver.scheme(
+            forHost: host, insecure: insecure, internalDnsDomain: internalDnsDomain
+        )
         guard let url = URL(string: "\(scheme.rawValue)://\(host)"), let urlHost = url.host else {
             throw ContainerCLIError(exitCode: 1, message: "\(host) is not a valid registry host.")
         }
@@ -2808,7 +2811,12 @@ final class LiveContainerService: ContainerServiceBase {
     }
 
     nonisolated static func runRegistryFlags(for options: RunOptions) -> Flags.Registry {
-        Flags.Registry(scheme: options.insecureRegistry ? "http" : "auto")
+        // apple/container#2100 removed the "auto" scheme. This one string fans out to both the
+        // app-image and init-image fetches inside `containerConfigFromFlags`, so per-host
+        // detection isn't safe here — the insecure toggle keeps its "force http" meaning and
+        // everything else is https. A run against an untoggled internal-registry image now needs
+        // the toggle (RegistrySchemeResolver still covers the single-host pull/push/recreate paths).
+        Flags.Registry(scheme: options.insecureRegistry ? "http" : "https")
     }
 
     nonisolated static func writeCIDFile(_ id: String, to path: String) throws {
@@ -2974,7 +2982,9 @@ final class LiveContainerService: ContainerServiceBase {
     }
 
     nonisolated static func machineRegistryFlags(for options: MachineCreateOptions) -> Flags.Registry {
-        Flags.Registry(scheme: options.insecureRegistry ? "http" : "auto")
+        // See runRegistryFlags: "auto" is gone (apple/container#2100), one scheme covers both the
+        // image and init-image fetch, so the insecure toggle is the only path to http here.
+        Flags.Registry(scheme: options.insecureRegistry ? "http" : "https")
     }
 
     /// Overrides to layer onto the system default `MachineConfig` via `MachineConfig.with(_:)` —
@@ -3113,7 +3123,9 @@ final class LiveContainerService: ContainerServiceBase {
         let image = try await ClientImage.pull(
             reference: reference,
             platform: ociPlatform,
-            scheme: insecure ? .http : .auto,
+            scheme: RegistrySchemeResolver.scheme(
+                forReference: reference, insecure: insecure, internalDnsDomain: config.dns.domain
+            ),
             containerSystemConfig: config,
             progressUpdate: progress
         )
@@ -3240,11 +3252,14 @@ final class LiveContainerService: ContainerServiceBase {
         // Pull phase — the only cancellable window: nothing destructive has happened yet, and a
         // pulled-but-unused image is harmless. Platform nil (all variants) so the stored digest
         // stays an index digest, comparable to what checkForImageUpdates checks against.
-        // The same insecure-host lookup checkOneImageUpdate uses — without it, this pull has the
-        // identical hardcoded-.auto bug the checker had: a badge could correctly appear for a
-        // private HTTP registry, then this exact call would fail against it.
+        // The same insecure-host lookup checkOneImageUpdate uses — without it, a badge could
+        // correctly appear for a private HTTP registry, then this exact call would fail against it.
         let knownInsecureHosts = UserDefaults.standard.stringArray(forKey: ImageStaleness.insecureHostsDefaultsKey) ?? []
-        let pullScheme: RequestScheme = ImageStaleness.isHostInsecure(reference: reference, knownInsecureHosts: knownInsecureHosts) ? .http : .auto
+        let pullScheme = RegistrySchemeResolver.scheme(
+            forReference: reference,
+            insecure: ImageStaleness.isHostInsecure(reference: reference, knownInsecureHosts: knownInsecureHosts),
+            internalDnsDomain: containerSystemConfig.dns.domain
+        )
         var didPull = false
         if pullFirst, (try? Reference.parse(reference))?.domain != nil {
             onPhase(.pullingImage)
@@ -3381,7 +3396,9 @@ final class LiveContainerService: ContainerServiceBase {
             do {
                 try await imageToPush.push(
                     platform: ociPlatform,
-                    scheme: insecure ? .http : .auto,
+                    scheme: RegistrySchemeResolver.scheme(
+                        forReference: pushDestination, insecure: insecure, internalDnsDomain: config.dns.domain
+                    ),
                     containerSystemConfig: config,
                     progressUpdate: watchedProgress
                 )

--- a/Berthly/Core/RegistrySchemeResolver.swift
+++ b/Berthly/Core/RegistrySchemeResolver.swift
@@ -1,0 +1,47 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import ContainerAPIClient
+import ContainerizationExtras
+
+/// Picks http vs https for a registry connection.
+///
+/// apple/container 1.3.0 ([apple/container#2100](https://github.com/apple/container/pull/2100))
+/// deleted `RequestScheme.auto` and the `isInternalHost` detection behind it: `schemeFor` now
+/// returns https for every host unless the caller already chose http. Without that heuristic a
+/// plain-HTTP registry on localhost or a private network is unreachable unless the user ticks
+/// "Allow insecure registry". This restores the removed rule — localhost, the daemon's internal
+/// DNS domain, and the RFC 1918 / loopback IPv4 ranges resolve to http; everything else to https
+/// — for the paths where Berthly controls a single host.
+enum RegistrySchemeResolver {
+
+    /// `isInternalHost` is a verbatim port of the detection apple/container#2100 removed.
+    static func scheme(forHost host: String, insecure: Bool, internalDnsDomain: String?) -> RequestScheme {
+        if insecure { return .http }
+        return isInternalHost(host: host, internalDnsDomain: internalDnsDomain) ? .http : .https
+    }
+
+    /// Resolves the registry host from an image reference via `ImageStaleness.registryHost`
+    /// (case-folded, Docker Hub alias applied — neither matters for an internal host). A
+    /// reference with no registry (e.g. `alpine:latest`) has no internal host, so it resolves
+    /// to https.
+    static func scheme(forReference reference: String, insecure: Bool, internalDnsDomain: String?) -> RequestScheme {
+        if insecure { return .http }
+        guard let host = ImageStaleness.registryHost(for: reference) else { return .https }
+        return isInternalHost(host: host, internalDnsDomain: internalDnsDomain) ? .http : .https
+    }
+
+    /// A verbatim port of the `RequestScheme.isInternalHost` apple/container#2100 removed. A
+    /// `host:port` string won't match `localhost` or parse as an IPv4 address, so a ported
+    /// local registry stays https unless the insecure toggle forces http — same as pre-1.3.0.
+    static func isInternalHost(host: String, internalDnsDomain: String?) -> Bool {
+        if host == "localhost" { return true }
+        if let internalDnsDomain, host.hasSuffix(".\(internalDnsDomain)") { return true }
+        guard let value = (try? IPv4Address(host))?.value else { return false }
+        if value & 0xff00_0000 == 0x0a00_0000 { return true }  // 10.0.0.0/8
+        if value & 0xff00_0000 == 0x7f00_0000 { return true }  // 127.0.0.0/8
+        if value & 0xffff_0000 == 0xc0a8_0000 { return true }  // 192.168.0.0/16
+        if value & 0xfff0_0000 == 0xac10_0000 { return true }  // 172.16.0.0/12
+        return false
+    }
+}

--- a/BerthlyTests/BerthlyTests.swift
+++ b/BerthlyTests/BerthlyTests.swift
@@ -150,7 +150,9 @@ struct BuildMappingTests {
     @Test func buildPlatformsParsesExplicitPlatform() throws {
         let options = BuildOptions(reference: "local/web:1.0", contextPath: "/tmp/web", platform: "linux/arm64")
         let platforms = try LiveContainerService.buildPlatforms(for: options)
-        #expect(platforms.map(\.description) == ["linux/arm64/v8"])
+        // containerization 0.41.0 (apple/containerization#783) drops the redundant `v8` variant
+        // from arm64's `description`, matching how Docker and containerd render it.
+        #expect(platforms.map(\.description) == ["linux/arm64"])
     }
 
     @Test func buildPlatformsDefaultsToHostLinuxPlatformWhenUnset() throws {
@@ -529,7 +531,14 @@ struct MachineCreateMappingTests {
         let secure = LiveContainerService.machineRegistryFlags(
             for: MachineCreateOptions(reference: "alpine:3.22")
         )
-        #expect(secure.scheme == "auto")
+        #expect(secure.scheme == "https")
+    }
+
+    @Test func runRegistryFlagsDefaultToHTTPS() {
+        // Without the insecure toggle the run/create path is https-only: its one scheme fans out
+        // to the init-image fetch too, so it can't do per-host detection (apple/container#2100).
+        let flags = LiveContainerService.runRegistryFlags(for: RunOptions(reference: "alpine:3.22"))
+        #expect(flags.scheme == "https")
     }
 
     @Test func machineBootConfigOverridesMapCpusMemoryAndHomeMount() {

--- a/BerthlyTests/RegistrySchemeResolverTests.swift
+++ b/BerthlyTests/RegistrySchemeResolverTests.swift
@@ -1,0 +1,51 @@
+// Copyright 2026 Berthly Contributors
+// Licensed under the Apache License, Version 2.0
+
+import ContainerAPIClient
+import Testing
+@testable import Berthly
+
+struct RegistrySchemeResolverTests {
+
+    @Test func insecureForcesHTTPRegardlessOfHost() {
+        #expect(RegistrySchemeResolver.scheme(forHost: "ghcr.io", insecure: true, internalDnsDomain: nil) == .http)
+        #expect(RegistrySchemeResolver.scheme(forReference: "ghcr.io/apple/x:1", insecure: true, internalDnsDomain: nil) == .http)
+    }
+
+    @Test func bareLocalhostIsInternal() {
+        #expect(RegistrySchemeResolver.scheme(forHost: "localhost", insecure: false, internalDnsDomain: nil) == .http)
+    }
+
+    @Test func localhostWithPortIsNotDetected() {
+        // A host:port string matches neither "localhost" nor an IPv4 address — same quirk the
+        // apple/container heuristic had; such a registry needs the insecure toggle.
+        #expect(RegistrySchemeResolver.scheme(forHost: "localhost:5000", insecure: false, internalDnsDomain: nil) == .https)
+    }
+
+    @Test func internalDnsDomainSuffixIsInternal() {
+        #expect(RegistrySchemeResolver.scheme(forHost: "registry.test", insecure: false, internalDnsDomain: "test") == .http)
+        #expect(RegistrySchemeResolver.scheme(forHost: "registry.example.com", insecure: false, internalDnsDomain: "test") == .https)
+    }
+
+    @Test func privateIPv4RangesAreInternal() {
+        for host in ["10.0.0.1", "10.255.255.255", "127.0.0.1", "192.168.1.10", "172.16.0.1", "172.31.255.255"] {
+            #expect(RegistrySchemeResolver.scheme(forHost: host, insecure: false, internalDnsDomain: nil) == .http, "\(host)")
+        }
+    }
+
+    @Test func publicIPv4AndHostsAreExternal() {
+        for host in ["8.8.8.8", "172.32.0.1", "ghcr.io", "registry-1.docker.io"] {
+            #expect(RegistrySchemeResolver.scheme(forHost: host, insecure: false, internalDnsDomain: nil) == .https, "\(host)")
+        }
+    }
+
+    @Test func referenceWithoutRegistryResolvesHTTPS() {
+        #expect(RegistrySchemeResolver.scheme(forReference: "alpine:latest", insecure: false, internalDnsDomain: nil) == .https)
+    }
+
+    @Test func referenceRegistryHostDrivesDetection() {
+        #expect(RegistrySchemeResolver.scheme(forReference: "10.1.2.3:5000/team/app:1", insecure: false, internalDnsDomain: nil) == .https)
+        #expect(RegistrySchemeResolver.scheme(forReference: "reg.lan/team/app:1", insecure: false, internalDnsDomain: "lan") == .http)
+        #expect(RegistrySchemeResolver.scheme(forReference: "ghcr.io/apple/x:1", insecure: false, internalDnsDomain: nil) == .https)
+    }
+}

--- a/BerthlyTests/RegistryTests.swift
+++ b/BerthlyTests/RegistryTests.swift
@@ -53,8 +53,8 @@ struct ResolveRegistryConnectionTargetTests {
     }
 
     @Test func insecureForcesHTTPRegardlessOfHost() throws {
-        // Mirrors pushImage/pullImage's `insecure ? .http : .auto` — a public host can still be
-        // forced to HTTP explicitly, same as the Push/Pull sheets' toggle.
+        // The insecure toggle forces HTTP explicitly even for a public host, same as the
+        // Push/Pull sheets.
         let target = try LiveContainerService.resolveRegistryConnectionTarget(
             host: "ghcr.io", insecure: true, internalDnsDomain: nil
         )
@@ -72,8 +72,9 @@ struct ResolveRegistryConnectionTargetTests {
     }
 
     @Test func bareLocalhostAutoDetectsHTTPWithoutTheInsecureToggle() throws {
-        // `RequestScheme.auto` already treats an exact "localhost" as an internal host (see
-        // `RequestScheme.isInternalHost`) — the toggle isn't the only way to reach HTTP.
+        // `RegistrySchemeResolver` treats an exact "localhost" as an internal host — a verbatim
+        // port of the detection apple/container removed in 1.3.0 (apple/container#2100) — so the
+        // toggle isn't the only way to reach HTTP.
         let target = try LiveContainerService.resolveRegistryConnectionTarget(
             host: "localhost", insecure: false, internalDnsDomain: nil
         )

--- a/PARITY.md
+++ b/PARITY.md
@@ -3,7 +3,7 @@
 How Berthly's GUI maps onto [Apple's `container`](https://github.com/apple/container)
 CLI, subcommand by subcommand — and the few places it deliberately doesn't.
 
-> Audited against **container CLI 1.2.2** (2026-08-14). When a change closes or
+> Audited against **container CLI 1.3.0** (2026-08-28). When a change closes or
 > opens a gap, update this file in the same commit.
 
 ## Containers
@@ -126,6 +126,13 @@ Expert or scripting-oriented flags the GUI intentionally leaves to the CLI:
   (hidden from the Compute list, protected from prune) so they don't get
   caught by unrelated container-management actions. Revisit only if upstream
   both drops EXPERIMENTAL and exposes cluster operations over the XPC API.
+- **`--scheme http` on run/machine create against an internal registry** — 1.3.0
+  ([apple/container#2100](https://github.com/apple/container/pull/2100)) removed
+  the `auto` scheme and its localhost/private-IP detection. Berthly restores that
+  detection for the single-host pull/push/recreate/login paths
+  (`RegistrySchemeResolver`), but run/create pass one scheme that also covers the
+  init-image fetch, so plain HTTP there needs the "Allow insecure registry"
+  toggle. `pull` then `run` the local image for the same result without it.
 - **Output formatting** (`--format json|yaml|toml`, `--quiet`, `--cidfile`,
   `--debug`) — scripting conveniences with no GUI meaning.
 - **`stats` as a fleet-wide table** — Berthly shows richer per-container


### PR DESCRIPTION
Closes #129.

## What

Adopts apple/container **1.3.0** (and its required containerization **0.41.0**).

### `RequestScheme.auto` removal ([apple/container#2100](https://github.com/apple/container/pull/2100))

1.3.0 deletes `RequestScheme.auto` and the internal-host detection behind it, so
`schemeFor` now returns `https` for every host unless the caller already chose
`http`. Without the old heuristic a plain-HTTP registry on `localhost` or a
private network is unreachable unless the user ticks "Allow insecure registry".

New `RegistrySchemeResolver` ports that detection **verbatim** — `localhost`, the
daemon's internal DNS domain, and the RFC 1918 / loopback IPv4 ranges resolve to
`http`; everything else to `https` — and drives the paths where Berthly controls
a single host: `resolveRegistryConnectionTarget` (login), `pullImage`,
`pushImage`, `recreateContainer`.

`runRegistryFlags` / `machineRegistryFlags` can't use it: their one
`Flags.Registry` scheme fans out to the init-image fetch too
(`Utility.containerConfigFromFlags`), so per-host detection isn't safe there. The
insecure toggle keeps its "force http" meaning and becomes the only path to
`http` for `run` / `machine create` against an untoggled internal registry —
documented as a deliberate gap in `PARITY.md` (`pull` then `run` for the same
result without the toggle).

The vminit base-image pull is hardcoded to `.https` (Apple's registry, not routed
through the resolver so a user's internal DNS domain can't match it).

### containerization 0.41.0

Required by 1.3.0. [apple/containerization#783](https://github.com/apple/containerization/pull/783)
drops the redundant `v8` variant from arm64's `Platform.description` (matching
Docker/containerd) — one test assertion updated. The `Platform` equality fix
([#833](https://github.com/apple/containerization/pull/833)) doesn't affect
`builderPlatform` (line 2433 mirrors 1.3.0's own `BuilderStart.swift:116`
verbatim).

### Compatibility floor

Stays at 1.2 — nothing in 1.3.0 adds an API Berthly newly calls, so a 1.2.x
daemon still works. Only the SPM pin moved.

## Test plan

- [x] `xcodebuild build` — succeeds
- [x] `xcodebuild build-for-testing` (all test targets incl. UITests/E2E) — succeeds
- [x] `BerthlyTests` — 532 pass, 0 failures (new `RegistrySchemeResolverTests`,
  `runRegistryFlagsDefaultToHTTPS`)
- [x] `swiftlint lint --strict` — 0 violations
- [ ] Not verified without a local daemon: disk-usage volume-name validation
  ([#2107](https://github.com/apple/container/pull/2107) /
  [#2136](https://github.com/apple/container/pull/2136)) on the `fetchDiskUsage`
  path — stricter input checks, Berthly passes real volume names, no expected impact.

## Follow-ups (separate issues)

#130 tmpfs fix verification · #131 k8s PARITY.md rationale · #132 mock kernel fixtures
