### PR TITLE
fix: bump requiredVersion to 1.4.1 to match container SPM pin

### DIFF
--- a/Berthly/BerthlyApp.swift
+++ b/Berthly/BerthlyApp.swift
@@ -59,7 +59,7 @@ struct BerthlyApp: App {
             // Same major.minor as required (stays `.connected`, nothing blocks) but behind the
             // exact pinned patch — exercises SystemView's non-blocking update affordance, distinct
             // from the hard `.versionMismatch` gate above.
-            mock.installedContainerVersion = "1.2.0"
+            mock.installedContainerVersion = "1.4.0"
         default: break
         }
         if let warning = env["UITEST_STARTUP_WARNING"] {

--- a/Berthly/Core/ContainerCompatibility.swift
+++ b/Berthly/Core/ContainerCompatibility.swift
@@ -14,13 +14,14 @@ import Foundation
 /// which nonisolated callers (e.g. test suites) warn on under Swift 6 checking.
 nonisolated enum ContainerCompatibility {
     /// Keep in sync with the `container` SPM package pin (Package.resolved / Package.swift).
-    static let requiredVersion = "1.2.2"
+    static let requiredVersion = "1.4.1"
 
     /// One-line, hand-written summary of what `requiredVersion` adds — shown on the
     /// version-mismatch gate so an upgrade prompt isn't just two bare version numbers. Update
     /// this by hand alongside `requiredVersion` bumps; it's not generated from upstream's
     /// changelog.
-    static let requiredVersionRationale = "Adds kernel boot-arg support and kernel archive integrity checks."
+    static let requiredVersionRationale =
+        "Fixes an OCI-load symlink security issue (GHSA-4587-w9mm-xxvh) and adds a container clean command."
 
     /// How an incompatible install relates to the required version. `tooOld` is fixable in place
     /// with the upstream update script; `tooNew` (newer major) is not — downgrading requires a
@@ -61,8 +62,8 @@ nonisolated enum ContainerCompatibility {
     }
 
     /// Same major.minor as `requiredVersion` (so `mismatch` sees it as fully compatible and
-    /// never blocks the app) but behind the exact pinned patch — e.g. daemon 1.2.0 against a
-    /// Berthly pinned to `requiredVersion` 1.2.2. `mismatch` deliberately ignores patch, so this
+    /// never blocks the app) but behind the exact pinned patch — e.g. daemon 1.4.0 against a
+    /// Berthly pinned to `requiredVersion` 1.4.1. `mismatch` deliberately ignores patch, so this
     /// is the only check that notices; without it, a patch-gated capability (`isAtLeast`, e.g.
     /// running-container export added in 1.2.1) can sit unreachable with no signal why. Drives
     /// the System page's non-blocking "Update available" affordance, distinct from the hard

--- a/BerthlyUITests/ContextMenuTests.swift
+++ b/BerthlyUITests/ContextMenuTests.swift
@@ -35,10 +35,11 @@ final class ContextMenuTests: XCTestCase {
     // MARK: - Containers
 
     /// Full menu on a running container ("cache" in the mock): lifecycle actions present, Export
-    /// Filesystem enabled (the mock reports daemon 1.2.2, which supports exporting a running
-    /// container per apple/container#1630 — see `ContainerComputeRow.canExportFilesystem`),
-    /// Delete… disabled (only non-running containers can be deleted). Dismissed with Escape rather
-    /// than clicked — a pure existence/gating check, no state change.
+    /// Filesystem enabled (the mock reports daemon `ContainerCompatibility.requiredVersion`, which
+    /// supports exporting a running container per apple/container#1630, added in 1.2.1 — see
+    /// `ContainerComputeRow.canExportFilesystem`), Delete… disabled (only non-running containers
+    /// can be deleted). Dismissed with Escape rather than clicked — a pure existence/gating check,
+    /// no state change.
     @MainActor
     func testContainerContextMenuOnRunningShowsLifecycleActionsAndGates() throws {
         let app = launchMock()
@@ -52,7 +53,7 @@ final class ContextMenuTests: XCTestCase {
         XCTAssertTrue(app.menuItems["Copy Name"].exists)
         XCTAssertTrue(app.menuItems["Copy Container ID"].exists)
         XCTAssertTrue(app.menuItems["Copy Image Reference"].exists)
-        XCTAssertTrue(app.menuItems["Export Filesystem…"].isEnabled, "daemon 1.2.2 can export a running container")
+        XCTAssertTrue(app.menuItems["Export Filesystem…"].isEnabled, "daemon can export a running container")
         XCTAssertFalse(app.menuItems["Delete…"].isEnabled, "a running container can't be deleted")
 
         app.typeKey(.escape, modifierFlags: [])


### PR DESCRIPTION
## Summary
- `ContainerCompatibility.requiredVersion` was still `1.2.2` while the SPM pin moved to `1.4.1` (via 1.3.0, 1.3.1) — `installContainer`/`upgradeContainer` were downloading the 1.2.2 installer, and `isPatchBehind` never fired for a 1.3.x daemon.
- Bumped `requiredVersion` to `1.4.1` and rewrote `requiredVersionRationale` (OCI-load symlink fix GHSA-4587-w9mm-xxvh, `container clean`).
- Re-verified `container-1.4.1-installer-signed.pkg` exists on the release, and both `pkgutil --check-signature` (installer) and `codesign -dv` (the `container` binary itself) still match Berthly's pinned Apple Containerization identity (`UPBK2H6LZM`) — no marker changes needed.
- Fixed a UI-test seed (`BerthlyApp.swift`) that hardcoded `1.2.0` for the "patch behind" mock state — it shared major.minor with the old pin but not the new one, which broke `SystemViewTests.testPatchUpdateSurvivesDaemonRestart` until bumped to `1.4.0`.

## Note
`mismatch()` gates on major.minor only, so this also turns every 1.2.x/1.3.x daemon into a hard `.versionMismatch` instead of the softer "update available" nudge. Issue #148 recommends accepting this; the formal policy decision is tracked separately in #149.

Fixes #148

## Test plan
- [x] `xcodebuild test -only-testing:BerthlyTests` — all pass
- [x] `xcodebuild test -only-testing:BerthlyUITests` (mock mode) — 78/78 pass
- [x] `swiftlint lint --strict` — 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwuxB2FRp62DaFqhfN7qea