### PR TITLE
chore(deps): bump apple/container to 1.4.1, containerization to 0.45.0

### DIFF
--- a/Berthly.xcodeproj/project.pbxproj
+++ b/Berthly.xcodeproj/project.pbxproj
@@ -775,7 +775,7 @@
 			repositoryURL = "https://github.com/apple/container";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 1.3.1;
+				minimumVersion = 1.4.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Berthly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Berthly.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/container",
       "state" : {
-        "revision" : "a9a62e28f6beb88940122a3d7b286f2d5ae8053a",
-        "version" : "1.3.1"
+        "revision" : "9a8917ca2da5cd6ba059b9ba5ca5a74892e9bb7d",
+        "version" : "1.4.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/containerization.git",
       "state" : {
-        "revision" : "c0185aea5c04fcd4d1cfe9359e0066a380835403",
-        "version" : "0.42.0"
+        "revision" : "9eacc197d7c3663eb29cbab6d51244ede6d1cd7d",
+        "version" : "0.45.0"
       }
     },
     {


### PR DESCRIPTION
## Summary
- `Package.resolved`: `container` 1.3.1 -> 1.4.1, `containerization` 0.42.0 -> 0.45.0 (exact versions, no transitive dependency drift)
- `project.pbxproj`: bump the `container` SPM package requirement floor to 1.4.1 (the old `upToNextMinorVersion 1.3.1` capped resolution at `<1.4.0`)
- Pulls in containerization 0.45.0's fixes for **GHSA-4587-w9mm-xxvh** (OCI image load follows a symlink out of the extraction directory — reachable through Berthly's Load OCI tar sheet) and **GHSA-rgqp-277h-gcwj** (not reachable from Berthly). This fixes Berthly's own build only; a daemon on <= 1.3.1 stays exposed until the user upgrades separately (tracked in the installer-drift and release issues).

## Verification
- Clean build: succeeded, zero new warnings (no 0.42->0.45 API adaptation needed in `Berthly/Core/`)
- `swiftlint lint --strict`: 0 violations
- `BerthlyTests`: all passed
- `BerthlyUITests` (mock mode): all passed
- `BerthlyE2ETests` (via `scripts/e2e.sh`, real daemon): all passed (1 expected skip)
- Checked for hardcoded `1.3.1`/`0.42.0` fixture strings — none needed updating; existing references document when CVE-2026-65388 behavior was introduced and that behavior is unchanged in 1.4.1

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJc4CFM3ua4ac5UCLyVjun