### PR TITLE
chore(deps): bump apple/container to 1.3.1, containerization to 0.42.0

### DIFF
--- a/Berthly.xcodeproj/project.pbxproj
+++ b/Berthly.xcodeproj/project.pbxproj
@@ -775,7 +775,7 @@
 			repositoryURL = "https://github.com/apple/container";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.3.0;
+				minimumVersion = 1.3.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Berthly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Berthly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/container",
       "state" : {
-        "revision" : "d6de5694200468d99a61662bfb9bb3aba763e3e5",
-        "version" : "1.3.0"
+        "revision" : "a9a62e28f6beb88940122a3d7b286f2d5ae8053a",
+        "version" : "1.3.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "edaa0373d22041a88960484acfef9fe7d4baf675",
-        "version" : "0.41.0"
+        "revision" : "c0185aea5c04fcd4d1cfe9359e0066a380835403",
+        "version" : "0.42.0"
       }
     },
     {


### PR DESCRIPTION
Follows apple/container **1.3.1**, which pulls `containerization` **0.42.0**.

## Why

Berthly links `apple/container` / `containerization` as SPM deps and runs some
of that code in-process, so 1.3.1's security fixes land in code Berthly
compiles — not just in the user's daemon install. The one that clearly applies:

- **CVE-2026-65388 / GHSA-mx96-5vvg-x2mg** — `RegistryClient` followed the
  `WWW-Authenticate` realm without validating its host or scheme. Berthly builds
  `RegistryClient` directly in `LiveContainerService.swift` (~`:2074`, `:3211`),
  passing the user's Keychain credentials, for the background image-update check
  and recreate/pull. A hostile or MITM'd registry could redirect the
  credential-bearing token request to another host or downgrade it to http.

0.42.0 also carries GHSA-x7pf-2jmj-pgcq, GHSA-f689-h8m7-3jp2,
GHSA-r3h2-rgqf-9hv9, GHSA-697p-8837-37h3, GHSA-g3rx-2m58-rr63 (image-unpack /
content-store / OCI-layout hardening, mostly daemon-side).

## Changes

- `Package.resolved`: `container` 1.3.0 → 1.3.1, `containerization` 0.41.0 → 0.42.0
  (revisions match the upstream tags).
- `project.pbxproj`: `minimumVersion` 1.3.0 → 1.3.1 so the security floor can't
  resolve back down (`upToNextMinorVersion`, still `< 1.4.0`).

## Behavior change to watch (tracked in #139)

0.42.0's CVE fix makes `RegistryClient` refuse the token exchange over plain
HTTP and require the auth realm to share the registry's registrable domain.
Impact on Berthly's insecure-registry path:

| Scenario | Result |
|---|---|
| Public HTTPS registry, normal auth (Docker Hub, GHCR, ECR, GCR, quay) | unaffected |
| Anonymous plain-HTTP local/internal registry | unaffected |
| **Authenticated plain-HTTP local/internal registry** | update-check / pull / recreate token flow now fails |

Acceptable (it's the insecure case the CVE fix targets), but the error should be
made legible and `RegistrySchemeResolver`'s doc note updated — **#139**.

## Not applicable

- **apple/container#2138** (tmpfs `source` fix) is in `Parser.mount`; Berthly
  builds `Filesystem` values directly and only calls `Parser.resources`.
- **apple/container#2154** ("Add container skill") is a Claude Code plugin/skill.

## Tests

- `swiftlint lint --strict` — clean
- BerthlyTests — pass
- BerthlyUITests (mock mode) — 78 pass, 2 skipped, 0 failures; no fixture refresh needed
- E2E not run locally (needs a real daemon on 1.3.1)

PARITY.md re-audit against 1.3.1 tracked in #140.

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)
