### PR TITLE
chore: refresh mock kernel fixtures and re-check k8s parity for 1.3.0

### DIFF
--- a/Berthly/Core/LargeMockFixture.swift
+++ b/Berthly/Core/LargeMockFixture.swift
@@ -102,7 +102,7 @@ struct LargeMockFixture: Equatable {
                 diskUsedGB: Double(index + 1) * 0.25,
                 diskTotalGB: 8,
                 uptimeString: index < 12 ? "\(index + 1)h" : "–",
-                kernel: "6.12.4-arm64",
+                kernel: "6.18.35-arm64",
                 resources: "\(cpus) vCPU · \(memoryGB) GB",
                 created: "2026-01-01",
                 homeMount: machineHomeMount(index),

--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -1049,7 +1049,7 @@ final class LiveContainerService: ContainerServiceBase {
     }
 
     /// Display name for a machine's kernel: the default kernel binary's filename
-    /// (e.g. `vmlinux-6.18.15-186`). The `Kernel` type carries no version string,
+    /// (e.g. `vmlinux-6.18.35-197-debug`). The `Kernel` type carries no version string,
     /// so the filename is the most honest stable identifier. `nil` → `"–"`.
     nonisolated static func kernelName(_ kernel: Kernel?) -> String {
         guard let kernel else { return "–" }

--- a/Berthly/Core/MockContainerService.swift
+++ b/Berthly/Core/MockContainerService.swift
@@ -65,9 +65,9 @@ final class MockContainerService: ContainerServiceBase {
             Network(id: "default", name: "default", driver: .nat, subnet: "192.168.64.0/24", gateway: "192.168.64.1", isDefault: true, scope: "local", ipv6Enabled: false, egress: "NAT → en0", attachable: true, backend: "vmnet", endpoints: [NetworkEndpoint(id: "e3", name: "dev", ipv4: "192.168.64.3", kind: "MACHINE", isRunning: true, aliases: ["machine"]), NetworkEndpoint(id: "e4", name: "ci-runner", ipv4: "192.168.64.4", kind: "MACHINE", isRunning: false, aliases: ["machine"]), NetworkEndpoint(id: "e5", name: "default", ipv4: "192.168.64.2", kind: "MACHINE", isRunning: true, aliases: ["machine", "utility VM"]), NetworkEndpoint(id: "e10", name: "edge-proxy", ipv4: "192.168.64.10", kind: "CONTAINER", isRunning: false, aliases: ["edge", "proxy"])])
         ]
         machines = [
-            Machine(id: "dev", name: "dev", image: "ubuntu:24.04", status: .running, isUtility: false, diskUsedGB: 3.1, diskTotalGB: 8.0, uptimeString: "1h 12m", kernel: "6.12.4-arm64", resources: "4 vCPU · 4 GB", created: "Jun 20", homeMount: .readWrite, isDefault: true),
-            Machine(id: "ci-runner", name: "ci-runner", image: "alpine:3.22", status: .stopped, isUtility: false, diskUsedGB: 0.48, diskTotalGB: 2.0, uptimeString: "–", kernel: "6.12.4-arm64", resources: "2 vCPU · 2 GB", created: "Jun 22", homeMount: .readOnly),
-            Machine(id: "default", name: "default", image: "debian:12", status: .running, isUtility: true, diskUsedGB: 1.2, diskTotalGB: 4.0, uptimeString: "6d 4h", kernel: "6.12.4-arm64", resources: "2 vCPU · 4 GB", created: "Jun 15", homeMount: .none)
+            Machine(id: "dev", name: "dev", image: "ubuntu:24.04", status: .running, isUtility: false, diskUsedGB: 3.1, diskTotalGB: 8.0, uptimeString: "1h 12m", kernel: "6.18.35-arm64", resources: "4 vCPU · 4 GB", created: "Jun 20", homeMount: .readWrite, isDefault: true),
+            Machine(id: "ci-runner", name: "ci-runner", image: "alpine:3.22", status: .stopped, isUtility: false, diskUsedGB: 0.48, diskTotalGB: 2.0, uptimeString: "–", kernel: "6.18.35-arm64", resources: "2 vCPU · 2 GB", created: "Jun 22", homeMount: .readOnly),
+            Machine(id: "default", name: "default", image: "debian:12", status: .running, isUtility: true, diskUsedGB: 1.2, diskTotalGB: 4.0, uptimeString: "6d 4h", kernel: "6.18.35-arm64", resources: "2 vCPU · 4 GB", created: "Jun 15", homeMount: .none)
         ]
         builders = [
             Builder(id: "default", name: "default", image: "buildkit:0.13", status: .running, autoStarted: true, cpus: 2, memoryGB: 2)
@@ -446,7 +446,7 @@ final class MockContainerService: ContainerServiceBase {
     }
 
     override func fetchKernelInfo() async throws {
-        kernelInfo = KernelInfo(path: "/opt/kata/share/kata-containers/vmlinux-6.18.15-186", platform: "linux/arm64")
+        kernelInfo = KernelInfo(path: "/opt/kata/share/kata-containers/vmlinux-6.18.35-197-debug", platform: "linux/arm64")
     }
 
     override func setKernel(options: KernelSetOptions, progress: ProgressUpdateHandler? = nil) async throws {
@@ -461,8 +461,8 @@ final class MockContainerService: ContainerServiceBase {
             SystemProperty(key: "build.image", value: "ghcr.io/apple/container-builder-shim/builder:latest"),
             SystemProperty(key: "container.cpus", value: "4"), SystemProperty(key: "container.memory", value: "1 GB"),
             SystemProperty(key: "dns.domain", value: "test"),
-            SystemProperty(key: "kernel.binaryPath", value: "opt/kata/share/kata-containers/vmlinux-6.18.15-186"),
-            SystemProperty(key: "kernel.url", value: "https://github.com/kata-containers/kata-containers/releases/download/3.28.0/kata-static-3.28.0-arm64.tar.zst"),
+            SystemProperty(key: "kernel.binaryPath", value: "opt/kata/share/kata-containers/vmlinux-6.18.35-197-debug"),
+            SystemProperty(key: "kernel.url", value: "https://github.com/kata-containers/kata-containers/releases/download/3.32.0/kata-static-3.32.0-arm64.tar.zst"),
             SystemProperty(key: "machine.cpus", value: "4"), SystemProperty(key: "machine.memory", value: "8 GB"),
             SystemProperty(key: "machine.home-mount", value: "rw"), SystemProperty(key: "machine.virtualization", value: "false"),
             SystemProperty(key: "network.subnet", value: "192.168.64.0/24"),
@@ -497,8 +497,8 @@ final class MockContainerService: ContainerServiceBase {
     override func fetchSystemConfig() async throws {
         systemConfigInfo = SystemConfigInfo(
             vminitImage: "ghcr.io/apple/containerization/vminit:latest",
-            kernelBinaryPath: "/opt/kata/share/kata-containers/vmlinux-6.18.15-186",
-            kernelURL: "https://github.com/kata-containers/kata-containers/releases/download/3.28.0/kata-static-3.28.0-arm64.tar.zst",
+            kernelBinaryPath: "/opt/kata/share/kata-containers/vmlinux-6.18.35-197-debug",
+            kernelURL: "https://github.com/kata-containers/kata-containers/releases/download/3.32.0/kata-static-3.32.0-arm64.tar.zst",
             kernelDigest: "sha256:f63d54abcd", builderImage: "ghcr.io/apple/container-builder-shim/builder:latest"
         )
     }

--- a/Berthly/Views/SetKernelSheet.swift
+++ b/Berthly/Views/SetKernelSheet.swift
@@ -362,7 +362,7 @@ private struct SetKernelSheetPreviewHarness: View {
     var body: some View {
         SetKernelSheet(
             service: mock,
-            currentKernel: KernelInfo(path: "/opt/kata/share/kata-containers/vmlinux-6.18.15-186", platform: "linux/arm64"),
+            currentKernel: KernelInfo(path: "/opt/kata/share/kata-containers/vmlinux-6.18.35-197-debug", platform: "linux/arm64"),
             initialSource: source
         )
         .task { try? await mock.fetchSystemConfig() }

--- a/Berthly/Views/SystemView.swift
+++ b/Berthly/Views/SystemView.swift
@@ -960,11 +960,11 @@ private struct DaemonLogView: View {
         SystemProperty(key: "dns.domain", value: "test"),
         SystemProperty(key: "registry.domain", value: "docker.io")
     ]
-    mock.kernelInfo = KernelInfo(path: "/opt/kata/share/kata-containers/vmlinux-6.18.15-186", platform: "linux/arm64")
+    mock.kernelInfo = KernelInfo(path: "/opt/kata/share/kata-containers/vmlinux-6.18.35-197-debug", platform: "linux/arm64")
     mock.systemConfigInfo = SystemConfigInfo(
         vminitImage: "ghcr.io/apple/containerization/vminit:latest",
-        kernelBinaryPath: "/opt/kata/share/kata-containers/vmlinux-6.18.15-186",
-        kernelURL: "https://github.com/kata-containers/kata-containers/releases/download/3.28.0/kata-static-3.28.0-arm64.tar.zst",
+        kernelBinaryPath: "/opt/kata/share/kata-containers/vmlinux-6.18.35-197-debug",
+        kernelURL: "https://github.com/kata-containers/kata-containers/releases/download/3.32.0/kata-static-3.32.0-arm64.tar.zst",
         kernelDigest: "sha256:f63d54abcd", builderImage: "ghcr.io/apple/container-builder-shim/builder:latest"
     )
     return SystemView()

--- a/BerthlyTests/SystemPageMappingTests.swift
+++ b/BerthlyTests/SystemPageMappingTests.swift
@@ -103,8 +103,8 @@ struct KernelMappingTests {
     }
 
     @Test func kernelNameIsBinaryFilename() {
-        let kernel = Kernel(path: URL(fileURLWithPath: "/opt/kata/share/kata-containers/vmlinux-6.18.15-186"), platform: .linuxArm)
-        #expect(LiveContainerService.kernelName(kernel) == "vmlinux-6.18.15-186")
+        let kernel = Kernel(path: URL(fileURLWithPath: "/opt/kata/share/kata-containers/vmlinux-6.18.35-197-debug"), platform: .linuxArm)
+        #expect(LiveContainerService.kernelName(kernel) == "vmlinux-6.18.35-197-debug")
     }
 
     @Test func kernelNameIsDashWhenNoKernel() {

--- a/PARITY.md
+++ b/PARITY.md
@@ -118,11 +118,16 @@ Expert or scripting-oriented flags the GUI intentionally leaves to the CLI:
   ([apple/container#2044](https://github.com/apple/container/pull/2044)) as
   an explicitly experimental plugin. Not a parity gap Berthly intends to
   close: driving `container k8s create` natively is structurally blocked —
-  `K8sHelper.loadKindnetManifest` locates its CNI manifest via
+  `loadKindnetManifest` locates its CNI manifest via
   `pluginLoader.findPlugin(forExecutable: CommandLine.executablePath)`, which
   fails for Berthly's own binary since it isn't a registered plugin — and the
   entire post-`create` workflow is `kubectl`, leaving no meaningful GUI
-  surface to add. Berthly does treat k8s cluster containers as infrastructure
+  surface to add. 1.3.0's k8s refactor
+  ([apple/container#2115](https://github.com/apple/container/pull/2115),
+  [#2110](https://github.com/apple/container/pull/2110)) split `K8sHelper` and
+  moved `createPluginLoader` into a shared helper, but that manifest lookup
+  and the `kubectl` workflow are unchanged and the command is still
+  `EXPERIMENTAL`. Berthly does treat k8s cluster containers as infrastructure
   (hidden from the Compute list, protected from prune) so they don't get
   caught by unrelated container-management actions. Revisit only if upstream
   both drops EXPERIMENTAL and exposes cluster operations over the XPC API.


### PR DESCRIPTION
Closes #131. Closes #132.

## #131 — k8s parity re-check

apple/container#2115 (`createPluginLoader` extracted to a shared `Utility`
helper) and #2110 (`K8sHelper` split, `NodeProvisioner` protocol) reorganized
the k8s code in 1.3.0. The structural blocker `PARITY.md` documents is
unchanged: `loadKindnetManifest` (now in `K8sHelper+Bootstrap.swift`) still
resolves its CNI manifest via
`pluginLoader.findPlugin(forExecutable: CommandLine.executablePath)`, which a
non-plugin binary can't satisfy; the post-`create` workflow is still `kubectl`;
and `container k8s` is still marked `EXPERIMENTAL`. Rationale updated to record
the recheck.

## #132 — mock kernel fixtures

Bumped the stale kernel strings in mock/preview fixtures to 1.3.0's live
defaults (read from a running 1.3.0 daemon):

- `vmlinux-6.18.15-186` → `vmlinux-6.18.35-197-debug`
- Kata `3.28.0` release URL → `3.32.0`
- machine kernel display `6.12.4-arm64` → `6.18.35-arm64`

Display-only; the one affected unit test (`kernelNameIsBinaryFilename`) updates
its input and expectation together.

## Test plan

- [x] `swiftlint lint --strict` — 0 violations
- [x] `BerthlyTests` — all pass
