### PR TITLE
chore: raise the registry-unreachable recreate wait to 60s

### DIFF
--- a/BerthlyE2ETests/RecreateWatchtowerJourneyTests.swift
+++ b/BerthlyE2ETests/RecreateWatchtowerJourneyTests.swift
@@ -196,7 +196,9 @@ extension RegistryJourneyTests {
         // match would be flaky by comparison — this can't pass by accident). ──
         _ = try ContainerCLI.run(["stop", watchtowerRegistryName], timeout: 30)
         openRecreateSheet(app, on: mainRow)
-        XCTAssertTrue(app.buttons["Done"].waitForExistence(timeout: 30),
+        // 60s to match the other no-pull recreate above — the assertion is "succeeds without the
+        // registry", not "succeeds fast"; 30s flaked once when this test ran late in a full suite.
+        XCTAssertTrue(app.buttons["Done"].waitForExistence(timeout: 60),
                       "recreate must succeed with the registry unreachable — proves .localImageNewer needs no network")
         dismissDoneSheet(app)
 


### PR DESCRIPTION
De-flakes `RegistryJourneyTests.testRecreateWithLatestImageThroughLocalRegistry` (defined in `RecreateWatchtowerJourneyTests.swift`).

Its final step stops the local registry and recreates a `.localImageNewer` container to prove that path needs zero network. It gave the recreate `Done` button **30s**, while the other no-pull recreate earlier in the same test gives it **60s**. During a full `scripts/e2e.sh` run it failed at that 30s wait; an isolated rerun passed in 133s with the recreate step well under 60s — a load flake, not a `container` 1.3.1 regression (`ClientImage.fetch` returns a locally-present image without touching the registry, unchanged 1.3.0→1.3.1).

The assertion is "recreate succeeds with the registry stopped", not "succeeds fast", so widening the wait doesn't weaken it. E2E-only; doesn't run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)