### PR TITLE
fix: explain registry sign-in failure over plain HTTP on container 1.3.1

### DIFF
--- a/Berthly/Core/LiveContainerService.swift
+++ b/Berthly/Core/LiveContainerService.swift
@@ -2060,6 +2060,18 @@ final class LiveContainerService: ContainerServiceBase {
         return (scheme, urlHost, url.port)
     }
 
+    /// apple/container 1.3.1 (CVE-2026-65388) made `RegistryClient` refuse to exchange credentials
+    /// or a bearer token unless the registry and its token realm are both HTTPS and share a
+    /// registrable domain. Berthly routes `localhost`, the internal DNS domain, and RFC 1918 hosts
+    /// to http (`RegistrySchemeResolver`), and "Allow insecure registry" forces http for any host —
+    /// so signing in to an authenticated registry reached that way now fails. Anonymous HTTP
+    /// registries are unaffected (no credential exchange happens).
+    nonisolated static func insecureRegistryAuthMessage(host: String) -> String {
+        "Can't sign in to \(host): apple/container 1.3.1 refuses to send credentials to a registry "
+            + "over plain HTTP, or to a token server outside the registry's own domain (CVE-2026-65388). "
+            + "This registry needs an HTTPS endpoint."
+    }
+
     override func signInRegistry(host: String, username: String, password: String, insecure: Bool = false) async throws {
         let host = Reference.resolveDomain(domain: host.trimmingCharacters(in: .whitespaces))
         let username = username.trimmingCharacters(in: .whitespaces)
@@ -2078,7 +2090,14 @@ final class LiveContainerService: ContainerServiceBase {
             authentication: BasicAuthentication(username: username, password: password),
             retryOptions: RetryOptions(maxRetries: 3, retryInterval: 300_000_000, shouldRetry: { $0.status.code >= 500 })
         )
-        try await client.ping()
+        do {
+            try await client.ping()
+        } catch let error as RegistryClient.Error {
+            if case .insecureCredentialExchange = error {
+                throw ContainerCLIError(exitCode: 1, message: Self.insecureRegistryAuthMessage(host: target.host))
+            }
+            throw error
+        }
 
         do {
             try await Self.keychainSave(hostname: host, username: username, password: password)
@@ -3225,6 +3244,10 @@ final class LiveContainerService: ContainerServiceBase {
                 checkedAt: .now
             ))
         } catch {
+            // Any failure → no badge. Since apple/container 1.3.1 that includes an authenticated
+            // registry reached over plain HTTP (internal host or insecure toggle): RegistryClient
+            // throws `insecureCredentialExchange` rather than send credentials in the clear. The
+            // caller clears every eligible reference before merging, so this can't pin a stale badge.
             return nil
         }
     }

--- a/Berthly/Core/RegistrySchemeResolver.swift
+++ b/Berthly/Core/RegistrySchemeResolver.swift
@@ -13,6 +13,12 @@ import ContainerizationExtras
 /// "Allow insecure registry". This restores the removed rule — localhost, the daemon's internal
 /// DNS domain, and the RFC 1918 / loopback IPv4 ranges resolve to http; everything else to https
 /// — for the paths where Berthly controls a single host.
+///
+/// This only picks a scheme; it does not make plain HTTP fully usable. Since apple/container 1.3.1
+/// (CVE-2026-65388) `RegistryClient` refuses to send credentials or a bearer token over a non-HTTPS
+/// connection, so an *authenticated* registry that resolves to http here (internal host, or the
+/// insecure toggle) fails the credential exchange — `signInRegistry` maps that to a clear message,
+/// and the background update check silently drops the badge. Anonymous HTTP registries are fine.
 enum RegistrySchemeResolver {
 
     /// `isInternalHost` is a verbatim port of the detection apple/container#2100 removed.

--- a/BerthlyTests/RegistryTests.swift
+++ b/BerthlyTests/RegistryTests.swift
@@ -93,6 +93,16 @@ struct RegistryOperationErrorTests {
     }
 }
 
+struct InsecureRegistryAuthMessageTests {
+
+    @Test func namesTheHostAndExplainsTheHTTPSRequirement() {
+        let message = LiveContainerService.insecureRegistryAuthMessage(host: "registry.lan")
+        #expect(message.contains("registry.lan"))
+        #expect(message.contains("HTTPS"))
+        #expect(message.contains("1.3.1"))
+    }
+}
+
 @MainActor
 struct RegistryMockTests {
 


### PR DESCRIPTION
Follow-up to #138. Handles the `RegistryClient` behavior change that landed with
`containerization` 0.42.0.

## What changed upstream

apple/container 1.3.1 (CVE-2026-65388) hardened `RegistryClient`'s token
exchange. It now throws `RegistryClient.Error.insecureCredentialExchange` when:

- the registry connection is not HTTPS and the registry issues a
  `WWW-Authenticate` challenge, or
- the token realm isn't HTTPS / isn't in the registry's registrable domain, or
- the token endpoint redirects or issues its own challenge.

`RegistrySchemeResolver` routes `localhost`, the internal DNS domain, and
RFC 1918 hosts to `http` (and "Allow insecure registry" forces `http` for any
host), so an **authenticated** registry reached that way now fails the exchange
instead of leaking credentials in the clear. Anonymous HTTP registries are
unaffected.

## This PR

| Path | Change |
|---|---|
| `signInRegistry` (in-process `RegistryClient.ping()`) | Catch `.insecureCredentialExchange` and rethrow as a message naming the host and the HTTPS requirement, instead of the raw `refusing insecure credential exchange: …` text. |
| `checkForImageUpdates` (in-process `RegistryClient.resolve()`) | No code change — already swallows every error to `nil` and clears each badge before merging, so an insecure-HTTP host just loses its update badge. Documented at the `catch`. |
| `RegistrySchemeResolver` doc | Added the caveat that picking `http` doesn't make an authenticated plain-HTTP registry usable on 1.3.1. |

## Deferred

`pullImage` / `pushImage` / `recreateContainer` reach `RegistryClient` inside
`container-apiserver` over XPC, so they only change once the user upgrades their
local `container` install to 1.3.1. The post-XPC error text isn't observable
from here yet, and string-matching an unverified message across the process
boundary for a case that can't be triggered would be exactly the kind of
speculative error handling `CLAUDE.md` rules out. Left as an open task on #139
to revisit against a real 1.3.1 daemon (E2E).

## Tests

- New `InsecureRegistryAuthMessageTests` covers the extracted message helper.
- The `catch` clause itself needs a live `RegistryClient` against an HTTP
  registry — E2E territory, tracked with the deferred half.
- `swiftlint lint --strict` clean; BerthlyTests pass.

Part of #139 (login path + docs); #139 stays open for the daemon-side paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
