### PR TITLE
chore: mark RegistrySchemeResolver nonisolated

### DIFF
--- a/Berthly/Core/RegistrySchemeResolver.swift
+++ b/Berthly/Core/RegistrySchemeResolver.swift
@@ -21,7 +21,10 @@ import ContainerizationExtras
 /// for auth fails: `signInRegistry` maps that to a clear message, and the background update check
 /// silently drops the badge. An http registry that never challenges (a plain `registry:2` with no
 /// auth) still works.
-enum RegistrySchemeResolver {
+///
+/// All `nonisolated` (like `ImageStaleness`): pure host/scheme logic with no main-actor state,
+/// called off-main from `checkOneImageUpdate`'s task group and from `BerthlyTests`.
+nonisolated enum RegistrySchemeResolver {
 
     /// `isInternalHost` is a verbatim port of the detection apple/container#2100 removed.
     static func scheme(forHost host: String, insecure: Bool, internalDnsDomain: String?) -> RequestScheme {


### PR DESCRIPTION
Clears a pre-existing compiler warning on `main` (unrelated to the 1.3.1 work):

```
LiveContainerService.swift:2054: warning: call to main actor-isolated static method
'scheme(forHost:insecure:internalDnsDomain:)' in a synchronous nonisolated context
```

`SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` makes any un-annotated type `@MainActor`, so `RegistrySchemeResolver` was main-actor-isolated by default while `resolveRegistryConnectionTarget` (which calls it) is explicitly `nonisolated`. `checkOneImageUpdate` also calls it off-main from a `TaskGroup`.

It's pure host/scheme logic — IPv4 range checks, string suffix matches, no state — so `nonisolated` is the correct annotation, matching `ImageStaleness` immediately below it in the same file group.

- `swiftlint lint --strict` clean
- BerthlyTests pass (`RegistrySchemeResolverTests`, `ResolveRegistryConnectionTargetTests`)
- Confirmed the warning is gone from a clean `build-for-testing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)